### PR TITLE
Add swiper-style search for current and open files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,26 @@ Full bibliography management with BibTeX support, DOI fetching, and citation ins
 **Commands:**
 | Command | Keybinding | Description |
 |---------|------------|-------------|
-| `Scimax: Insert Citation` | `Ctrl+]` / `Cmd+]` | Insert a citation at cursor |
+| `Scimax: Insert Citation` | `Ctrl+c ]` | Insert a citation at cursor |
+| `Scimax: Insert Reference Link` | `Ctrl+u Ctrl+c ]` | Insert ref:/eqref:/pageref: link |
 | `Scimax: Fetch BibTeX from DOI` | - | Fetch bibliography entry from DOI |
 | `Scimax: Search References` | - | Search all bibliography entries |
 | `Scimax: Open Bibliography` | - | Open a .bib file |
 | `Scimax: Find Citations of Reference` | - | Find all citations of a reference |
 | `Scimax: Copy BibTeX Entry` | - | Copy BibTeX to clipboard |
+| `Scimax: Extract Bibliography from File` | - | Extract all cited references to a new .bib file |
+| `Scimax: Show Citing Works (OpenAlex)` | - | Show papers that cite a DOI |
+| `Scimax: Show Related Works (OpenAlex)` | - | Show related papers for a DOI |
+| `Scimax: Search OpenAlex` | - | Search the OpenAlex academic database |
 
 **Features:**
-- **Hover preview**: Hover over citations to see reference details
+- **Hover preview**: Hover over citations to see reference details with source file
+- **DOI tooltips**: Hover over DOIs to see metadata from CrossRef + OpenAlex (citation count, open access status, topics)
 - **Autocomplete**: Type `cite:` or `@` for citation suggestions
 - **Go to definition**: Jump from citation to bibliography entry
 - **Code lens**: In .bib files, see citations count and quick actions
 - **Citation styles**: cite, citet, citep, citeauthor, citeyear
+- **OpenAlex integration**: View citation counts, open access links, citing works, related works
 
 **Configuration:**
 ```json
@@ -69,6 +76,71 @@ Full bibliography management with BibTeX support, DOI fetching, and citation ins
   "scimax.ref.defaultCiteStyle": "cite"
 }
 ```
+
+---
+
+### Fuzzy Search (swiper-style)
+
+Fast, interactive search for the current file and all open files, inspired by Emacs [swiper](https://github.com/abo-abo/swiper).
+
+**Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Fuzzy Search (Current File)` | `Ctrl+c s` | Search lines in current file with live preview |
+| `Scimax: Fuzzy Search (Open Files)` | `Ctrl+c Shift+s` | Search across all open editor tabs |
+| `Scimax: Fuzzy Search (Outline)` | `Ctrl+c Alt+s` | Search headings/symbols in current file |
+
+**Features:**
+- **Live preview**: Cursor moves to match as you type
+- **Match highlighting**: Matches highlighted in the editor
+- **Multi-file search**: Search all open tabs at once
+- **Outline mode**: Jump to headings, functions, classes
+
+---
+
+### Jump Navigation (avy-style)
+
+Quick navigation to visible text using labeled targets, inspired by Emacs [avy](https://github.com/abo-abo/avy).
+
+**Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Jump to Character` | `Ctrl+c j c` | Jump to any occurrence of a character |
+| `Scimax: Jump to 2-Character Sequence` | `Ctrl+c j j` | Jump to a two-character sequence |
+| `Scimax: Jump to Word` | `Ctrl+c j w` | Jump to word starts |
+| `Scimax: Jump to Line` | `Ctrl+c j l` | Jump to any visible line |
+| `Scimax: Jump to Symbol` | `Ctrl+c j o` | Jump to symbols/headings in view |
+| `Scimax: Jump to Subword` | `Ctrl+c j s` | Jump to subword boundaries (camelCase, snake_case) |
+| `Scimax: Jump Copy Line` | - | Select a visible line and copy it |
+| `Scimax: Jump Kill Line` | - | Select a visible line and delete it |
+
+**Features:**
+- **Label-based selection**: Type a label (a, s, d, f...) to instantly jump
+- **QuickPick fallback**: Browse and filter targets in a list
+- **Match highlighting**: All targets highlighted in the editor
+- **Works everywhere**: Functions in any file type
+
+---
+
+### Project Management (projectile-style)
+
+Quick project switching and file finding, inspired by Emacs [projectile](https://github.com/bbatsov/projectile).
+
+**Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Switch Project` | `Ctrl+c p p` | Switch to a known project |
+| `Scimax: Find File in Project` | `Ctrl+c p f` | Find file in current project |
+| `Scimax: Search in Project` | `Ctrl+c p s` | Search text in project files |
+| `Scimax: Open Project Root` | `Ctrl+c p d` | Open project root directory |
+| `Scimax: Add Project` | `Ctrl+c p a` | Add a project to the list |
+| `Scimax: Remove Project` | - | Remove project from tracking |
+| `Scimax: Scan Directory for Projects` | - | Scan a directory for projects |
+| `Scimax: Project Info` | - | Show project statistics |
+| `Scimax: Cleanup Non-existent Projects` | - | Remove deleted projects |
+
+**Project Detection:**
+Automatically detects projects via: `.projectile`, `.git`, `.scimax`, `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`, `.project`
 
 ---
 
@@ -155,9 +227,6 @@ Project-based organization for scientific research and software development.
 - **software**: Software project with src/, tests/, docs/
 - **notes**: Note-taking with journal/ directory
 
-**Project Detection:**
-Automatically detects projects via: `.projectile`, `.git`, `.scimax`, `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`, `.project`
-
 **Configuration:**
 ```json
 {
@@ -166,6 +235,65 @@ Automatically detects projects via: `.projectile`, `.git`, `.scimax`, `package.j
   "scimax.notebook.autoDetect": true
 }
 ```
+
+---
+
+### Org-Mode Editing Features
+
+Enhanced editing commands for org-mode and markdown files.
+
+**Timestamp Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Insert Timestamp` | `Ctrl+c .` | Insert timestamp at cursor |
+| `Scimax: Shift Timestamp Up` | `Shift+Up` | Increment date component |
+| `Scimax: Shift Timestamp Down` | `Shift+Down` | Decrement date component |
+| `Scimax: Shift Timestamp Left` | `Shift+Left` | Previous day |
+| `Scimax: Shift Timestamp Right` | `Shift+Right` | Next day |
+| `Scimax: Add/Change Repeater` | `Ctrl+c Ctrl+r` | Add repeater to timestamp |
+
+**Table Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Create Table` | `Ctrl+c \|` | Create a new table |
+| `Scimax: Insert Row Below` | `Alt+Enter` | Insert row below current |
+| `Scimax: Insert Row Above` | `Alt+Shift+Enter` | Insert row above current |
+| `Scimax: Delete Row` | `Alt+Shift+Backspace` | Delete current row |
+| `Scimax: Insert Column Right` | `Alt+Shift+Right` | Insert column (in table) |
+| `Scimax: Delete Column` | `Alt+Shift+Left` | Delete column (in table) |
+| `Scimax: Insert Separator` | `Ctrl+c -` | Insert table separator line |
+| `Scimax: Align Table` | - | Align table columns |
+
+**Heading Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Promote Heading` | `Alt+Left` | Decrease heading level |
+| `Scimax: Demote Heading` | `Alt+Right` | Increase heading level |
+| `Scimax: Promote Subtree` | `Alt+Shift+Left` | Promote heading and children |
+| `Scimax: Demote Subtree` | `Alt+Shift+Right` | Demote heading and children |
+| `Scimax: Move Heading Up` | `Alt+Up` | Move heading up |
+| `Scimax: Move Heading Down` | `Alt+Down` | Move heading down |
+| `Scimax: Insert Heading` | `Ctrl+Enter` | Insert new heading |
+| `Scimax: Insert Subheading` | - | Insert subheading |
+
+**Task Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Toggle Checkbox` | `Ctrl+c Ctrl+c` | Toggle checkbox state |
+| `Scimax: Insert Task` | - | Insert a new task |
+| `Scimax: Insert Due Date` | `Ctrl+c Ctrl+d` | Add due date to task |
+| `Scimax: Insert Scheduled Date` | `Ctrl+c Ctrl+s` | Add scheduled date to task |
+| `Scimax: Insert Priority` | - | Add priority to task |
+| `Scimax: Show Agenda` | - | Show agenda view |
+| `Scimax: Show Today's Tasks` | - | Show tasks due today |
+| `Scimax: Show Tasks by Project` | - | Filter tasks by @project |
+| `Scimax: Show Tasks by Tag` | - | Filter tasks by #tag |
+
+**Folding:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Toggle Fold at Cursor` | `Tab` | Toggle fold at current heading |
+| `Scimax: Cycle Global Folding` | `Shift+Tab` | Cycle all headings fold state |
 
 ---
 
@@ -211,15 +339,72 @@ The extension adds a **Scimax** activity bar icon with these views:
 
 ---
 
-## Keyboard Shortcuts
+## Keyboard Shortcuts Summary
 
+### General
+| Shortcut | Command |
+|----------|---------|
+| `Ctrl+Shift+J` / `Cmd+Shift+J` | Open Today's Journal |
+| `Ctrl+Alt+V` / `Ctrl+Cmd+V` | Database Menu (quick access to search commands) |
+
+### Journal Navigation
 | Shortcut | Command | When |
 |----------|---------|------|
-| `Ctrl+Shift+J` / `Cmd+Shift+J` | Open Today's Journal | Always |
 | `Alt+[` | Previous Journal Entry | In journal file |
 | `Alt+]` | Next Journal Entry | In journal file |
-| `Ctrl+Enter` / `Cmd+Enter` | Execute Code Block | In org/markdown |
-| `Ctrl+]` / `Cmd+]` | Insert Citation | In org/markdown |
+
+### Citations & References
+| Shortcut | Command | When |
+|----------|---------|------|
+| `Ctrl+c ]` | Insert Citation | In org/markdown/latex |
+| `Ctrl+u Ctrl+c ]` | Insert Reference Link | In org/markdown/latex |
+
+### Fuzzy Search
+| Shortcut | Command | When |
+|----------|---------|------|
+| `Ctrl+c s` | Fuzzy Search (Current File) | In editor |
+| `Ctrl+c Shift+s` | Fuzzy Search (Open Files) | In editor |
+| `Ctrl+c Alt+s` | Fuzzy Search (Outline) | In editor |
+
+### Jump Navigation
+| Shortcut | Command | When |
+|----------|---------|------|
+| `Ctrl+c j c` | Jump to Character | In editor |
+| `Ctrl+c j j` | Jump to 2-Char Sequence | In editor |
+| `Ctrl+c j w` | Jump to Word | In editor |
+| `Ctrl+c j l` | Jump to Line | In editor |
+| `Ctrl+c j o` | Jump to Symbol | In editor |
+| `Ctrl+c j s` | Jump to Subword | In editor |
+
+### Project Management
+| Shortcut | Command |
+|----------|---------|
+| `Ctrl+c p p` | Switch Project |
+| `Ctrl+c p f` | Find File in Project |
+| `Ctrl+c p s` | Search in Project |
+| `Ctrl+c p d` | Open Project Root |
+| `Ctrl+c p a` | Add Project |
+
+### Org-Mode Editing
+| Shortcut | Command | When |
+|----------|---------|------|
+| `Tab` | Toggle Fold | On heading, in org |
+| `Shift+Tab` | Cycle Global Folding | In org |
+| `Ctrl+Enter` | Insert Heading / Execute Block | In org/markdown |
+| `Ctrl+c Ctrl+c` | Toggle Checkbox | In org/markdown |
+| `Ctrl+c .` | Insert Timestamp | In org/markdown |
+| `Ctrl+c Ctrl+d` | Insert Due Date | In org/markdown |
+| `Ctrl+c Ctrl+s` | Insert Scheduled Date | In org/markdown |
+| `Ctrl+c Ctrl+r` | Add Repeater | In org/markdown |
+| `Ctrl+c \|` | Create Table | In org/markdown |
+| `Ctrl+c -` | Insert Table Separator | In org/markdown |
+| `Shift+Up/Down` | Adjust Timestamp | On timestamp |
+| `Shift+Left/Right` | Previous/Next Day | On timestamp |
+| `Alt+Left/Right` | Promote/Demote Heading | On heading |
+| `Alt+Up/Down` | Move Heading Up/Down | On heading |
+| `Alt+Enter` | Insert Table Row Below | In table |
+| `Alt+Shift+Enter` | Insert Table Row Above | In table |
+| `Alt+Shift+Left/Right` | Promote/Demote Subtree or Delete/Insert Column | Context-dependent |
 
 ---
 
@@ -237,9 +422,12 @@ The extension supports:
 | Feature | Emacs Scimax | VS Code Scimax |
 |---------|--------------|----------------|
 | Journal | scimax-journal | Full support |
-| Bibliography | org-ref | Full support |
+| Bibliography | org-ref | Full support + OpenAlex |
 | Database | org-db-v3 | Full support with semantic search |
 | Notebooks | scimax-notebook | Full support |
+| Projectile | projectile | Full support |
+| Swiper | swiper/ivy | Full support (fuzzy search) |
+| Avy | avy | Full support (jump) |
 | Literate Programming | ob-ipython | Planned |
 | Contacts | org-contacts | Not yet |
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,59 @@ Quick navigation to visible text using labeled targets, inspired by Emacs [avy](
 
 ---
 
+### Spell Checking (jinx-style)
+
+Just-in-time spell checking with smart exclusions for scientific writing, inspired by [jinx](https://github.com/minad/jinx).
+
+**Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Correct Spelling` | `Alt+$` | Correct word at cursor (or find next error) |
+| `Scimax: Next Spelling Error` | `Ctrl+c ; n` | Jump to next spelling error |
+| `Scimax: Previous Spelling Error` | `Ctrl+c ; p` | Jump to previous spelling error |
+| `Scimax: Add Word to Dictionary` | - | Add word at cursor to personal dictionary |
+| `Scimax: Toggle Spell Checking` | - | Enable/disable spell checking |
+| `Scimax: Check Document Spelling` | - | Force spell check on current document |
+
+**Features:**
+- **Smart exclusions**: Skips citations, DOIs, URLs, code blocks, LaTeX math, file paths
+- **Personal dictionary**: Add words to your custom dictionary
+- **Quick fix**: Quick actions in editor for corrections
+- **Code-aware**: Recognizes camelCase, snake_case, SCREAMING_CASE
+
+---
+
+### Edit Marks (Track Changes)
+
+Collaborative editing markup for reviewing changes, inspired by scimax-editmarks.
+
+**Commands:**
+| Command | Keybinding | Description |
+|---------|------------|-------------|
+| `Scimax: Mark Insertion` | `Ctrl+c e i` | Mark selected text as insertion |
+| `Scimax: Mark Deletion` | `Ctrl+c e d` | Mark selected text for deletion |
+| `Scimax: Insert Edit Comment` | `Ctrl+c e c` | Insert a review comment |
+| `Scimax: Mark Typo Correction` | `Ctrl+c e t` | Mark typo with correction |
+| `Scimax: Accept Edit Mark` | `Ctrl+c e a` | Accept the edit mark at cursor |
+| `Scimax: Reject Edit Mark` | `Ctrl+c e r` | Reject the edit mark at cursor |
+| `Scimax: Accept All Edit Marks` | - | Accept all marks in document |
+| `Scimax: Reject All Edit Marks` | - | Reject all marks in document |
+| `Scimax: Next Edit Mark` | `Ctrl+c e ]` | Navigate to next edit mark |
+| `Scimax: Previous Edit Mark` | `Ctrl+c e [` | Navigate to previous edit mark |
+| `Scimax: Show Edit Marks Summary` | `Ctrl+c e s` | Show summary of all edit marks |
+
+**Markup Format:**
+```
+@@+inserted text+@@          # Insertion (green)
+@@-deleted text-@@           # Deletion (red, strikethrough)
+@@>comment text<@@           # Comment (yellow, italic)
+@@~old text|new text~@@      # Typo correction (orange)
+```
+
+Also supports CriticMarkup format: `{++insert++}`, `{--delete--}`, `{>>comment<<}`, `{~~old~>new~~}`
+
+---
+
 ### Project Management (projectile-style)
 
 Quick project switching and file finding, inspired by Emacs [projectile](https://github.com/bbatsov/projectile).
@@ -387,6 +440,26 @@ The extension adds a **Scimax** activity bar icon with these views:
 | `Ctrl+c j o` | Jump to Symbol | In editor |
 | `Ctrl+c j s` | Jump to Subword | In editor |
 
+### Spell Checking
+| Shortcut | Command | When |
+|----------|---------|------|
+| `Alt+$` | Correct Spelling | In editor |
+| `Ctrl+c ; n` | Next Spelling Error | In editor |
+| `Ctrl+c ; p` | Previous Spelling Error | In editor |
+
+### Edit Marks (Track Changes)
+| Shortcut | Command | When |
+|----------|---------|------|
+| `Ctrl+c e i` | Mark Insertion | In editor |
+| `Ctrl+c e d` | Mark Deletion | In editor |
+| `Ctrl+c e c` | Insert Comment | In editor |
+| `Ctrl+c e t` | Mark Typo | In editor |
+| `Ctrl+c e a` | Accept Edit Mark | In editor |
+| `Ctrl+c e r` | Reject Edit Mark | In editor |
+| `Ctrl+c e ]` | Next Edit Mark | In editor |
+| `Ctrl+c e [` | Previous Edit Mark | In editor |
+| `Ctrl+c e s` | Show Summary | In editor |
+
 ### Project Management
 | Shortcut | Command |
 |----------|---------|
@@ -439,6 +512,8 @@ The extension supports:
 | Projectile | projectile | Full support |
 | Swiper | swiper/ivy | Full support (fuzzy search) |
 | Avy | avy | Full support (jump) |
+| Spell Check | jinx/flyspell | Full support (smart exclusions) |
+| Track Changes | scimax-editmarks | Full support (editmarks) |
 | Literate Programming | ob-ipython | Planned |
 | Contacts | org-contacts | Not yet |
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Full bibliography management with BibTeX support, DOI fetching, and citation ins
 | `Scimax: Show Citing Works (OpenAlex)` | - | Show papers that cite a DOI |
 | `Scimax: Show Related Works (OpenAlex)` | - | Show related papers for a DOI |
 | `Scimax: Search OpenAlex` | - | Search the OpenAlex academic database |
+| `Scimax: Transpose Citation Left` | `Shift+Left` | Swap citation with previous (when on citation) |
+| `Scimax: Transpose Citation Right` | `Shift+Right` | Swap citation with next (when on citation) |
+| `Scimax: Sort Citations Alphabetically` | `Shift+Up` | Sort citation keys alphabetically (when on citation) |
+| `Scimax: Sort Citations by Year` | `Shift+Down` | Sort citation keys by year (when on citation) |
+| `Scimax: Delete Citation at Cursor` | `Ctrl+Shift+K` | Delete citation key at cursor (when on citation) |
 
 **Features:**
 - **Hover preview**: Hover over citations to see reference details with source file
@@ -66,6 +71,7 @@ Full bibliography management with BibTeX support, DOI fetching, and citation ins
 - **Code lens**: In .bib files, see citations count and quick actions
 - **Citation styles**: cite, citet, citep, citeauthor, citeyear
 - **OpenAlex integration**: View citation counts, open access links, citing works, related works
+- **Citation manipulation**: Transpose, sort, and delete citations with keyboard shortcuts (like org-ref)
 
 **Configuration:**
 ```json
@@ -358,6 +364,11 @@ The extension adds a **Scimax** activity bar icon with these views:
 |----------|---------|------|
 | `Ctrl+c ]` | Insert Citation | In org/markdown/latex |
 | `Ctrl+u Ctrl+c ]` | Insert Reference Link | In org/markdown/latex |
+| `Shift+Left` | Transpose Citation Left | On citation |
+| `Shift+Right` | Transpose Citation Right | On citation |
+| `Shift+Up` | Sort Citations Alphabetically | On citation |
+| `Shift+Down` | Sort Citations by Year | On citation |
+| `Ctrl+Shift+K` | Delete Citation | On citation |
 
 ### Fuzzy Search
 | Shortcut | Command | When |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1495,7 +1495,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2024,7 +2023,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3114,7 +3112,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6148,7 +6145,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -401,6 +401,10 @@
         "title": "Scimax: Insert Reference Link"
       },
       {
+        "command": "scimax.ref.extractBibliography",
+        "title": "Scimax: Extract Bibliography from File"
+      },
+      {
         "command": "scimax.notebook.new",
         "title": "Scimax: New Notebook"
       },

--- a/package.json
+++ b/package.json
@@ -405,6 +405,18 @@
         "title": "Scimax: Extract Bibliography from File"
       },
       {
+        "command": "scimax.ref.showCitingWorks",
+        "title": "Scimax: Show Citing Works (OpenAlex)"
+      },
+      {
+        "command": "scimax.ref.showRelatedWorks",
+        "title": "Scimax: Show Related Works (OpenAlex)"
+      },
+      {
+        "command": "scimax.ref.searchOpenAlex",
+        "title": "Scimax: Search OpenAlex"
+      },
+      {
         "command": "scimax.notebook.new",
         "title": "Scimax: New Notebook"
       },

--- a/package.json
+++ b/package.json
@@ -723,6 +723,74 @@
       {
         "command": "scimax.jump.killLine",
         "title": "Scimax: Jump Kill Line"
+      },
+      {
+        "command": "scimax.spelling.correct",
+        "title": "Scimax: Correct Spelling"
+      },
+      {
+        "command": "scimax.spelling.nextError",
+        "title": "Scimax: Next Spelling Error"
+      },
+      {
+        "command": "scimax.spelling.prevError",
+        "title": "Scimax: Previous Spelling Error"
+      },
+      {
+        "command": "scimax.spelling.addToDictionary",
+        "title": "Scimax: Add Word to Dictionary"
+      },
+      {
+        "command": "scimax.spelling.toggle",
+        "title": "Scimax: Toggle Spell Checking"
+      },
+      {
+        "command": "scimax.spelling.checkDocument",
+        "title": "Scimax: Check Document Spelling"
+      },
+      {
+        "command": "scimax.editmarks.insertion",
+        "title": "Scimax: Mark Insertion"
+      },
+      {
+        "command": "scimax.editmarks.deletion",
+        "title": "Scimax: Mark Deletion"
+      },
+      {
+        "command": "scimax.editmarks.comment",
+        "title": "Scimax: Insert Edit Comment"
+      },
+      {
+        "command": "scimax.editmarks.typo",
+        "title": "Scimax: Mark Typo Correction"
+      },
+      {
+        "command": "scimax.editmarks.accept",
+        "title": "Scimax: Accept Edit Mark"
+      },
+      {
+        "command": "scimax.editmarks.reject",
+        "title": "Scimax: Reject Edit Mark"
+      },
+      {
+        "command": "scimax.editmarks.acceptAll",
+        "title": "Scimax: Accept All Edit Marks"
+      },
+      {
+        "command": "scimax.editmarks.rejectAll",
+        "title": "Scimax: Reject All Edit Marks"
+      },
+      {
+        "command": "scimax.editmarks.next",
+        "title": "Scimax: Next Edit Mark"
+      },
+      {
+        "command": "scimax.editmarks.prev",
+        "title": "Scimax: Previous Edit Mark"
+      },
+      {
+        "command": "scimax.editmarks.summary",
+        "title": "Scimax: Show Edit Marks Summary"
       }
     ],
     "keybindings": [
@@ -1031,6 +1099,78 @@
         "key": "ctrl+shift+k",
         "mac": "cmd+shift+k",
         "when": "editorTextFocus && editorLangId =~ /org|markdown|latex/ && scimax.onCitation"
+      },
+      {
+        "command": "scimax.spelling.correct",
+        "key": "alt+$",
+        "mac": "alt+$",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.spelling.nextError",
+        "key": "ctrl+c ; n",
+        "mac": "ctrl+c ; n",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.spelling.prevError",
+        "key": "ctrl+c ; p",
+        "mac": "ctrl+c ; p",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.insertion",
+        "key": "ctrl+c e i",
+        "mac": "ctrl+c e i",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.deletion",
+        "key": "ctrl+c e d",
+        "mac": "ctrl+c e d",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.comment",
+        "key": "ctrl+c e c",
+        "mac": "ctrl+c e c",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.typo",
+        "key": "ctrl+c e t",
+        "mac": "ctrl+c e t",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.accept",
+        "key": "ctrl+c e a",
+        "mac": "ctrl+c e a",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.reject",
+        "key": "ctrl+c e r",
+        "mac": "ctrl+c e r",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.next",
+        "key": "ctrl+c e ]",
+        "mac": "ctrl+c e ]",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.prev",
+        "key": "ctrl+c e [",
+        "mac": "ctrl+c e [",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.editmarks.summary",
+        "key": "ctrl+c e s",
+        "mac": "ctrl+c e s",
+        "when": "editorTextFocus"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -671,6 +671,38 @@
       {
         "command": "scimax.fuzzySearchOutline",
         "title": "Scimax: Fuzzy Search (Outline)"
+      },
+      {
+        "command": "scimax.jump.gotoChar",
+        "title": "Scimax: Jump to Character"
+      },
+      {
+        "command": "scimax.jump.gotoChar2",
+        "title": "Scimax: Jump to 2-Character Sequence"
+      },
+      {
+        "command": "scimax.jump.gotoWord",
+        "title": "Scimax: Jump to Word"
+      },
+      {
+        "command": "scimax.jump.gotoLine",
+        "title": "Scimax: Jump to Line"
+      },
+      {
+        "command": "scimax.jump.gotoSymbol",
+        "title": "Scimax: Jump to Symbol"
+      },
+      {
+        "command": "scimax.jump.gotoSubword",
+        "title": "Scimax: Jump to Subword"
+      },
+      {
+        "command": "scimax.jump.copyLine",
+        "title": "Scimax: Jump Copy Line"
+      },
+      {
+        "command": "scimax.jump.killLine",
+        "title": "Scimax: Jump Kill Line"
       }
     ],
     "keybindings": [
@@ -912,6 +944,42 @@
         "command": "scimax.fuzzySearchOutline",
         "key": "ctrl+c alt+s",
         "mac": "ctrl+c alt+s",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.jump.gotoChar",
+        "key": "ctrl+c j c",
+        "mac": "ctrl+c j c",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.jump.gotoChar2",
+        "key": "ctrl+c j j",
+        "mac": "ctrl+c j j",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.jump.gotoWord",
+        "key": "ctrl+c j w",
+        "mac": "ctrl+c j w",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.jump.gotoLine",
+        "key": "ctrl+c j l",
+        "mac": "ctrl+c j l",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.jump.gotoSymbol",
+        "key": "ctrl+c j o",
+        "mac": "ctrl+c j o",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.jump.gotoSubword",
+        "key": "ctrl+c j s",
+        "mac": "ctrl+c j s",
         "when": "editorTextFocus"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -417,6 +417,26 @@
         "title": "Scimax: Search OpenAlex"
       },
       {
+        "command": "scimax.ref.transposeCitationLeft",
+        "title": "Scimax: Transpose Citation Left"
+      },
+      {
+        "command": "scimax.ref.transposeCitationRight",
+        "title": "Scimax: Transpose Citation Right"
+      },
+      {
+        "command": "scimax.ref.sortCitations",
+        "title": "Scimax: Sort Citations Alphabetically"
+      },
+      {
+        "command": "scimax.ref.sortCitationsByYear",
+        "title": "Scimax: Sort Citations by Year"
+      },
+      {
+        "command": "scimax.ref.deleteCitation",
+        "title": "Scimax: Delete Citation at Cursor"
+      },
+      {
         "command": "scimax.notebook.new",
         "title": "Scimax: New Notebook"
       },
@@ -981,6 +1001,36 @@
         "key": "ctrl+c j s",
         "mac": "ctrl+c j s",
         "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.ref.transposeCitationLeft",
+        "key": "shift+left",
+        "mac": "shift+left",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown|latex/ && scimax.onCitation"
+      },
+      {
+        "command": "scimax.ref.transposeCitationRight",
+        "key": "shift+right",
+        "mac": "shift+right",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown|latex/ && scimax.onCitation"
+      },
+      {
+        "command": "scimax.ref.sortCitations",
+        "key": "shift+up",
+        "mac": "shift+up",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown|latex/ && scimax.onCitation"
+      },
+      {
+        "command": "scimax.ref.sortCitationsByYear",
+        "key": "shift+down",
+        "mac": "shift+down",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown|latex/ && scimax.onCitation"
+      },
+      {
+        "command": "scimax.ref.deleteCitation",
+        "key": "ctrl+shift+k",
+        "mac": "cmd+shift+k",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown|latex/ && scimax.onCitation"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -643,6 +643,18 @@
       {
         "command": "scimax.projectile.cleanup",
         "title": "Scimax: Cleanup Non-existent Projects"
+      },
+      {
+        "command": "scimax.swiper",
+        "title": "Scimax: Swiper (Search Current File)"
+      },
+      {
+        "command": "scimax.swiperAll",
+        "title": "Scimax: Swiper All (Search Open Files)"
+      },
+      {
+        "command": "scimax.swiperSymbol",
+        "title": "Scimax: Swiper Symbol (Search Headings)"
       }
     ],
     "keybindings": [
@@ -867,6 +879,24 @@
         "command": "scimax.projectile.add",
         "key": "ctrl+c p a",
         "mac": "ctrl+c p a"
+      },
+      {
+        "command": "scimax.swiper",
+        "key": "ctrl+c s",
+        "mac": "ctrl+c s",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.swiperAll",
+        "key": "ctrl+c shift+s",
+        "mac": "ctrl+c shift+s",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.swiperSymbol",
+        "key": "ctrl+c alt+s",
+        "mac": "ctrl+c alt+s",
+        "when": "editorTextFocus"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -645,16 +645,16 @@
         "title": "Scimax: Cleanup Non-existent Projects"
       },
       {
-        "command": "scimax.swiper",
-        "title": "Scimax: Swiper (Search Current File)"
+        "command": "scimax.fuzzySearch",
+        "title": "Scimax: Fuzzy Search (Current File)"
       },
       {
-        "command": "scimax.swiperAll",
-        "title": "Scimax: Swiper All (Search Open Files)"
+        "command": "scimax.fuzzySearchOpenFiles",
+        "title": "Scimax: Fuzzy Search (Open Files)"
       },
       {
-        "command": "scimax.swiperSymbol",
-        "title": "Scimax: Swiper Symbol (Search Headings)"
+        "command": "scimax.fuzzySearchOutline",
+        "title": "Scimax: Fuzzy Search (Outline)"
       }
     ],
     "keybindings": [
@@ -881,19 +881,19 @@
         "mac": "ctrl+c p a"
       },
       {
-        "command": "scimax.swiper",
+        "command": "scimax.fuzzySearch",
         "key": "ctrl+c s",
         "mac": "ctrl+c s",
         "when": "editorTextFocus"
       },
       {
-        "command": "scimax.swiperAll",
+        "command": "scimax.fuzzySearchOpenFiles",
         "key": "ctrl+c shift+s",
         "mac": "ctrl+c shift+s",
         "when": "editorTextFocus"
       },
       {
-        "command": "scimax.swiperSymbol",
+        "command": "scimax.fuzzySearchOutline",
         "key": "ctrl+c alt+s",
         "mac": "ctrl+c alt+s",
         "when": "editorTextFocus"

--- a/src/editmarks/editmarks.ts
+++ b/src/editmarks/editmarks.ts
@@ -1,0 +1,672 @@
+import * as vscode from 'vscode';
+
+/**
+ * Editmarks - Track Changes for Scientific Writing
+ *
+ * Inspired by scimax-editmarks for collaborative editing.
+ * Provides markup for insertions, deletions, and comments
+ * that works across org-mode, markdown, and LaTeX.
+ *
+ * Markup format (works in all formats):
+ * - Insertion: @@+inserted text+@@
+ * - Deletion:  @@-deleted text-@@
+ * - Comment:   @@>comment text<@@
+ * - Typo:      @@~old text|new text~@@
+ *
+ * Alternative markup for org-mode:
+ * - Insertion: {++inserted text++}
+ * - Deletion:  {--deleted text--}
+ * - Comment:   {>>comment text<<}
+ */
+
+// Decoration types for editmarks
+const insertionDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: 'rgba(0, 255, 0, 0.2)',
+    border: '1px solid rgba(0, 200, 0, 0.5)',
+    borderRadius: '2px'
+});
+
+const deletionDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: 'rgba(255, 0, 0, 0.2)',
+    textDecoration: 'line-through',
+    border: '1px solid rgba(200, 0, 0, 0.5)',
+    borderRadius: '2px'
+});
+
+const commentDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: 'rgba(255, 255, 0, 0.2)',
+    border: '1px solid rgba(200, 200, 0, 0.5)',
+    borderRadius: '2px',
+    fontStyle: 'italic'
+});
+
+const typoDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: 'rgba(255, 165, 0, 0.2)',
+    border: '1px solid rgba(200, 130, 0, 0.5)',
+    borderRadius: '2px'
+});
+
+// Patterns for editmarks
+const EDITMARK_PATTERNS = {
+    // Universal format: @@+text+@@ @@-text-@@ @@>text<@@ @@~old|new~@@
+    insertion: /@@\+([^+]*)\+@@/g,
+    deletion: /@@-([^-]*)-@@/g,
+    comment: /@@>([^<]*)<@@/g,
+    typo: /@@~([^|]*)\|([^~]*)~@@/g,
+
+    // CriticMarkup format: {++text++} {--text--} {>>text<<} {~~old~>new~~}
+    insertionCritic: /\{\+\+([^+]*)\+\+\}/g,
+    deletionCritic: /\{--([^-]*)--\}/g,
+    commentCritic: /\{>>([^<]*)<<\}/g,
+    typoCritic: /\{~~([^~]*)~>([^~]*)~~\}/g
+};
+
+interface EditMark {
+    type: 'insertion' | 'deletion' | 'comment' | 'typo';
+    range: vscode.Range;
+    content: string;
+    replacement?: string;  // For typos: the new text
+    fullMatch: string;
+}
+
+/**
+ * Find all editmarks in a document
+ */
+function findEditmarks(document: vscode.TextDocument): EditMark[] {
+    const text = document.getText();
+    const marks: EditMark[] = [];
+
+    // Find insertions
+    for (const pattern of [EDITMARK_PATTERNS.insertion, EDITMARK_PATTERNS.insertionCritic]) {
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            const startPos = document.positionAt(match.index);
+            const endPos = document.positionAt(match.index + match[0].length);
+            marks.push({
+                type: 'insertion',
+                range: new vscode.Range(startPos, endPos),
+                content: match[1],
+                fullMatch: match[0]
+            });
+        }
+    }
+
+    // Find deletions
+    for (const pattern of [EDITMARK_PATTERNS.deletion, EDITMARK_PATTERNS.deletionCritic]) {
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            const startPos = document.positionAt(match.index);
+            const endPos = document.positionAt(match.index + match[0].length);
+            marks.push({
+                type: 'deletion',
+                range: new vscode.Range(startPos, endPos),
+                content: match[1],
+                fullMatch: match[0]
+            });
+        }
+    }
+
+    // Find comments
+    for (const pattern of [EDITMARK_PATTERNS.comment, EDITMARK_PATTERNS.commentCritic]) {
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            const startPos = document.positionAt(match.index);
+            const endPos = document.positionAt(match.index + match[0].length);
+            marks.push({
+                type: 'comment',
+                range: new vscode.Range(startPos, endPos),
+                content: match[1],
+                fullMatch: match[0]
+            });
+        }
+    }
+
+    // Find typos
+    for (const pattern of [EDITMARK_PATTERNS.typo, EDITMARK_PATTERNS.typoCritic]) {
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            const startPos = document.positionAt(match.index);
+            const endPos = document.positionAt(match.index + match[0].length);
+            marks.push({
+                type: 'typo',
+                range: new vscode.Range(startPos, endPos),
+                content: match[1],
+                replacement: match[2],
+                fullMatch: match[0]
+            });
+        }
+    }
+
+    return marks;
+}
+
+/**
+ * Update decorations for editmarks
+ */
+function updateDecorations(editor: vscode.TextEditor): void {
+    const marks = findEditmarks(editor.document);
+
+    const insertions: vscode.DecorationOptions[] = [];
+    const deletions: vscode.DecorationOptions[] = [];
+    const comments: vscode.DecorationOptions[] = [];
+    const typos: vscode.DecorationOptions[] = [];
+
+    for (const mark of marks) {
+        const decoration: vscode.DecorationOptions = {
+            range: mark.range,
+            hoverMessage: getHoverMessage(mark)
+        };
+
+        switch (mark.type) {
+            case 'insertion':
+                insertions.push(decoration);
+                break;
+            case 'deletion':
+                deletions.push(decoration);
+                break;
+            case 'comment':
+                comments.push(decoration);
+                break;
+            case 'typo':
+                typos.push(decoration);
+                break;
+        }
+    }
+
+    editor.setDecorations(insertionDecorationType, insertions);
+    editor.setDecorations(deletionDecorationType, deletions);
+    editor.setDecorations(commentDecorationType, comments);
+    editor.setDecorations(typoDecorationType, typos);
+}
+
+/**
+ * Get hover message for an editmark
+ */
+function getHoverMessage(mark: EditMark): vscode.MarkdownString {
+    const md = new vscode.MarkdownString();
+    md.isTrusted = true;
+
+    switch (mark.type) {
+        case 'insertion':
+            md.appendMarkdown(`**Insertion:** "${mark.content}"\n\n`);
+            md.appendMarkdown(`[Accept](command:scimax.editmarks.accept) | [Reject](command:scimax.editmarks.reject)`);
+            break;
+        case 'deletion':
+            md.appendMarkdown(`**Deletion:** "${mark.content}"\n\n`);
+            md.appendMarkdown(`[Accept](command:scimax.editmarks.accept) | [Reject](command:scimax.editmarks.reject)`);
+            break;
+        case 'comment':
+            md.appendMarkdown(`**Comment:** ${mark.content}\n\n`);
+            md.appendMarkdown(`[Delete Comment](command:scimax.editmarks.accept)`);
+            break;
+        case 'typo':
+            md.appendMarkdown(`**Typo correction:** "${mark.content}" → "${mark.replacement}"\n\n`);
+            md.appendMarkdown(`[Accept](command:scimax.editmarks.accept) | [Reject](command:scimax.editmarks.reject)`);
+            break;
+    }
+
+    return md;
+}
+
+/**
+ * Insert an insertion mark around selected text
+ */
+async function insertInsertion(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const selection = editor.selection;
+
+    if (selection.isEmpty) {
+        // No selection - prompt for text
+        const text = await vscode.window.showInputBox({
+            prompt: 'Enter text to insert',
+            placeHolder: 'inserted text'
+        });
+
+        if (text) {
+            await editor.edit(editBuilder => {
+                editBuilder.insert(selection.start, `@@+${text}+@@`);
+            });
+        }
+    } else {
+        // Wrap selection
+        const selectedText = editor.document.getText(selection);
+        await editor.edit(editBuilder => {
+            editBuilder.replace(selection, `@@+${selectedText}+@@`);
+        });
+    }
+
+    updateDecorations(editor);
+}
+
+/**
+ * Mark selected text for deletion
+ */
+async function insertDeletion(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const selection = editor.selection;
+
+    if (selection.isEmpty) {
+        vscode.window.showInformationMessage('Select text to mark for deletion');
+        return;
+    }
+
+    const selectedText = editor.document.getText(selection);
+    await editor.edit(editBuilder => {
+        editBuilder.replace(selection, `@@-${selectedText}-@@`);
+    });
+
+    updateDecorations(editor);
+}
+
+/**
+ * Insert a comment mark
+ */
+async function insertComment(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const selection = editor.selection;
+    let commentText: string | undefined;
+
+    if (selection.isEmpty) {
+        // No selection - prompt for comment
+        commentText = await vscode.window.showInputBox({
+            prompt: 'Enter comment',
+            placeHolder: 'Your comment here'
+        });
+    } else {
+        // Selection becomes the comment
+        commentText = editor.document.getText(selection);
+    }
+
+    if (commentText) {
+        await editor.edit(editBuilder => {
+            if (selection.isEmpty) {
+                editBuilder.insert(selection.start, `@@>${commentText}<@@`);
+            } else {
+                editBuilder.replace(selection, `@@>${commentText}<@@`);
+            }
+        });
+    }
+
+    updateDecorations(editor);
+}
+
+/**
+ * Mark a typo correction (select wrong text, enter correct text)
+ */
+async function insertTypo(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const selection = editor.selection;
+
+    if (selection.isEmpty) {
+        vscode.window.showInformationMessage('Select the incorrect text first');
+        return;
+    }
+
+    const wrongText = editor.document.getText(selection);
+    const correctText = await vscode.window.showInputBox({
+        prompt: `Replace "${wrongText}" with:`,
+        placeHolder: 'correct text'
+    });
+
+    if (correctText) {
+        await editor.edit(editBuilder => {
+            editBuilder.replace(selection, `@@~${wrongText}|${correctText}~@@`);
+        });
+    }
+
+    updateDecorations(editor);
+}
+
+/**
+ * Find editmark at cursor position
+ */
+function findEditmarkAtCursor(editor: vscode.TextEditor): EditMark | null {
+    const position = editor.selection.active;
+    const marks = findEditmarks(editor.document);
+
+    for (const mark of marks) {
+        if (mark.range.contains(position)) {
+            return mark;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Accept the editmark at cursor
+ */
+async function acceptEditmark(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const mark = findEditmarkAtCursor(editor);
+    if (!mark) {
+        vscode.window.showInformationMessage('No editmark at cursor');
+        return;
+    }
+
+    await editor.edit(editBuilder => {
+        switch (mark.type) {
+            case 'insertion':
+                // Keep the inserted text, remove markup
+                editBuilder.replace(mark.range, mark.content);
+                break;
+            case 'deletion':
+                // Accept deletion - remove the text entirely
+                editBuilder.replace(mark.range, '');
+                break;
+            case 'comment':
+                // Remove the comment
+                editBuilder.replace(mark.range, '');
+                break;
+            case 'typo':
+                // Accept the correction
+                editBuilder.replace(mark.range, mark.replacement || '');
+                break;
+        }
+    });
+
+    updateDecorations(editor);
+}
+
+/**
+ * Reject the editmark at cursor
+ */
+async function rejectEditmark(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const mark = findEditmarkAtCursor(editor);
+    if (!mark) {
+        vscode.window.showInformationMessage('No editmark at cursor');
+        return;
+    }
+
+    await editor.edit(editBuilder => {
+        switch (mark.type) {
+            case 'insertion':
+                // Reject insertion - remove entirely
+                editBuilder.replace(mark.range, '');
+                break;
+            case 'deletion':
+                // Reject deletion - keep the original text
+                editBuilder.replace(mark.range, mark.content);
+                break;
+            case 'comment':
+                // Keep the comment (or remove it)
+                editBuilder.replace(mark.range, '');
+                break;
+            case 'typo':
+                // Reject correction - keep original
+                editBuilder.replace(mark.range, mark.content);
+                break;
+        }
+    });
+
+    updateDecorations(editor);
+}
+
+/**
+ * Accept all editmarks in document
+ */
+async function acceptAllEditmarks(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const marks = findEditmarks(editor.document);
+    if (marks.length === 0) {
+        vscode.window.showInformationMessage('No editmarks in document');
+        return;
+    }
+
+    const confirm = await vscode.window.showWarningMessage(
+        `Accept all ${marks.length} editmarks?`,
+        'Yes',
+        'No'
+    );
+
+    if (confirm !== 'Yes') return;
+
+    // Sort marks by position (reverse order to edit from end to start)
+    marks.sort((a, b) => b.range.start.compareTo(a.range.start));
+
+    await editor.edit(editBuilder => {
+        for (const mark of marks) {
+            switch (mark.type) {
+                case 'insertion':
+                    editBuilder.replace(mark.range, mark.content);
+                    break;
+                case 'deletion':
+                    editBuilder.replace(mark.range, '');
+                    break;
+                case 'comment':
+                    editBuilder.replace(mark.range, '');
+                    break;
+                case 'typo':
+                    editBuilder.replace(mark.range, mark.replacement || '');
+                    break;
+            }
+        }
+    });
+
+    updateDecorations(editor);
+    vscode.window.showInformationMessage(`Accepted ${marks.length} editmarks`);
+}
+
+/**
+ * Reject all editmarks in document
+ */
+async function rejectAllEditmarks(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const marks = findEditmarks(editor.document);
+    if (marks.length === 0) {
+        vscode.window.showInformationMessage('No editmarks in document');
+        return;
+    }
+
+    const confirm = await vscode.window.showWarningMessage(
+        `Reject all ${marks.length} editmarks?`,
+        'Yes',
+        'No'
+    );
+
+    if (confirm !== 'Yes') return;
+
+    // Sort marks by position (reverse order)
+    marks.sort((a, b) => b.range.start.compareTo(a.range.start));
+
+    await editor.edit(editBuilder => {
+        for (const mark of marks) {
+            switch (mark.type) {
+                case 'insertion':
+                    editBuilder.replace(mark.range, '');
+                    break;
+                case 'deletion':
+                    editBuilder.replace(mark.range, mark.content);
+                    break;
+                case 'comment':
+                    editBuilder.replace(mark.range, '');
+                    break;
+                case 'typo':
+                    editBuilder.replace(mark.range, mark.content);
+                    break;
+            }
+        }
+    });
+
+    updateDecorations(editor);
+    vscode.window.showInformationMessage(`Rejected ${marks.length} editmarks`);
+}
+
+/**
+ * Navigate to next editmark
+ */
+async function nextEditmark(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const marks = findEditmarks(editor.document);
+    if (marks.length === 0) {
+        vscode.window.showInformationMessage('No editmarks in document');
+        return;
+    }
+
+    const position = editor.selection.active;
+
+    // Sort by position
+    marks.sort((a, b) => a.range.start.compareTo(b.range.start));
+
+    // Find next mark after cursor
+    let nextMark = marks.find(m => m.range.start.isAfter(position));
+
+    // Wrap around if no mark found after cursor
+    if (!nextMark) {
+        nextMark = marks[0];
+    }
+
+    editor.selection = new vscode.Selection(nextMark.range.start, nextMark.range.start);
+    editor.revealRange(nextMark.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+}
+
+/**
+ * Navigate to previous editmark
+ */
+async function prevEditmark(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const marks = findEditmarks(editor.document);
+    if (marks.length === 0) {
+        vscode.window.showInformationMessage('No editmarks in document');
+        return;
+    }
+
+    const position = editor.selection.active;
+
+    // Sort by position (reverse)
+    marks.sort((a, b) => b.range.start.compareTo(a.range.start));
+
+    // Find previous mark before cursor
+    let prevMark = marks.find(m => m.range.start.isBefore(position));
+
+    // Wrap around
+    if (!prevMark) {
+        prevMark = marks[0];
+    }
+
+    editor.selection = new vscode.Selection(prevMark.range.start, prevMark.range.start);
+    editor.revealRange(prevMark.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+}
+
+/**
+ * Show summary of all editmarks in document
+ */
+async function showEditmarkSummary(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const marks = findEditmarks(editor.document);
+
+    if (marks.length === 0) {
+        vscode.window.showInformationMessage('No editmarks in document');
+        return;
+    }
+
+    const insertions = marks.filter(m => m.type === 'insertion').length;
+    const deletions = marks.filter(m => m.type === 'deletion').length;
+    const comments = marks.filter(m => m.type === 'comment').length;
+    const typos = marks.filter(m => m.type === 'typo').length;
+
+    const items: (vscode.QuickPickItem & { mark?: EditMark })[] = [
+        { label: `$(info) Summary`, description: `${marks.length} total editmarks`, kind: vscode.QuickPickItemKind.Separator },
+        { label: `$(add) Insertions: ${insertions}`, description: 'Green' },
+        { label: `$(remove) Deletions: ${deletions}`, description: 'Red' },
+        { label: `$(comment) Comments: ${comments}`, description: 'Yellow' },
+        { label: `$(edit) Typos: ${typos}`, description: 'Orange' },
+        { label: '', kind: vscode.QuickPickItemKind.Separator }
+    ];
+
+    // Add individual marks
+    for (const mark of marks) {
+        const icon = mark.type === 'insertion' ? '$(add)' :
+                     mark.type === 'deletion' ? '$(remove)' :
+                     mark.type === 'comment' ? '$(comment)' : '$(edit)';
+        const preview = mark.content.slice(0, 40) + (mark.content.length > 40 ? '...' : '');
+
+        items.push({
+            label: `${icon} ${preview}`,
+            description: `Line ${mark.range.start.line + 1}`,
+            mark
+        });
+    }
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Editmarks Summary - Select to navigate',
+        matchOnDescription: true
+    });
+
+    if (selected?.mark) {
+        editor.selection = new vscode.Selection(selected.mark.range.start, selected.mark.range.start);
+        editor.revealRange(selected.mark.range, vscode.TextEditorRevealType.InCenter);
+    }
+}
+
+/**
+ * Register editmark commands
+ */
+export function registerEditmarkCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        // Insert marks
+        vscode.commands.registerCommand('scimax.editmarks.insertion', insertInsertion),
+        vscode.commands.registerCommand('scimax.editmarks.deletion', insertDeletion),
+        vscode.commands.registerCommand('scimax.editmarks.comment', insertComment),
+        vscode.commands.registerCommand('scimax.editmarks.typo', insertTypo),
+
+        // Accept/reject
+        vscode.commands.registerCommand('scimax.editmarks.accept', acceptEditmark),
+        vscode.commands.registerCommand('scimax.editmarks.reject', rejectEditmark),
+        vscode.commands.registerCommand('scimax.editmarks.acceptAll', acceptAllEditmarks),
+        vscode.commands.registerCommand('scimax.editmarks.rejectAll', rejectAllEditmarks),
+
+        // Navigation
+        vscode.commands.registerCommand('scimax.editmarks.next', nextEditmark),
+        vscode.commands.registerCommand('scimax.editmarks.prev', prevEditmark),
+
+        // Summary
+        vscode.commands.registerCommand('scimax.editmarks.summary', showEditmarkSummary)
+    );
+
+    // Update decorations on editor change
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor(editor => {
+            if (editor) {
+                updateDecorations(editor);
+            }
+        }),
+        vscode.workspace.onDidChangeTextDocument(e => {
+            const editor = vscode.window.activeTextEditor;
+            if (editor && e.document === editor.document) {
+                updateDecorations(editor);
+            }
+        })
+    );
+
+    // Initial decoration update
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+        updateDecorations(editor);
+    }
+
+    console.log('Scimax: Editmark commands registered');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import { registerTableCommands, isInTable } from './org/tableProvider';
 import { registerHeadingCommands } from './org/headingProvider';
 import { ProjectileManager } from './projectile/projectileManager';
 import { registerProjectileCommands } from './projectile/commands';
+import { registerSwiperCommands } from './swiper/commands';
 
 let journalManager: JournalManager;
 let journalStatusBar: JournalStatusBar;
@@ -335,6 +336,9 @@ export async function activate(context: vscode.ExtensionContext) {
     // Register Projectile Commands
     registerProjectileCommands(context, projectileManager);
     console.log('Scimax: Projectile manager initialized');
+
+    // Register Swiper Commands (search current/all open files)
+    registerSwiperCommands(context);
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import { ProjectileManager } from './projectile/projectileManager';
 import { registerProjectileCommands } from './projectile/commands';
 import { registerFuzzySearchCommands } from './fuzzySearch/commands';
 import { registerJumpCommands } from './jump/commands';
+import { registerCitationManipulationCommands, checkCitationContext } from './references/citationManipulation';
 
 let journalManager: JournalManager;
 let journalStatusBar: JournalStatusBar;
@@ -139,6 +140,11 @@ export async function activate(context: vscode.ExtensionContext) {
         // Register cite action command (for clickable cite links)
         registerCiteActionCommand(context, referenceManager);
         console.log('Scimax: Cite action command registered');
+
+        // Register citation manipulation commands (transpose, sort)
+        registerCitationManipulationCommands(context, (key) => referenceManager.getEntry(key));
+        checkCitationContext(context);
+        console.log('Scimax: Citation manipulation commands registered');
     } catch (error: any) {
         const errorMsg = error?.message || String(error);
         console.error('Scimax: Failed to initialize ReferenceManager:', errorMsg, error?.stack);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,8 @@ import { registerProjectileCommands } from './projectile/commands';
 import { registerFuzzySearchCommands } from './fuzzySearch/commands';
 import { registerJumpCommands } from './jump/commands';
 import { registerCitationManipulationCommands, checkCitationContext } from './references/citationManipulation';
+import { SpellChecker, registerSpellCheckCommands, SpellingCodeActionProvider } from './spelling/spellChecker';
+import { registerEditmarkCommands } from './editmarks/editmarks';
 
 let journalManager: JournalManager;
 let journalStatusBar: JournalStatusBar;
@@ -44,6 +46,7 @@ let scimaxDb: ScimaxDb;
 let referenceManager: ReferenceManager;
 let notebookManager: NotebookManager;
 let projectileManager: ProjectileManager;
+let spellChecker: SpellChecker;
 
 export async function activate(context: vscode.ExtensionContext) {
     console.log('Scimax VS Code extension activating...');
@@ -358,6 +361,31 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Register Jump Commands (avy-style jump to visible locations)
     registerJumpCommands(context);
+
+    // Initialize Spell Checker (jinx-style)
+    spellChecker = new SpellChecker(context);
+    registerSpellCheckCommands(context, spellChecker);
+    context.subscriptions.push({ dispose: () => spellChecker.dispose() });
+
+    // Register spell check code action provider
+    const spellCheckSelector = [
+        { language: 'org', scheme: 'file' },
+        { language: 'markdown', scheme: 'file' },
+        { language: 'plaintext', scheme: 'file' },
+        { language: 'latex', scheme: 'file' }
+    ];
+    context.subscriptions.push(
+        vscode.languages.registerCodeActionsProvider(
+            spellCheckSelector,
+            new SpellingCodeActionProvider(spellChecker),
+            { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }
+        )
+    );
+    console.log('Scimax: Spell checker initialized');
+
+    // Register Editmark Commands (track changes)
+    registerEditmarkCommands(context);
+    console.log('Scimax: Editmarks initialized');
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import { registerHeadingCommands } from './org/headingProvider';
 import { ProjectileManager } from './projectile/projectileManager';
 import { registerProjectileCommands } from './projectile/commands';
 import { registerFuzzySearchCommands } from './fuzzySearch/commands';
+import { registerJumpCommands } from './jump/commands';
 
 let journalManager: JournalManager;
 let journalStatusBar: JournalStatusBar;
@@ -348,6 +349,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Register Fuzzy Search Commands (search current/all open files)
     registerFuzzySearchCommands(context);
+
+    // Register Jump Commands (avy-style jump to visible locations)
+    registerJumpCommands(context);
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import {
     BibliographyCodeLensProvider,
     BibliographyHoverProvider,
     RefHoverProvider,
+    DoiHoverProvider,
     registerCiteActionCommand
 } from './references/providers';
 import { NotebookManager } from './notebook/notebookManager';
@@ -174,6 +175,14 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerHoverProvider(
             documentSelector,
             new RefHoverProvider()
+        )
+    );
+
+    // Register DOI Hover Provider (fetches metadata from CrossRef)
+    context.subscriptions.push(
+        vscode.languages.registerHoverProvider(
+            documentSelector,
+            new DoiHoverProvider(referenceManager)
         )
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import { registerTableCommands, isInTable } from './org/tableProvider';
 import { registerHeadingCommands } from './org/headingProvider';
 import { ProjectileManager } from './projectile/projectileManager';
 import { registerProjectileCommands } from './projectile/commands';
-import { registerSwiperCommands } from './swiper/commands';
+import { registerFuzzySearchCommands } from './fuzzySearch/commands';
 
 let journalManager: JournalManager;
 let journalStatusBar: JournalStatusBar;
@@ -337,8 +337,8 @@ export async function activate(context: vscode.ExtensionContext) {
     registerProjectileCommands(context, projectileManager);
     console.log('Scimax: Projectile manager initialized');
 
-    // Register Swiper Commands (search current/all open files)
-    registerSwiperCommands(context);
+    // Register Fuzzy Search Commands (search current/all open files)
+    registerFuzzySearchCommands(context);
 }
 
 export async function deactivate() {

--- a/src/fuzzySearch/commands.ts
+++ b/src/fuzzySearch/commands.ts
@@ -84,10 +84,10 @@ async function goToLine(filePath: string, lineNumber: number): Promise<void> {
 }
 
 /**
- * Swiper - Search current file with live preview
- * Similar to Emacs swiper, shows all matching lines as you type
+ * Fuzzy search current file with live preview
+ * Shows all matching lines as you type
  */
-async function swiper(): Promise<void> {
+async function fuzzySearch(): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         vscode.window.showWarningMessage('No active editor');
@@ -150,10 +150,10 @@ async function swiper(): Promise<void> {
 }
 
 /**
- * Swiper All - Search all open files with live preview
- * Similar to Emacs swiper-all, searches across all open buffers
+ * Fuzzy search all open files with live preview
+ * Searches across all open buffers
  */
-async function swiperAll(): Promise<void> {
+async function fuzzySearchOpenFiles(): Promise<void> {
     // Get all open text documents
     const openDocuments = vscode.workspace.textDocuments.filter(doc => {
         // Filter out internal VS Code documents
@@ -236,10 +236,10 @@ async function swiperAll(): Promise<void> {
 }
 
 /**
- * Swiper Symbol - Search headings/symbols in current file
- * Like swiper but focused on structure (headings, functions, etc.)
+ * Fuzzy search headings/symbols in current file
+ * Focused on structure (headings, functions, etc.)
  */
-async function swiperSymbol(): Promise<void> {
+async function fuzzySearchOutline(): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         vscode.window.showWarningMessage('No active editor');
@@ -345,14 +345,14 @@ async function swiperSymbol(): Promise<void> {
 }
 
 /**
- * Register all swiper commands
+ * Register all fuzzy search commands
  */
-export function registerSwiperCommands(context: vscode.ExtensionContext): void {
+export function registerFuzzySearchCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
-        vscode.commands.registerCommand('scimax.swiper', swiper),
-        vscode.commands.registerCommand('scimax.swiperAll', swiperAll),
-        vscode.commands.registerCommand('scimax.swiperSymbol', swiperSymbol)
+        vscode.commands.registerCommand('scimax.fuzzySearch', fuzzySearch),
+        vscode.commands.registerCommand('scimax.fuzzySearchOpenFiles', fuzzySearchOpenFiles),
+        vscode.commands.registerCommand('scimax.fuzzySearchOutline', fuzzySearchOutline)
     );
 
-    console.log('Scimax: Swiper commands registered');
+    console.log('Scimax: Fuzzy search commands registered');
 }

--- a/src/jump/commands.ts
+++ b/src/jump/commands.ts
@@ -1,0 +1,472 @@
+import * as vscode from 'vscode';
+
+/**
+ * Jump to visible text - avy-style navigation
+ * Inspired by https://github.com/abo-abo/avy
+ */
+
+// Jump label characters (ordered by ease of typing on home row)
+const JUMP_CHARS = 'asdfjklghqweruiopzxcvbnmty';
+
+interface JumpTarget {
+    position: vscode.Position;
+    label: string;
+    lineText: string;
+    matchText: string;
+}
+
+/**
+ * Generate jump labels for targets
+ * Uses single chars for small sets, double chars for larger sets
+ */
+function generateLabels(count: number): string[] {
+    const labels: string[] = [];
+
+    if (count <= JUMP_CHARS.length) {
+        // Single character labels
+        for (let i = 0; i < count && i < JUMP_CHARS.length; i++) {
+            labels.push(JUMP_CHARS[i]);
+        }
+    } else {
+        // Two character labels for more targets
+        for (let i = 0; i < JUMP_CHARS.length && labels.length < count; i++) {
+            for (let j = 0; j < JUMP_CHARS.length && labels.length < count; j++) {
+                labels.push(JUMP_CHARS[i] + JUMP_CHARS[j]);
+            }
+        }
+    }
+
+    return labels;
+}
+
+/**
+ * Find all visible positions matching a pattern
+ */
+function findVisibleMatches(
+    editor: vscode.TextEditor,
+    pattern: RegExp
+): Array<{ position: vscode.Position; matchText: string; lineText: string }> {
+    const matches: Array<{ position: vscode.Position; matchText: string; lineText: string }> = [];
+    const visibleRanges = editor.visibleRanges;
+
+    for (const range of visibleRanges) {
+        for (let line = range.start.line; line <= range.end.line; line++) {
+            const lineText = editor.document.lineAt(line).text;
+            let match;
+
+            // Reset regex for each line
+            const localPattern = new RegExp(pattern.source, pattern.flags);
+
+            while ((match = localPattern.exec(lineText)) !== null) {
+                matches.push({
+                    position: new vscode.Position(line, match.index),
+                    matchText: match[0],
+                    lineText
+                });
+
+                // Prevent infinite loop for zero-width matches
+                if (match[0].length === 0) {
+                    localPattern.lastIndex++;
+                }
+            }
+        }
+    }
+
+    return matches;
+}
+
+/**
+ * Show jump labels using QuickPick and decorations
+ */
+async function showJumpTargets(
+    editor: vscode.TextEditor,
+    matches: Array<{ position: vscode.Position; matchText: string; lineText: string }>
+): Promise<vscode.Position | undefined> {
+    if (matches.length === 0) {
+        vscode.window.showInformationMessage('No matches found');
+        return undefined;
+    }
+
+    if (matches.length === 1) {
+        // Only one match, jump directly
+        return matches[0].position;
+    }
+
+    const labels = generateLabels(matches.length);
+    const targets: JumpTarget[] = matches.map((match, i) => ({
+        position: match.position,
+        label: labels[i],
+        lineText: match.lineText,
+        matchText: match.matchText
+    }));
+
+    // Create decoration type for highlighting matches
+    const highlightDecoration = vscode.window.createTextEditorDecorationType({
+        backgroundColor: new vscode.ThemeColor('editor.findMatchHighlightBackground'),
+        border: '1px solid',
+        borderColor: new vscode.ThemeColor('editor.findMatchHighlightBorder')
+    });
+
+    // Highlight all match positions
+    const decorations: vscode.DecorationOptions[] = targets.map(target => ({
+        range: new vscode.Range(
+            target.position,
+            target.position.translate(0, target.matchText.length || 1)
+        )
+    }));
+
+    editor.setDecorations(highlightDecoration, decorations);
+
+    try {
+        // Build QuickPick items
+        const items = targets.map(target => ({
+            label: `[${target.label}] ${target.lineText.trim()}`,
+            description: `Line ${target.position.line + 1}, Col ${target.position.character + 1}`,
+            detail: target.matchText !== target.lineText.trim() ? `Match: "${target.matchText}"` : undefined,
+            target
+        }));
+
+        // Create QuickPick
+        const quickPick = vscode.window.createQuickPick<typeof items[0]>();
+        quickPick.items = items;
+        quickPick.placeholder = `Type label (${labels[0]}, ${labels[1]}...) or select from list`;
+        quickPick.matchOnDescription = false;
+        quickPick.matchOnDetail = false;
+
+        return new Promise((resolve) => {
+            let resolved = false;
+
+            // Custom filtering: match against labels
+            quickPick.onDidChangeValue(value => {
+                if (resolved) return;
+
+                const lowerValue = value.toLowerCase();
+
+                // Check for exact label match
+                const exactMatch = targets.find(t => t.label === lowerValue);
+                if (exactMatch) {
+                    resolved = true;
+                    quickPick.hide();
+                    resolve(exactMatch.position);
+                    return;
+                }
+
+                // Filter items by label prefix
+                if (lowerValue.length > 0) {
+                    const filtered = items.filter(item =>
+                        item.target.label.startsWith(lowerValue)
+                    );
+                    quickPick.items = filtered.length > 0 ? filtered : items;
+                } else {
+                    quickPick.items = items;
+                }
+            });
+
+            // Handle selection
+            quickPick.onDidAccept(() => {
+                if (resolved) return;
+                resolved = true;
+
+                const selected = quickPick.selectedItems[0];
+                quickPick.hide();
+
+                if (selected) {
+                    resolve(selected.target.position);
+                } else {
+                    resolve(undefined);
+                }
+            });
+
+            // Handle cancel
+            quickPick.onDidHide(() => {
+                if (!resolved) {
+                    resolved = true;
+                    resolve(undefined);
+                }
+                quickPick.dispose();
+            });
+
+            quickPick.show();
+        });
+    } finally {
+        // Clean up decorations
+        highlightDecoration.dispose();
+    }
+}
+
+/**
+ * Jump to position
+ */
+function jumpToPosition(editor: vscode.TextEditor, position: vscode.Position): void {
+    editor.selection = new vscode.Selection(position, position);
+    editor.revealRange(
+        new vscode.Range(position, position),
+        vscode.TextEditorRevealType.InCenterIfOutsideViewport
+    );
+}
+
+/**
+ * Jump to char - jump to any occurrence of a character
+ */
+async function jumpGotoChar(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const char = await vscode.window.showInputBox({
+        prompt: 'Jump: Enter character to jump to',
+        placeHolder: 'Enter a character to jump to',
+        validateInput: (value) => value.length > 1 ? 'Enter a single character' : null
+    });
+
+    if (!char) return;
+
+    // Escape special regex characters
+    const escaped = char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(escaped, 'gi');
+
+    const matches = findVisibleMatches(editor, pattern);
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        jumpToPosition(editor, target);
+    }
+}
+
+/**
+ * Jump to char 2 - jump to two-character sequence
+ */
+async function jumpGotoChar2(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const chars = await vscode.window.showInputBox({
+        prompt: 'Jump: Enter 2-char sequence',
+        placeHolder: 'Enter two characters',
+        validateInput: (value) => {
+            if (value.length < 2) return 'Enter 2 characters';
+            if (value.length > 2) return 'Enter exactly 2 characters';
+            return null;
+        }
+    });
+
+    if (!chars || chars.length !== 2) return;
+
+    const escaped = chars.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(escaped, 'gi');
+
+    const matches = findVisibleMatches(editor, pattern);
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        jumpToPosition(editor, target);
+    }
+}
+
+/**
+ * Jump to word - jump to word starts
+ */
+async function jumpGotoWord(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const char = await vscode.window.showInputBox({
+        prompt: 'Jump: Enter starting character (or leave empty for all words)',
+        placeHolder: 'Enter starting character (or leave empty for all words)',
+    });
+
+    // Pattern for word starts
+    let pattern: RegExp;
+    if (char && char.length >= 1) {
+        const escaped = char[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        pattern = new RegExp(`\\b${escaped}\\w*`, 'gi');
+    } else {
+        pattern = /\b\w+/g;
+    }
+
+    const matches = findVisibleMatches(editor, pattern);
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        jumpToPosition(editor, target);
+    }
+}
+
+/**
+ * Jump to line - jump to any visible line
+ */
+async function jumpGotoLine(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const matches: Array<{ position: vscode.Position; matchText: string; lineText: string }> = [];
+    const visibleRanges = editor.visibleRanges;
+
+    for (const range of visibleRanges) {
+        for (let line = range.start.line; line <= range.end.line; line++) {
+            const lineText = editor.document.lineAt(line).text;
+            // Find first non-whitespace character
+            const firstNonWhitespace = lineText.search(/\S/);
+            const col = firstNonWhitespace >= 0 ? firstNonWhitespace : 0;
+
+            matches.push({
+                position: new vscode.Position(line, col),
+                matchText: lineText.trim().substring(0, 20) || '(empty line)',
+                lineText
+            });
+        }
+    }
+
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        jumpToPosition(editor, target);
+    }
+}
+
+/**
+ * Jump to symbol - jump to symbol/heading definitions
+ */
+async function jumpGotoSymbol(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const matches: Array<{ position: vscode.Position; matchText: string; lineText: string }> = [];
+    const visibleRanges = editor.visibleRanges;
+
+    // Patterns for symbols/headings
+    const symbolPatterns = [
+        /^(\s*)(function|def|class|interface|type|const|let|var|export|async|public|private|protected)\s+(\w+)/,
+        /^(\s*)(\*+)\s+(.+)$/,  // Org headings
+        /^(\s*)(#{1,6})\s+(.+)$/,   // Markdown headings
+        /^(\s*)(\/\/|#|\/\*)\s*(TODO|FIXME|NOTE|HACK|XXX)/i, // Comment markers
+    ];
+
+    for (const range of visibleRanges) {
+        for (let line = range.start.line; line <= range.end.line; line++) {
+            const lineText = editor.document.lineAt(line).text;
+
+            for (const pattern of symbolPatterns) {
+                const match = pattern.exec(lineText);
+                if (match) {
+                    const indent = match[1]?.length || 0;
+                    matches.push({
+                        position: new vscode.Position(line, indent),
+                        matchText: match[3] || match[2] || lineText.trim(),
+                        lineText
+                    });
+                    break;
+                }
+            }
+        }
+    }
+
+    if (matches.length === 0) {
+        vscode.window.showInformationMessage('No symbols found in visible area');
+        return;
+    }
+
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        jumpToPosition(editor, target);
+    }
+}
+
+/**
+ * Jump copy line - select a line and copy it
+ */
+async function jumpCopyLine(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const matches: Array<{ position: vscode.Position; matchText: string; lineText: string }> = [];
+    const visibleRanges = editor.visibleRanges;
+
+    for (const range of visibleRanges) {
+        for (let line = range.start.line; line <= range.end.line; line++) {
+            const lineText = editor.document.lineAt(line).text;
+            if (lineText.trim().length > 0) {
+                matches.push({
+                    position: new vscode.Position(line, 0),
+                    matchText: lineText.trim().substring(0, 30),
+                    lineText
+                });
+            }
+        }
+    }
+
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        const lineText = editor.document.lineAt(target.line).text;
+        await vscode.env.clipboard.writeText(lineText);
+        vscode.window.showInformationMessage(`Copied line ${target.line + 1}`);
+    }
+}
+
+/**
+ * Jump kill line - select a line and delete it
+ */
+async function jumpKillLine(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const matches: Array<{ position: vscode.Position; matchText: string; lineText: string }> = [];
+    const visibleRanges = editor.visibleRanges;
+
+    for (const range of visibleRanges) {
+        for (let line = range.start.line; line <= range.end.line; line++) {
+            const lineText = editor.document.lineAt(line).text;
+            matches.push({
+                position: new vscode.Position(line, 0),
+                matchText: lineText.trim().substring(0, 30) || '(empty)',
+                lineText
+            });
+        }
+    }
+
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        const line = editor.document.lineAt(target.line);
+        await editor.edit(editBuilder => {
+            editBuilder.delete(line.rangeIncludingLineBreak);
+        });
+    }
+}
+
+/**
+ * Jump to subword - jump to subword boundaries (camelCase, snake_case)
+ */
+async function jumpGotoSubword(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    // Pattern for subword boundaries: capital letters, after underscores, after hyphens
+    const pattern = /(?<=[a-z])[A-Z]|(?<=[A-Za-z])[0-9]|(?<=_)[a-zA-Z]|(?<=-)[a-zA-Z]|\b[a-zA-Z]/g;
+
+    const matches = findVisibleMatches(editor, pattern);
+    const target = await showJumpTargets(editor, matches);
+
+    if (target) {
+        jumpToPosition(editor, target);
+    }
+}
+
+/**
+ * Register all jump commands
+ */
+export function registerJumpCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.jump.gotoChar', jumpGotoChar),
+        vscode.commands.registerCommand('scimax.jump.gotoChar2', jumpGotoChar2),
+        vscode.commands.registerCommand('scimax.jump.gotoWord', jumpGotoWord),
+        vscode.commands.registerCommand('scimax.jump.gotoLine', jumpGotoLine),
+        vscode.commands.registerCommand('scimax.jump.gotoSymbol', jumpGotoSymbol),
+        vscode.commands.registerCommand('scimax.jump.gotoSubword', jumpGotoSubword),
+        vscode.commands.registerCommand('scimax.jump.copyLine', jumpCopyLine),
+        vscode.commands.registerCommand('scimax.jump.killLine', jumpKillLine)
+    );
+
+    console.log('Scimax: Jump commands registered');
+}

--- a/src/references/citationManipulation.ts
+++ b/src/references/citationManipulation.ts
@@ -1,0 +1,443 @@
+import * as vscode from 'vscode';
+
+/**
+ * Citation manipulation commands
+ * Inspired by org-ref citation manipulation in Emacs
+ *
+ * - Shift-left: Transpose citation left (swap with previous)
+ * - Shift-right: Transpose citation right (swap with next)
+ * - Shift-up: Sort citations alphabetically
+ */
+
+interface CitationInfo {
+    fullMatch: string;
+    prefix: string;           // e.g., "cite:", "citep:", "\cite{"
+    suffix: string;           // e.g., "" or "}"
+    keys: string[];           // Individual citation keys
+    separator: string;        // "," or ";"
+    keyPrefix: string;        // "" or "@" for org-mode 9.5 style
+    start: number;            // Start position in line
+    end: number;              // End position in line
+    keysStart: number;        // Start of keys within fullMatch
+}
+
+/**
+ * Find citation at cursor position
+ */
+function findCitationAtPosition(line: string, position: number): CitationInfo | null {
+    // Patterns to match different citation formats
+    const patterns = [
+        // org-ref style: cite:key1,key2,key3
+        {
+            regex: /(cite[pt]?|citeauthor|citeyear|Citep|Citet|citealp|citealt):([a-zA-Z0-9_:,-]+)/g,
+            prefix: (m: RegExpExecArray) => m[1] + ':',
+            suffix: '',
+            separator: ',',
+            keyPrefix: '',
+            keysGroup: 2
+        },
+        // LaTeX style: \cite{key1,key2,key3}
+        {
+            regex: /(\\cite[pt]?)\{([a-zA-Z0-9_:,-]+)\}/g,
+            prefix: (m: RegExpExecArray) => m[1] + '{',
+            suffix: '}',
+            separator: ',',
+            keyPrefix: '',
+            keysGroup: 2
+        },
+        // org-mode 9.5+ style: [cite:@key1;@key2]
+        {
+            regex: /(\[cite(?:\/[^\]:]*)?\:)(@[a-zA-Z0-9_:;@-]+)(\])/g,
+            prefix: (m: RegExpExecArray) => m[1],
+            suffix: ']',
+            separator: ';',
+            keyPrefix: '@',
+            keysGroup: 2
+        }
+    ];
+
+    for (const pattern of patterns) {
+        let match;
+        while ((match = pattern.regex.exec(line)) !== null) {
+            const start = match.index;
+            const end = start + match[0].length;
+
+            if (position >= start && position <= end) {
+                const prefix = typeof pattern.prefix === 'function'
+                    ? pattern.prefix(match)
+                    : pattern.prefix;
+                const keysStr = match[pattern.keysGroup];
+
+                // Parse keys
+                let keys: string[];
+                if (pattern.keyPrefix === '@') {
+                    // org-mode 9.5 style with @key;@key2
+                    keys = keysStr.split(pattern.separator).map(k => k.trim().replace(/^@/, ''));
+                } else {
+                    keys = keysStr.split(pattern.separator).map(k => k.trim());
+                }
+
+                // Calculate keysStart position within the line
+                const keysStart = start + prefix.length;
+
+                return {
+                    fullMatch: match[0],
+                    prefix,
+                    suffix: pattern.suffix,
+                    keys,
+                    separator: pattern.separator,
+                    keyPrefix: pattern.keyPrefix,
+                    start,
+                    end,
+                    keysStart
+                };
+            }
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Find which key index the cursor is on
+ */
+function findKeyIndexAtPosition(citation: CitationInfo, line: string, position: number): number {
+    let currentPos = citation.keysStart;
+
+    for (let i = 0; i < citation.keys.length; i++) {
+        const key = citation.keys[i];
+        const keyWithPrefix = citation.keyPrefix + key;
+        const keyEnd = currentPos + keyWithPrefix.length;
+
+        if (position >= currentPos && position <= keyEnd) {
+            return i;
+        }
+
+        // Move past the key and separator
+        currentPos = keyEnd + citation.separator.length;
+    }
+
+    // Default to last key if position is at the end
+    return citation.keys.length - 1;
+}
+
+/**
+ * Rebuild citation string from parts
+ */
+function rebuildCitation(citation: CitationInfo): string {
+    const keysWithPrefix = citation.keys.map(k => citation.keyPrefix + k);
+    return citation.prefix + keysWithPrefix.join(citation.separator) + citation.suffix;
+}
+
+/**
+ * Transpose citation key left (swap with previous)
+ */
+async function transposeCitationLeft(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+    const line = document.lineAt(position.line).text;
+
+    const citation = findCitationAtPosition(line, position.character);
+    if (!citation) {
+        // Not on a citation, fall back to default shift-left behavior
+        await vscode.commands.executeCommand('cursorWordLeft');
+        return;
+    }
+
+    if (citation.keys.length < 2) {
+        vscode.window.showInformationMessage('Only one citation key - nothing to transpose');
+        return;
+    }
+
+    const keyIndex = findKeyIndexAtPosition(citation, line, position.character);
+
+    if (keyIndex === 0) {
+        vscode.window.showInformationMessage('Already at first citation');
+        return;
+    }
+
+    // Swap with previous key
+    const temp = citation.keys[keyIndex];
+    citation.keys[keyIndex] = citation.keys[keyIndex - 1];
+    citation.keys[keyIndex - 1] = temp;
+
+    // Replace in document
+    const newCitation = rebuildCitation(citation);
+    const range = new vscode.Range(
+        position.line, citation.start,
+        position.line, citation.end
+    );
+
+    await editor.edit(editBuilder => {
+        editBuilder.replace(range, newCitation);
+    });
+
+    // Move cursor to follow the transposed key
+    const newKeyStart = calculateKeyPosition(citation, keyIndex - 1);
+    const newPosition = new vscode.Position(position.line, newKeyStart);
+    editor.selection = new vscode.Selection(newPosition, newPosition);
+}
+
+/**
+ * Transpose citation key right (swap with next)
+ */
+async function transposeCitationRight(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+    const line = document.lineAt(position.line).text;
+
+    const citation = findCitationAtPosition(line, position.character);
+    if (!citation) {
+        // Not on a citation, fall back to default shift-right behavior
+        await vscode.commands.executeCommand('cursorWordRight');
+        return;
+    }
+
+    if (citation.keys.length < 2) {
+        vscode.window.showInformationMessage('Only one citation key - nothing to transpose');
+        return;
+    }
+
+    const keyIndex = findKeyIndexAtPosition(citation, line, position.character);
+
+    if (keyIndex >= citation.keys.length - 1) {
+        vscode.window.showInformationMessage('Already at last citation');
+        return;
+    }
+
+    // Swap with next key
+    const temp = citation.keys[keyIndex];
+    citation.keys[keyIndex] = citation.keys[keyIndex + 1];
+    citation.keys[keyIndex + 1] = temp;
+
+    // Replace in document
+    const newCitation = rebuildCitation(citation);
+    const range = new vscode.Range(
+        position.line, citation.start,
+        position.line, citation.end
+    );
+
+    await editor.edit(editBuilder => {
+        editBuilder.replace(range, newCitation);
+    });
+
+    // Move cursor to follow the transposed key
+    const newKeyStart = calculateKeyPosition(citation, keyIndex + 1);
+    const newPosition = new vscode.Position(position.line, newKeyStart);
+    editor.selection = new vscode.Selection(newPosition, newPosition);
+}
+
+/**
+ * Calculate position of a key by index after modification
+ */
+function calculateKeyPosition(citation: CitationInfo, keyIndex: number): number {
+    let pos = citation.start + citation.prefix.length;
+
+    for (let i = 0; i < keyIndex; i++) {
+        pos += citation.keyPrefix.length + citation.keys[i].length + citation.separator.length;
+    }
+
+    return pos + citation.keyPrefix.length;
+}
+
+/**
+ * Sort citations alphabetically
+ */
+async function sortCitations(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+    const line = document.lineAt(position.line).text;
+
+    const citation = findCitationAtPosition(line, position.character);
+    if (!citation) {
+        vscode.window.showInformationMessage('Cursor not on a citation');
+        return;
+    }
+
+    if (citation.keys.length < 2) {
+        vscode.window.showInformationMessage('Only one citation key - nothing to sort');
+        return;
+    }
+
+    // Sort keys alphabetically (case-insensitive)
+    const originalKeys = [...citation.keys];
+    citation.keys.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+
+    // Check if already sorted
+    if (originalKeys.every((k, i) => k === citation.keys[i])) {
+        vscode.window.showInformationMessage('Citations already sorted');
+        return;
+    }
+
+    // Replace in document
+    const newCitation = rebuildCitation(citation);
+    const range = new vscode.Range(
+        position.line, citation.start,
+        position.line, citation.end
+    );
+
+    await editor.edit(editBuilder => {
+        editBuilder.replace(range, newCitation);
+    });
+
+    vscode.window.showInformationMessage(`Sorted ${citation.keys.length} citations`);
+}
+
+/**
+ * Sort citations by year (requires reference manager)
+ */
+async function sortCitationsByYear(getEntry: (key: string) => any): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+    const line = document.lineAt(position.line).text;
+
+    const citation = findCitationAtPosition(line, position.character);
+    if (!citation) {
+        vscode.window.showInformationMessage('Cursor not on a citation');
+        return;
+    }
+
+    if (citation.keys.length < 2) {
+        vscode.window.showInformationMessage('Only one citation key - nothing to sort');
+        return;
+    }
+
+    // Sort keys by year
+    citation.keys.sort((a, b) => {
+        const entryA = getEntry(a);
+        const entryB = getEntry(b);
+        const yearA = parseInt(entryA?.year || '9999');
+        const yearB = parseInt(entryB?.year || '9999');
+        return yearA - yearB;
+    });
+
+    // Replace in document
+    const newCitation = rebuildCitation(citation);
+    const range = new vscode.Range(
+        position.line, citation.start,
+        position.line, citation.end
+    );
+
+    await editor.edit(editBuilder => {
+        editBuilder.replace(range, newCitation);
+    });
+
+    vscode.window.showInformationMessage(`Sorted ${citation.keys.length} citations by year`);
+}
+
+/**
+ * Delete citation at cursor
+ */
+async function deleteCitation(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+    const line = document.lineAt(position.line).text;
+
+    const citation = findCitationAtPosition(line, position.character);
+    if (!citation) {
+        vscode.window.showInformationMessage('Cursor not on a citation');
+        return;
+    }
+
+    const keyIndex = findKeyIndexAtPosition(citation, line, position.character);
+    const keyToDelete = citation.keys[keyIndex];
+
+    if (citation.keys.length === 1) {
+        // Only one key - delete entire citation
+        const range = new vscode.Range(
+            position.line, citation.start,
+            position.line, citation.end
+        );
+
+        await editor.edit(editBuilder => {
+            editBuilder.delete(range);
+        });
+        vscode.window.showInformationMessage(`Deleted citation: ${keyToDelete}`);
+    } else {
+        // Multiple keys - remove just this one
+        citation.keys.splice(keyIndex, 1);
+
+        const newCitation = rebuildCitation(citation);
+        const range = new vscode.Range(
+            position.line, citation.start,
+            position.line, citation.end
+        );
+
+        await editor.edit(editBuilder => {
+            editBuilder.replace(range, newCitation);
+        });
+        vscode.window.showInformationMessage(`Removed citation key: ${keyToDelete}`);
+    }
+}
+
+/**
+ * Check if cursor is on a citation
+ */
+function isOnCitation(document: vscode.TextDocument, position: vscode.Position): boolean {
+    const line = document.lineAt(position.line).text;
+    return findCitationAtPosition(line, position.character) !== null;
+}
+
+/**
+ * Register citation manipulation commands
+ */
+export function registerCitationManipulationCommands(
+    context: vscode.ExtensionContext,
+    getEntry?: (key: string) => any
+): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.ref.transposeCitationLeft', transposeCitationLeft),
+        vscode.commands.registerCommand('scimax.ref.transposeCitationRight', transposeCitationRight),
+        vscode.commands.registerCommand('scimax.ref.sortCitations', sortCitations),
+        vscode.commands.registerCommand('scimax.ref.deleteCitation', deleteCitation)
+    );
+
+    // Sort by year if reference manager is available
+    if (getEntry) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand('scimax.ref.sortCitationsByYear', () =>
+                sortCitationsByYear(getEntry)
+            )
+        );
+    }
+
+    console.log('Scimax: Citation manipulation commands registered');
+}
+
+/**
+ * Check if cursor is on citation (for keybinding context)
+ */
+export function checkCitationContext(context: vscode.ExtensionContext): void {
+    // Update context when selection changes
+    context.subscriptions.push(
+        vscode.window.onDidChangeTextEditorSelection(e => {
+            const editor = e.textEditor;
+            const document = editor.document;
+
+            // Only check for org/markdown/latex files
+            if (!['org', 'markdown', 'latex'].includes(document.languageId)) {
+                vscode.commands.executeCommand('setContext', 'scimax.onCitation', false);
+                return;
+            }
+
+            const position = editor.selection.active;
+            const onCitation = isOnCitation(document, position);
+            vscode.commands.executeCommand('setContext', 'scimax.onCitation', onCitation);
+        })
+    );
+}

--- a/src/references/openalexService.ts
+++ b/src/references/openalexService.ts
@@ -1,0 +1,454 @@
+import * as https from 'https';
+
+/**
+ * OpenAlex Work metadata
+ * See: https://docs.openalex.org/api-entities/works/work-object
+ */
+export interface OpenAlexWork {
+    id: string;
+    doi?: string;
+    title: string;
+    publication_year?: number;
+    publication_date?: string;
+    type?: string;
+    cited_by_count: number;
+    is_retracted: boolean;
+    is_paratext: boolean;
+
+    // Open Access info
+    open_access?: {
+        is_oa: boolean;
+        oa_status: 'gold' | 'green' | 'hybrid' | 'bronze' | 'closed';
+        oa_url?: string;
+    };
+
+    // Authors
+    authorships?: Array<{
+        author: {
+            id: string;
+            display_name: string;
+            orcid?: string;
+        };
+        institutions?: Array<{
+            id: string;
+            display_name: string;
+            country_code?: string;
+        }>;
+        author_position: 'first' | 'middle' | 'last';
+    }>;
+
+    // Source (journal/venue)
+    primary_location?: {
+        source?: {
+            id: string;
+            display_name: string;
+            issn_l?: string;
+            type?: string;
+        };
+        pdf_url?: string;
+        landing_page_url?: string;
+    };
+
+    // Topics (AI-assigned)
+    primary_topic?: {
+        id: string;
+        display_name: string;
+        score: number;
+        subfield?: { display_name: string };
+        field?: { display_name: string };
+        domain?: { display_name: string };
+    };
+
+    topics?: Array<{
+        id: string;
+        display_name: string;
+        score: number;
+    }>;
+
+    // Concepts (legacy, but still useful)
+    concepts?: Array<{
+        id: string;
+        display_name: string;
+        score: number;
+    }>;
+
+    // Citations
+    referenced_works?: string[];
+    related_works?: string[];
+    cited_by_api_url?: string;
+
+    // Counts by year
+    counts_by_year?: Array<{
+        year: number;
+        cited_by_count: number;
+    }>;
+
+    // Abstract (inverted index format)
+    abstract_inverted_index?: Record<string, number[]>;
+
+    // Biblio info
+    biblio?: {
+        volume?: string;
+        issue?: string;
+        first_page?: string;
+        last_page?: string;
+    };
+
+    // Field-weighted citation impact
+    fwci?: number;
+
+    // Sustainable Development Goals
+    sustainable_development_goals?: Array<{
+        id: string;
+        display_name: string;
+        score: number;
+    }>;
+}
+
+/**
+ * OpenAlex Author metadata
+ */
+export interface OpenAlexAuthor {
+    id: string;
+    orcid?: string;
+    display_name: string;
+    works_count: number;
+    cited_by_count: number;
+    summary_stats?: {
+        '2yr_mean_citedness': number;
+        h_index: number;
+        i10_index: number;
+    };
+    affiliations?: Array<{
+        institution: {
+            id: string;
+            display_name: string;
+        };
+        years: number[];
+    }>;
+    topics?: Array<{
+        id: string;
+        display_name: string;
+        count: number;
+    }>;
+}
+
+// Cache for OpenAlex results
+const openAlexCache = new Map<string, { data: OpenAlexWork | null; fetchedAt: number }>();
+const CACHE_TTL = 1000 * 60 * 60; // 1 hour
+
+/**
+ * Reconstruct abstract from inverted index
+ */
+export function reconstructAbstract(invertedIndex: Record<string, number[]>): string {
+    if (!invertedIndex || Object.keys(invertedIndex).length === 0) {
+        return '';
+    }
+
+    // Build array of [position, word] pairs
+    const words: [number, string][] = [];
+    for (const [word, positions] of Object.entries(invertedIndex)) {
+        for (const pos of positions) {
+            words.push([pos, word]);
+        }
+    }
+
+    // Sort by position and join
+    words.sort((a, b) => a[0] - b[0]);
+    return words.map(w => w[1]).join(' ');
+}
+
+/**
+ * Format citation count with appropriate suffix
+ */
+export function formatCitationCount(count: number): string {
+    if (count >= 1000000) {
+        return `${(count / 1000000).toFixed(1)}M`;
+    }
+    if (count >= 1000) {
+        return `${(count / 1000).toFixed(1)}K`;
+    }
+    return count.toString();
+}
+
+/**
+ * Get Open Access status emoji/icon
+ */
+export function getOAStatusIcon(status?: string): string {
+    switch (status) {
+        case 'gold': return '🔓'; // Gold OA (published in OA journal)
+        case 'green': return '🟢'; // Green OA (self-archived)
+        case 'hybrid': return '🟡'; // Hybrid (OA in subscription journal)
+        case 'bronze': return '🟠'; // Bronze (free to read but no license)
+        case 'closed': return '🔒';
+        default: return '';
+    }
+}
+
+/**
+ * Get Open Access status description
+ */
+export function getOAStatusDescription(status?: string): string {
+    switch (status) {
+        case 'gold': return 'Gold Open Access';
+        case 'green': return 'Green Open Access (self-archived)';
+        case 'hybrid': return 'Hybrid Open Access';
+        case 'bronze': return 'Bronze (free to read)';
+        case 'closed': return 'Closed Access';
+        default: return 'Unknown';
+    }
+}
+
+/**
+ * Fetch work metadata from OpenAlex by DOI
+ */
+export async function fetchOpenAlexWork(doi: string): Promise<OpenAlexWork | null> {
+    // Check cache
+    const cached = openAlexCache.get(doi);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
+        return cached.data;
+    }
+
+    return new Promise((resolve) => {
+        const options = {
+            hostname: 'api.openalex.org',
+            path: `/works/doi:${encodeURIComponent(doi)}`,
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'scimax-vscode/1.0 (mailto:jkitchin@andrew.cmu.edu)'
+            },
+            timeout: 8000
+        };
+
+        const req = https.request(options, (res) => {
+            let data = '';
+
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                if (res.statusCode === 200) {
+                    try {
+                        const work = JSON.parse(data) as OpenAlexWork;
+                        openAlexCache.set(doi, { data: work, fetchedAt: Date.now() });
+                        resolve(work);
+                    } catch {
+                        openAlexCache.set(doi, { data: null, fetchedAt: Date.now() });
+                        resolve(null);
+                    }
+                } else {
+                    openAlexCache.set(doi, { data: null, fetchedAt: Date.now() });
+                    resolve(null);
+                }
+            });
+        });
+
+        req.on('error', () => {
+            resolve(null);
+        });
+
+        req.on('timeout', () => {
+            req.destroy();
+            resolve(null);
+        });
+
+        req.end();
+    });
+}
+
+/**
+ * Fetch author metadata from OpenAlex
+ */
+export async function fetchOpenAlexAuthor(authorId: string): Promise<OpenAlexAuthor | null> {
+    return new Promise((resolve) => {
+        const options = {
+            hostname: 'api.openalex.org',
+            path: `/authors/${encodeURIComponent(authorId)}`,
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'scimax-vscode/1.0 (mailto:jkitchin@andrew.cmu.edu)'
+            },
+            timeout: 8000
+        };
+
+        const req = https.request(options, (res) => {
+            let data = '';
+
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                if (res.statusCode === 200) {
+                    try {
+                        resolve(JSON.parse(data) as OpenAlexAuthor);
+                    } catch {
+                        resolve(null);
+                    }
+                } else {
+                    resolve(null);
+                }
+            });
+        });
+
+        req.on('error', () => resolve(null));
+        req.on('timeout', () => {
+            req.destroy();
+            resolve(null);
+        });
+
+        req.end();
+    });
+}
+
+/**
+ * Search works in OpenAlex
+ */
+export async function searchOpenAlexWorks(query: string, limit: number = 10): Promise<OpenAlexWork[]> {
+    return new Promise((resolve) => {
+        const options = {
+            hostname: 'api.openalex.org',
+            path: `/works?search=${encodeURIComponent(query)}&per_page=${limit}`,
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'scimax-vscode/1.0 (mailto:jkitchin@andrew.cmu.edu)'
+            },
+            timeout: 10000
+        };
+
+        const req = https.request(options, (res) => {
+            let data = '';
+
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                if (res.statusCode === 200) {
+                    try {
+                        const result = JSON.parse(data);
+                        resolve(result.results || []);
+                    } catch {
+                        resolve([]);
+                    }
+                } else {
+                    resolve([]);
+                }
+            });
+        });
+
+        req.on('error', () => resolve([]));
+        req.on('timeout', () => {
+            req.destroy();
+            resolve([]);
+        });
+
+        req.end();
+    });
+}
+
+/**
+ * Fetch citing works for a given OpenAlex work ID
+ */
+export async function fetchCitingWorks(workId: string, limit: number = 10): Promise<OpenAlexWork[]> {
+    return new Promise((resolve) => {
+        // Extract just the ID part if full URL provided
+        const id = workId.replace('https://openalex.org/', '');
+
+        const options = {
+            hostname: 'api.openalex.org',
+            path: `/works?filter=cites:${id}&per_page=${limit}&sort=cited_by_count:desc`,
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'scimax-vscode/1.0 (mailto:jkitchin@andrew.cmu.edu)'
+            },
+            timeout: 10000
+        };
+
+        const req = https.request(options, (res) => {
+            let data = '';
+
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                if (res.statusCode === 200) {
+                    try {
+                        const result = JSON.parse(data);
+                        resolve(result.results || []);
+                    } catch {
+                        resolve([]);
+                    }
+                } else {
+                    resolve([]);
+                }
+            });
+        });
+
+        req.on('error', () => resolve([]));
+        req.on('timeout', () => {
+            req.destroy();
+            resolve([]);
+        });
+
+        req.end();
+    });
+}
+
+/**
+ * Fetch related works for a given work
+ */
+export async function fetchRelatedWorks(relatedIds: string[], limit: number = 5): Promise<OpenAlexWork[]> {
+    if (!relatedIds || relatedIds.length === 0) return [];
+
+    // Take first N related work IDs
+    const ids = relatedIds.slice(0, limit).map(id => id.replace('https://openalex.org/', ''));
+
+    return new Promise((resolve) => {
+        const options = {
+            hostname: 'api.openalex.org',
+            path: `/works?filter=openalex:${ids.join('|')}`,
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'scimax-vscode/1.0 (mailto:jkitchin@andrew.cmu.edu)'
+            },
+            timeout: 10000
+        };
+
+        const req = https.request(options, (res) => {
+            let data = '';
+
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                if (res.statusCode === 200) {
+                    try {
+                        const result = JSON.parse(data);
+                        resolve(result.results || []);
+                    } catch {
+                        resolve([]);
+                    }
+                } else {
+                    resolve([]);
+                }
+            });
+        });
+
+        req.on('error', () => resolve([]));
+        req.on('timeout', () => {
+            req.destroy();
+            resolve([]);
+        });
+
+        req.end();
+    });
+}

--- a/src/references/providers.ts
+++ b/src/references/providers.ts
@@ -1356,6 +1356,21 @@ export function registerCiteActionCommand(
                     description: `https://doi.org/${entry.doi}`,
                     action: 'doi'
                 });
+                items.push({
+                    label: '$(references) Citing Works (OpenAlex)',
+                    description: 'Show papers that cite this work',
+                    action: 'citingWorks'
+                });
+                items.push({
+                    label: '$(telescope) Related Works (OpenAlex)',
+                    description: 'Show related papers',
+                    action: 'relatedWorks'
+                });
+                items.push({
+                    label: '$(graph) View in OpenAlex',
+                    description: 'Open in OpenAlex web interface',
+                    action: 'openAlex'
+                });
             }
 
             if (entry.url) {
@@ -1405,6 +1420,15 @@ export function registerCiteActionCommand(
                     break;
                 case 'doi':
                     await vscode.env.openExternal(vscode.Uri.parse(`https://doi.org/${entry.doi}`));
+                    break;
+                case 'citingWorks':
+                    await vscode.commands.executeCommand('scimax.ref.showCitingWorks', entry.doi);
+                    break;
+                case 'relatedWorks':
+                    await vscode.commands.executeCommand('scimax.ref.showRelatedWorks', entry.doi);
+                    break;
+                case 'openAlex':
+                    await vscode.env.openExternal(vscode.Uri.parse(`https://openalex.org/works/doi:${entry.doi}`));
                     break;
                 case 'url':
                     await vscode.env.openExternal(vscode.Uri.parse(entry.url!));

--- a/src/references/providers.ts
+++ b/src/references/providers.ts
@@ -78,6 +78,13 @@ export class CitationHoverProvider implements vscode.HoverProvider {
         }
         markdown.appendMarkdown(`[Actions](command:scimax.ref.showDetails?${encodeURIComponent(JSON.stringify(key))})`);
 
+        // Show source file
+        const sourceFile = (entry as any)._sourceFile;
+        if (sourceFile) {
+            const fileName = path.basename(sourceFile);
+            markdown.appendMarkdown(`\n\n---\n*Source: ${fileName}*`);
+        }
+
         return new vscode.Hover(markdown);
     }
 

--- a/src/references/providers.ts
+++ b/src/references/providers.ts
@@ -580,6 +580,282 @@ export class RefHoverProvider implements vscode.HoverProvider {
 }
 
 /**
+ * DOI metadata cache for hover tooltips
+ */
+interface DoiMetadata {
+    title: string;
+    authors: string[];
+    year: string;
+    journal?: string;
+    volume?: string;
+    issue?: string;
+    pages?: string;
+    publisher?: string;
+    type?: string;
+    abstract?: string;
+    url?: string;
+    fetchedAt: number;
+}
+
+const doiCache = new Map<string, DoiMetadata | null>();
+const DOI_CACHE_TTL = 1000 * 60 * 60; // 1 hour
+
+/**
+ * Hover provider for DOI links
+ * Fetches and displays metadata from CrossRef
+ */
+export class DoiHoverProvider implements vscode.HoverProvider {
+    constructor(private manager: ReferenceManager) {}
+
+    async provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken
+    ): Promise<vscode.Hover | null> {
+        const line = document.lineAt(position.line).text;
+
+        // Find DOI at position
+        const doiInfo = this.findDoiAtPosition(line, position.character);
+        if (!doiInfo) return null;
+
+        const { doi, start, end } = doiInfo;
+
+        // Check if already in bibliography
+        const existingEntry = this.findEntryByDoi(doi);
+        if (existingEntry) {
+            return this.createExistingEntryHover(existingEntry, doi);
+        }
+
+        // Check cache
+        const cached = doiCache.get(doi);
+        if (cached !== undefined) {
+            if (cached === null) {
+                return this.createNotFoundHover(doi);
+            }
+            if (Date.now() - cached.fetchedAt < DOI_CACHE_TTL) {
+                return this.createMetadataHover(cached, doi);
+            }
+        }
+
+        // Fetch from CrossRef (async)
+        try {
+            const metadata = await this.fetchDoiMetadata(doi);
+            if (metadata) {
+                doiCache.set(doi, metadata);
+                return this.createMetadataHover(metadata, doi);
+            } else {
+                doiCache.set(doi, null);
+                return this.createNotFoundHover(doi);
+            }
+        } catch (error) {
+            return this.createErrorHover(doi, error);
+        }
+    }
+
+    private findDoiAtPosition(line: string, position: number): { doi: string; start: number; end: number } | null {
+        // Patterns to match DOI links
+        const patterns = [
+            // doi:10.xxx/xxx
+            /doi:(10\.\d{4,9}\/[^\s<>\[\](){}]+)/gi,
+            // https://doi.org/10.xxx or http://dx.doi.org/10.xxx
+            /https?:\/\/(?:dx\.)?doi\.org\/(10\.\d{4,9}\/[^\s<>\[\](){}]+)/gi,
+            // [[doi:10.xxx/xxx]] org link
+            /\[\[doi:(10\.\d{4,9}\/[^\]]+)\]\]/gi,
+            // Bare DOI 10.xxx/xxx (when not preceded by letter)
+            /(?:^|[^\w\/])(10\.\d{4,9}\/[^\s<>\[\](){}]+)/gi
+        ];
+
+        for (const pattern of patterns) {
+            let match;
+            while ((match = pattern.exec(line)) !== null) {
+                const fullStart = match.index;
+                const fullEnd = fullStart + match[0].length;
+
+                if (position >= fullStart && position <= fullEnd) {
+                    // Clean DOI - remove trailing punctuation
+                    let doi = match[1].replace(/[.,;:)\]}>]+$/, '');
+                    return { doi, start: fullStart, end: fullEnd };
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private findEntryByDoi(doi: string): any | null {
+        const entries = this.manager.getAllEntries();
+        const normalizedDoi = doi.toLowerCase();
+        for (const entry of entries) {
+            if (entry.doi && entry.doi.toLowerCase() === normalizedDoi) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private createExistingEntryHover(entry: any, doi: string): vscode.Hover {
+        const markdown = new vscode.MarkdownString();
+        markdown.isTrusted = true;
+        markdown.supportHtml = true;
+
+        markdown.appendMarkdown(`### ${entry.title || 'Untitled'}\n\n`);
+        markdown.appendMarkdown(`**${formatAuthors(entry.author)}** (${entry.year || 'n.d.'})\n\n`);
+
+        if (entry.journal) {
+            markdown.appendMarkdown(`*${entry.journal}*`);
+            if (entry.volume) {
+                markdown.appendMarkdown(`, ${entry.volume}`);
+                if (entry.number) markdown.appendMarkdown(`(${entry.number})`);
+            }
+            if (entry.pages) markdown.appendMarkdown(`, pp. ${entry.pages}`);
+            markdown.appendMarkdown('\n\n');
+        }
+
+        markdown.appendMarkdown(`[Open DOI](https://doi.org/${doi}) | `);
+        markdown.appendMarkdown(`[Insert Citation](command:scimax.ref.insertCitationForKey?${encodeURIComponent(JSON.stringify(entry.key))}) | `);
+        markdown.appendMarkdown(`[Actions](command:scimax.ref.showDetails?${encodeURIComponent(JSON.stringify(entry.key))})`);
+
+        markdown.appendMarkdown(`\n\n---\n*In bibliography as: ${entry.key}*`);
+
+        return new vscode.Hover(markdown);
+    }
+
+    private createMetadataHover(metadata: DoiMetadata, doi: string): vscode.Hover {
+        const markdown = new vscode.MarkdownString();
+        markdown.isTrusted = true;
+        markdown.supportHtml = true;
+
+        markdown.appendMarkdown(`### ${metadata.title}\n\n`);
+
+        const authors = metadata.authors.length > 3
+            ? metadata.authors.slice(0, 3).join(', ') + ' et al.'
+            : metadata.authors.join(', ');
+        markdown.appendMarkdown(`**${authors}** (${metadata.year})\n\n`);
+
+        if (metadata.journal) {
+            markdown.appendMarkdown(`*${metadata.journal}*`);
+            if (metadata.volume) {
+                markdown.appendMarkdown(`, ${metadata.volume}`);
+                if (metadata.issue) markdown.appendMarkdown(`(${metadata.issue})`);
+            }
+            if (metadata.pages) markdown.appendMarkdown(`, pp. ${metadata.pages}`);
+            markdown.appendMarkdown('\n\n');
+        } else if (metadata.publisher) {
+            markdown.appendMarkdown(`*${metadata.publisher}*\n\n`);
+        }
+
+        if (metadata.abstract) {
+            const abstract = metadata.abstract.length > 250
+                ? metadata.abstract.substring(0, 250) + '...'
+                : metadata.abstract;
+            markdown.appendMarkdown(`> ${abstract}\n\n`);
+        }
+
+        markdown.appendMarkdown(`[Open DOI](https://doi.org/${doi}) | `);
+        markdown.appendMarkdown(`[Add to Bibliography](command:scimax.ref.fetchFromDOI?${encodeURIComponent(JSON.stringify(doi))}) | `);
+        markdown.appendMarkdown(`[Google Scholar](https://scholar.google.com/scholar?q=${encodeURIComponent(metadata.title)})`);
+
+        markdown.appendMarkdown(`\n\n---\n*DOI: ${doi}*`);
+
+        return new vscode.Hover(markdown);
+    }
+
+    private createNotFoundHover(doi: string): vscode.Hover {
+        const markdown = new vscode.MarkdownString();
+        markdown.isTrusted = true;
+
+        markdown.appendMarkdown(`### DOI: ${doi}\n\n`);
+        markdown.appendMarkdown(`*Metadata not found on CrossRef*\n\n`);
+        markdown.appendMarkdown(`[Open DOI](https://doi.org/${doi}) | `);
+        markdown.appendMarkdown(`[Search CrossRef](https://search.crossref.org/?q=${encodeURIComponent(doi)})`);
+
+        return new vscode.Hover(markdown);
+    }
+
+    private createErrorHover(doi: string, error: any): vscode.Hover {
+        const markdown = new vscode.MarkdownString();
+        markdown.isTrusted = true;
+
+        markdown.appendMarkdown(`### DOI: ${doi}\n\n`);
+        markdown.appendMarkdown(`*Error fetching metadata*\n\n`);
+        markdown.appendMarkdown(`[Open DOI](https://doi.org/${doi})`);
+
+        return new vscode.Hover(markdown);
+    }
+
+    private async fetchDoiMetadata(doi: string): Promise<DoiMetadata | null> {
+        return new Promise((resolve) => {
+            const https = require('https');
+
+            const options = {
+                hostname: 'api.crossref.org',
+                path: `/works/${encodeURIComponent(doi)}`,
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/json',
+                    'User-Agent': 'scimax-vscode/1.0 (https://github.com/jkitchin/scimax_vscode)'
+                },
+                timeout: 5000
+            };
+
+            const req = https.request(options, (res: any) => {
+                let data = '';
+
+                res.on('data', (chunk: any) => {
+                    data += chunk;
+                });
+
+                res.on('end', () => {
+                    if (res.statusCode === 200) {
+                        try {
+                            const json = JSON.parse(data);
+                            const work = json.message;
+
+                            const metadata: DoiMetadata = {
+                                title: work.title?.[0] || 'Untitled',
+                                authors: (work.author || []).map((a: any) =>
+                                    a.given ? `${a.given} ${a.family}` : a.family || a.name || 'Unknown'
+                                ),
+                                year: work.published?.['date-parts']?.[0]?.[0]?.toString() ||
+                                      work['published-print']?.['date-parts']?.[0]?.[0]?.toString() ||
+                                      work['published-online']?.['date-parts']?.[0]?.[0]?.toString() ||
+                                      'n.d.',
+                                journal: work['container-title']?.[0],
+                                volume: work.volume,
+                                issue: work.issue,
+                                pages: work.page,
+                                publisher: work.publisher,
+                                type: work.type,
+                                abstract: work.abstract?.replace(/<[^>]*>/g, ''), // Strip HTML
+                                url: work.URL,
+                                fetchedAt: Date.now()
+                            };
+
+                            resolve(metadata);
+                        } catch {
+                            resolve(null);
+                        }
+                    } else {
+                        resolve(null);
+                    }
+                });
+            });
+
+            req.on('error', () => {
+                resolve(null);
+            });
+
+            req.on('timeout', () => {
+                req.destroy();
+                resolve(null);
+            });
+
+            req.end();
+        });
+    }
+}
+
+/**
  * Completion provider for citations
  * Triggers after cite:, @, etc.
  */

--- a/src/spelling/spellChecker.ts
+++ b/src/spelling/spellChecker.ts
@@ -1,0 +1,758 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Scimax Spell Checker - jinx-style spell checking
+ *
+ * Features:
+ * - Just-in-time checking of visible text
+ * - Smart exclusions for scientific writing (citations, DOIs, code blocks, LaTeX)
+ * - Quick correction via QuickPick
+ * - Personal dictionary support
+ * - Language-aware checking
+ */
+
+// Common English words (basic dictionary for fallback)
+// In production, this would be loaded from a larger word list file
+const COMMON_WORDS = new Set([
+    'the', 'be', 'to', 'of', 'and', 'a', 'in', 'that', 'have', 'i',
+    'it', 'for', 'not', 'on', 'with', 'he', 'as', 'you', 'do', 'at',
+    'this', 'but', 'his', 'by', 'from', 'they', 'we', 'say', 'her', 'she',
+    'or', 'an', 'will', 'my', 'one', 'all', 'would', 'there', 'their', 'what',
+    // Add more as needed
+]);
+
+// Patterns to exclude from spell checking
+const EXCLUSION_PATTERNS = [
+    // Citations
+    /(?:cite[pt]?|citeauthor|citeyear|Citep|Citet|citealp|citealt):[a-zA-Z0-9_:,-]+/g,
+    /\[@[a-zA-Z0-9_:-]+\]/g,
+    /(?:^|[^\w@])@[a-zA-Z][a-zA-Z0-9_:-]*/g,
+    /\\cite[pt]?\{[^}]+\}/g,
+    /\[cite(?:\/[^\]]*)?:[^\]]+\]/g,
+
+    // DOIs
+    /doi:10\.\d{4,9}\/[^\s<>\[\](){}]+/gi,
+    /https?:\/\/(?:dx\.)?doi\.org\/[^\s<>\[\](){}]+/gi,
+    /10\.\d{4,9}\/[^\s<>\[\](){}]+/g,
+
+    // URLs
+    /https?:\/\/[^\s<>\[\](){}]+/gi,
+    /www\.[^\s<>\[\](){}]+/gi,
+
+    // Email addresses
+    /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+
+    // Org-mode syntax
+    /^#\+[A-Z_]+:.*/gm,
+    /:PROPERTIES:/g,
+    /:END:/g,
+    /:[A-Z_]+:/g,
+    /\[\[[^\]]+\]\]/g,  // Org links
+    /<<[^>]+>>/g,       // Org targets
+
+    // LaTeX
+    /\$[^$]+\$/g,       // Inline math
+    /\$\$[^$]+\$\$/g,   // Display math
+    /\\[a-zA-Z]+\{[^}]*\}/g,  // LaTeX commands
+    /\\[a-zA-Z]+/g,     // Simple LaTeX commands
+
+    // Code-related
+    /`[^`]+`/g,         // Inline code
+    /```[\s\S]*?```/g,  // Code blocks
+    /#+begin_src[\s\S]*?#+end_src/gi,
+    /#+begin_example[\s\S]*?#+end_example/gi,
+
+    // File paths
+    /(?:\/|\.\/|~\/)[^\s<>\[\](){}]+/g,
+    /[A-Za-z]:\\[^\s<>\[\](){}]+/g,
+
+    // Programming identifiers (camelCase, snake_case, SCREAMING_CASE)
+    /\b[a-z]+(?:[A-Z][a-z]+)+\b/g,  // camelCase
+    /\b[A-Z][a-z]+(?:[A-Z][a-z]+)+\b/g,  // PascalCase
+    /\b[a-z]+(?:_[a-z]+)+\b/g,  // snake_case
+    /\b[A-Z]+(?:_[A-Z]+)+\b/g,  // SCREAMING_SNAKE_CASE
+
+    // Numbers and units
+    /\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\s*(?:km|m|cm|mm|nm|kg|g|mg|s|ms|Hz|kHz|MHz|GHz|V|mV|A|mA|K|°C|°F|mol|L|mL|%)\b/gi,
+
+    // Abbreviations (all caps)
+    /\b[A-Z]{2,}\b/g,
+
+    // Hashtags and mentions
+    /#[a-zA-Z][a-zA-Z0-9_]*/g,
+    /@[a-zA-Z][a-zA-Z0-9_]*/g,
+];
+
+interface SpellingError {
+    word: string;
+    range: vscode.Range;
+    suggestions: string[];
+}
+
+export class SpellChecker {
+    private personalDictionary: Set<string> = new Set();
+    private personalDictionaryPath: string;
+    private diagnosticCollection: vscode.DiagnosticCollection;
+    private enabled: boolean = true;
+    private checkDelay: number = 500;
+    private checkTimer: NodeJS.Timeout | undefined;
+
+    constructor(context: vscode.ExtensionContext) {
+        this.personalDictionaryPath = path.join(context.globalStorageUri.fsPath, 'personal-dictionary.txt');
+        this.diagnosticCollection = vscode.languages.createDiagnosticCollection('scimax-spelling');
+        context.subscriptions.push(this.diagnosticCollection);
+
+        this.loadPersonalDictionary();
+    }
+
+    /**
+     * Load personal dictionary from file
+     */
+    private async loadPersonalDictionary(): Promise<void> {
+        try {
+            // Ensure directory exists
+            const dir = path.dirname(this.personalDictionaryPath);
+            if (!fs.existsSync(dir)) {
+                fs.mkdirSync(dir, { recursive: true });
+            }
+
+            if (fs.existsSync(this.personalDictionaryPath)) {
+                const content = fs.readFileSync(this.personalDictionaryPath, 'utf8');
+                const words = content.split('\n').filter(w => w.trim());
+                this.personalDictionary = new Set(words.map(w => w.toLowerCase()));
+                console.log(`Scimax: Loaded ${this.personalDictionary.size} words from personal dictionary`);
+            }
+        } catch (error) {
+            console.error('Scimax: Failed to load personal dictionary:', error);
+        }
+    }
+
+    /**
+     * Save personal dictionary to file
+     */
+    private async savePersonalDictionary(): Promise<void> {
+        try {
+            const dir = path.dirname(this.personalDictionaryPath);
+            if (!fs.existsSync(dir)) {
+                fs.mkdirSync(dir, { recursive: true });
+            }
+
+            const content = Array.from(this.personalDictionary).sort().join('\n');
+            fs.writeFileSync(this.personalDictionaryPath, content);
+        } catch (error) {
+            console.error('Scimax: Failed to save personal dictionary:', error);
+        }
+    }
+
+    /**
+     * Add word to personal dictionary
+     */
+    async addToPersonalDictionary(word: string): Promise<void> {
+        this.personalDictionary.add(word.toLowerCase());
+        await this.savePersonalDictionary();
+        vscode.window.showInformationMessage(`Added "${word}" to personal dictionary`);
+
+        // Recheck current document
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+            this.checkDocument(editor.document);
+        }
+    }
+
+    /**
+     * Remove word from personal dictionary
+     */
+    async removeFromPersonalDictionary(word: string): Promise<void> {
+        this.personalDictionary.delete(word.toLowerCase());
+        await this.savePersonalDictionary();
+        vscode.window.showInformationMessage(`Removed "${word}" from personal dictionary`);
+    }
+
+    /**
+     * Check if a word should be excluded from spell checking
+     */
+    private shouldExclude(text: string, wordStart: number, wordEnd: number): boolean {
+        // Check each exclusion pattern
+        for (const pattern of EXCLUSION_PATTERNS) {
+            // Reset regex state
+            pattern.lastIndex = 0;
+            let match;
+            while ((match = pattern.exec(text)) !== null) {
+                const matchStart = match.index;
+                const matchEnd = matchStart + match[0].length;
+
+                // Check if word overlaps with excluded region
+                if (wordStart < matchEnd && wordEnd > matchStart) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if a word is spelled correctly
+     */
+    private isCorrectlySpelled(word: string): boolean {
+        const lowerWord = word.toLowerCase();
+
+        // Check personal dictionary first
+        if (this.personalDictionary.has(lowerWord)) {
+            return true;
+        }
+
+        // Check common words
+        if (COMMON_WORDS.has(lowerWord)) {
+            return true;
+        }
+
+        // Skip very short words
+        if (word.length <= 2) {
+            return true;
+        }
+
+        // Skip words with numbers
+        if (/\d/.test(word)) {
+            return true;
+        }
+
+        // Skip words that look like acronyms or abbreviations
+        if (/^[A-Z]+$/.test(word) || /^[A-Z][a-z]?$/.test(word)) {
+            return true;
+        }
+
+        // For now, use a simple heuristic: words with common patterns are likely correct
+        // This is a placeholder - a real implementation would use a proper dictionary
+        // or integrate with VS Code's spell check extension
+
+        // Common English word patterns
+        const commonPatterns = [
+            /^[a-z]+(?:ing|ed|ly|er|est|tion|sion|ment|ness|ful|less|able|ible|ous|ive|al|ic|ical)$/i,
+            /^(?:un|re|pre|dis|mis|over|under|out|up|down|non|anti|auto|bi|co|de|ex|inter|multi|post|semi|sub|super|trans|tri)[a-z]+$/i,
+        ];
+
+        for (const pattern of commonPatterns) {
+            if (pattern.test(word)) {
+                // Check if base word looks reasonable
+                return true;
+            }
+        }
+
+        // Default: assume misspelled for demonstration
+        // In production, this would check against a real dictionary
+        return false;
+    }
+
+    /**
+     * Generate spelling suggestions for a word
+     */
+    private getSuggestions(word: string): string[] {
+        // Simple suggestion generation using edit distance
+        // In production, use a proper spell checking library
+
+        const suggestions: string[] = [];
+
+        // Common letter substitutions
+        const substitutions: Record<string, string[]> = {
+            'a': ['e', 'o'],
+            'e': ['a', 'i'],
+            'i': ['e', 'y'],
+            'o': ['a', 'u'],
+            'u': ['o', 'a'],
+            'c': ['k', 's'],
+            's': ['c', 'z'],
+        };
+
+        // Generate candidates by substitution
+        for (let i = 0; i < word.length; i++) {
+            const char = word[i].toLowerCase();
+            if (substitutions[char]) {
+                for (const sub of substitutions[char]) {
+                    const candidate = word.slice(0, i) + sub + word.slice(i + 1);
+                    if (this.isCorrectlySpelled(candidate)) {
+                        suggestions.push(candidate);
+                    }
+                }
+            }
+        }
+
+        // Try removing doubled letters
+        for (let i = 0; i < word.length - 1; i++) {
+            if (word[i] === word[i + 1]) {
+                const candidate = word.slice(0, i) + word.slice(i + 1);
+                if (this.isCorrectlySpelled(candidate)) {
+                    suggestions.push(candidate);
+                }
+            }
+        }
+
+        // Try adding common letters
+        const commonLetters = ['e', 's', 'd', 'r', 'n'];
+        for (const letter of commonLetters) {
+            const candidateEnd = word + letter;
+            if (this.isCorrectlySpelled(candidateEnd)) {
+                suggestions.push(candidateEnd);
+            }
+        }
+
+        return [...new Set(suggestions)].slice(0, 5);
+    }
+
+    /**
+     * Check document for spelling errors
+     */
+    checkDocument(document: vscode.TextDocument): void {
+        if (!this.enabled) {
+            this.diagnosticCollection.delete(document.uri);
+            return;
+        }
+
+        // Only check org, markdown, and text files
+        const supportedLanguages = ['org', 'markdown', 'plaintext', 'latex'];
+        if (!supportedLanguages.includes(document.languageId)) {
+            return;
+        }
+
+        const text = document.getText();
+        const diagnostics: vscode.Diagnostic[] = [];
+
+        // Find all words
+        const wordPattern = /\b[a-zA-Z']+\b/g;
+        let match;
+
+        while ((match = wordPattern.exec(text)) !== null) {
+            const word = match[0];
+            const wordStart = match.index;
+            const wordEnd = wordStart + word.length;
+
+            // Skip if word is in an excluded region
+            if (this.shouldExclude(text, wordStart, wordEnd)) {
+                continue;
+            }
+
+            // Check spelling
+            if (!this.isCorrectlySpelled(word)) {
+                const startPos = document.positionAt(wordStart);
+                const endPos = document.positionAt(wordEnd);
+                const range = new vscode.Range(startPos, endPos);
+
+                const suggestions = this.getSuggestions(word);
+                const message = suggestions.length > 0
+                    ? `"${word}" may be misspelled. Suggestions: ${suggestions.join(', ')}`
+                    : `"${word}" may be misspelled`;
+
+                const diagnostic = new vscode.Diagnostic(
+                    range,
+                    message,
+                    vscode.DiagnosticSeverity.Information
+                );
+                diagnostic.source = 'scimax-spelling';
+                diagnostic.code = 'spelling';
+
+                // Store suggestions in diagnostic for quick fix
+                (diagnostic as any).suggestions = suggestions;
+                (diagnostic as any).word = word;
+
+                diagnostics.push(diagnostic);
+            }
+        }
+
+        this.diagnosticCollection.set(document.uri, diagnostics);
+    }
+
+    /**
+     * Schedule document check with debounce
+     */
+    scheduleCheck(document: vscode.TextDocument): void {
+        if (this.checkTimer) {
+            clearTimeout(this.checkTimer);
+        }
+
+        this.checkTimer = setTimeout(() => {
+            this.checkDocument(document);
+        }, this.checkDelay);
+    }
+
+    /**
+     * Toggle spell checking
+     */
+    toggle(): void {
+        this.enabled = !this.enabled;
+        vscode.window.showInformationMessage(
+            `Scimax spell checking ${this.enabled ? 'enabled' : 'disabled'}`
+        );
+
+        if (!this.enabled) {
+            this.diagnosticCollection.clear();
+        } else {
+            const editor = vscode.window.activeTextEditor;
+            if (editor) {
+                this.checkDocument(editor.document);
+            }
+        }
+    }
+
+    /**
+     * Get spelling errors at position
+     */
+    getErrorAtPosition(document: vscode.TextDocument, position: vscode.Position): SpellingError | null {
+        const diagnostics = this.diagnosticCollection.get(document.uri);
+        if (!diagnostics) return null;
+
+        for (const diagnostic of diagnostics) {
+            if (diagnostic.range.contains(position)) {
+                return {
+                    word: (diagnostic as any).word,
+                    range: diagnostic.range,
+                    suggestions: (diagnostic as any).suggestions || []
+                };
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find next spelling error from position
+     */
+    findNextError(document: vscode.TextDocument, position: vscode.Position): SpellingError | null {
+        const diagnostics = this.diagnosticCollection.get(document.uri);
+        if (!diagnostics || diagnostics.length === 0) return null;
+
+        // Sort by position
+        const sorted = [...diagnostics].sort((a, b) => {
+            const lineComp = a.range.start.line - b.range.start.line;
+            return lineComp !== 0 ? lineComp : a.range.start.character - b.range.start.character;
+        });
+
+        // Find next error after position
+        for (const diagnostic of sorted) {
+            if (diagnostic.range.start.isAfter(position)) {
+                return {
+                    word: (diagnostic as any).word,
+                    range: diagnostic.range,
+                    suggestions: (diagnostic as any).suggestions || []
+                };
+            }
+        }
+
+        // Wrap around to first error
+        const first = sorted[0];
+        return {
+            word: (first as any).word,
+            range: first.range,
+            suggestions: (first as any).suggestions || []
+        };
+    }
+
+    /**
+     * Find previous spelling error from position
+     */
+    findPrevError(document: vscode.TextDocument, position: vscode.Position): SpellingError | null {
+        const diagnostics = this.diagnosticCollection.get(document.uri);
+        if (!diagnostics || diagnostics.length === 0) return null;
+
+        // Sort by position (reverse)
+        const sorted = [...diagnostics].sort((a, b) => {
+            const lineComp = b.range.start.line - a.range.start.line;
+            return lineComp !== 0 ? lineComp : b.range.start.character - a.range.start.character;
+        });
+
+        // Find previous error before position
+        for (const diagnostic of sorted) {
+            if (diagnostic.range.start.isBefore(position)) {
+                return {
+                    word: (diagnostic as any).word,
+                    range: diagnostic.range,
+                    suggestions: (diagnostic as any).suggestions || []
+                };
+            }
+        }
+
+        // Wrap around to last error
+        const last = sorted[0];
+        return {
+            word: (last as any).word,
+            range: last.range,
+            suggestions: (last as any).suggestions || []
+        };
+    }
+
+    dispose(): void {
+        if (this.checkTimer) {
+            clearTimeout(this.checkTimer);
+        }
+        this.diagnosticCollection.dispose();
+    }
+}
+
+/**
+ * Correct word at cursor - jinx-style
+ */
+async function correctWordAtCursor(spellChecker: SpellChecker): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Get error at cursor
+    let error = spellChecker.getErrorAtPosition(document, position);
+
+    // If no error at cursor, find next error
+    if (!error) {
+        error = spellChecker.findNextError(document, position);
+        if (!error) {
+            vscode.window.showInformationMessage('No spelling errors found');
+            return;
+        }
+        // Move cursor to error
+        editor.selection = new vscode.Selection(error.range.start, error.range.start);
+        editor.revealRange(error.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    }
+
+    // Build quick pick items
+    const items: (vscode.QuickPickItem & { action: string; value?: string })[] = [];
+
+    // Add suggestions
+    for (const suggestion of error.suggestions) {
+        items.push({
+            label: suggestion,
+            description: 'Replace with this word',
+            action: 'replace',
+            value: suggestion
+        });
+    }
+
+    // Add other actions
+    items.push({
+        label: '$(add) Add to dictionary',
+        description: `Add "${error.word}" to personal dictionary`,
+        action: 'add'
+    });
+
+    items.push({
+        label: '$(edit) Edit manually',
+        description: 'Enter a custom correction',
+        action: 'edit'
+    });
+
+    items.push({
+        label: '$(arrow-right) Skip',
+        description: 'Skip this word',
+        action: 'skip'
+    });
+
+    items.push({
+        label: '$(close) Ignore all',
+        description: `Ignore "${error.word}" in this session`,
+        action: 'ignore'
+    });
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: `Correct: "${error.word}"`,
+        matchOnDescription: true
+    });
+
+    if (!selected) return;
+
+    switch (selected.action) {
+        case 'replace':
+            await editor.edit(editBuilder => {
+                editBuilder.replace(error!.range, selected.value!);
+            });
+            break;
+
+        case 'add':
+            await spellChecker.addToPersonalDictionary(error.word);
+            break;
+
+        case 'edit':
+            const customWord = await vscode.window.showInputBox({
+                prompt: `Replace "${error.word}" with:`,
+                value: error.word
+            });
+            if (customWord) {
+                await editor.edit(editBuilder => {
+                    editBuilder.replace(error!.range, customWord);
+                });
+            }
+            break;
+
+        case 'skip':
+            // Find and go to next error
+            const nextError = spellChecker.findNextError(document, error.range.end);
+            if (nextError) {
+                editor.selection = new vscode.Selection(nextError.range.start, nextError.range.start);
+                editor.revealRange(nextError.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+            }
+            break;
+
+        case 'ignore':
+            // Add to personal dictionary for this session
+            await spellChecker.addToPersonalDictionary(error.word);
+            break;
+    }
+}
+
+/**
+ * Go to next spelling error
+ */
+async function gotoNextError(spellChecker: SpellChecker): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const error = spellChecker.findNextError(editor.document, editor.selection.active);
+    if (error) {
+        editor.selection = new vscode.Selection(error.range.start, error.range.end);
+        editor.revealRange(error.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    } else {
+        vscode.window.showInformationMessage('No spelling errors found');
+    }
+}
+
+/**
+ * Go to previous spelling error
+ */
+async function gotoPrevError(spellChecker: SpellChecker): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const error = spellChecker.findPrevError(editor.document, editor.selection.active);
+    if (error) {
+        editor.selection = new vscode.Selection(error.range.start, error.range.end);
+        editor.revealRange(error.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+    } else {
+        vscode.window.showInformationMessage('No spelling errors found');
+    }
+}
+
+/**
+ * Add word at cursor to dictionary
+ */
+async function addWordAtCursor(spellChecker: SpellChecker): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Get word at cursor
+    const wordRange = document.getWordRangeAtPosition(position);
+    if (!wordRange) {
+        vscode.window.showInformationMessage('No word at cursor');
+        return;
+    }
+
+    const word = document.getText(wordRange);
+    await spellChecker.addToPersonalDictionary(word);
+}
+
+/**
+ * Register spell checking commands
+ */
+export function registerSpellCheckCommands(
+    context: vscode.ExtensionContext,
+    spellChecker: SpellChecker
+): void {
+    // Register commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.spelling.correct', () =>
+            correctWordAtCursor(spellChecker)
+        ),
+        vscode.commands.registerCommand('scimax.spelling.nextError', () =>
+            gotoNextError(spellChecker)
+        ),
+        vscode.commands.registerCommand('scimax.spelling.prevError', () =>
+            gotoPrevError(spellChecker)
+        ),
+        vscode.commands.registerCommand('scimax.spelling.addToDictionary', () =>
+            addWordAtCursor(spellChecker)
+        ),
+        vscode.commands.registerCommand('scimax.spelling.toggle', () =>
+            spellChecker.toggle()
+        ),
+        vscode.commands.registerCommand('scimax.spelling.checkDocument', () => {
+            const editor = vscode.window.activeTextEditor;
+            if (editor) {
+                spellChecker.checkDocument(editor.document);
+                vscode.window.showInformationMessage('Spell check complete');
+            }
+        })
+    );
+
+    // Check on document open and change
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument(doc => {
+            spellChecker.scheduleCheck(doc);
+        }),
+        vscode.workspace.onDidChangeTextDocument(e => {
+            spellChecker.scheduleCheck(e.document);
+        }),
+        vscode.window.onDidChangeActiveTextEditor(editor => {
+            if (editor) {
+                spellChecker.scheduleCheck(editor.document);
+            }
+        })
+    );
+
+    // Check current document on activation
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+        spellChecker.scheduleCheck(editor.document);
+    }
+
+    console.log('Scimax: Spell checking commands registered');
+}
+
+/**
+ * Code action provider for quick fixes
+ */
+export class SpellingCodeActionProvider implements vscode.CodeActionProvider {
+    constructor(private spellChecker: SpellChecker) {}
+
+    provideCodeActions(
+        document: vscode.TextDocument,
+        range: vscode.Range | vscode.Selection,
+        context: vscode.CodeActionContext,
+        token: vscode.CancellationToken
+    ): vscode.CodeAction[] {
+        const actions: vscode.CodeAction[] = [];
+
+        for (const diagnostic of context.diagnostics) {
+            if (diagnostic.source !== 'scimax-spelling') continue;
+
+            const word = (diagnostic as any).word;
+            const suggestions = (diagnostic as any).suggestions || [];
+
+            // Add suggestion fixes
+            for (const suggestion of suggestions) {
+                const fix = new vscode.CodeAction(
+                    `Replace with "${suggestion}"`,
+                    vscode.CodeActionKind.QuickFix
+                );
+                fix.edit = new vscode.WorkspaceEdit();
+                fix.edit.replace(document.uri, diagnostic.range, suggestion);
+                fix.isPreferred = suggestions.indexOf(suggestion) === 0;
+                fix.diagnostics = [diagnostic];
+                actions.push(fix);
+            }
+
+            // Add to dictionary action
+            const addAction = new vscode.CodeAction(
+                `Add "${word}" to dictionary`,
+                vscode.CodeActionKind.QuickFix
+            );
+            addAction.command = {
+                command: 'scimax.spelling.addToDictionary',
+                title: 'Add to dictionary'
+            };
+            addAction.diagnostics = [diagnostic];
+            actions.push(addAction);
+        }
+
+        return actions;
+    }
+}

--- a/src/swiper/commands.ts
+++ b/src/swiper/commands.ts
@@ -1,0 +1,358 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+interface LineItem extends vscode.QuickPickItem {
+    filePath: string;
+    lineNumber: number;
+    lineText: string;
+}
+
+/**
+ * Get all lines from a document with their line numbers
+ */
+function getDocumentLines(document: vscode.TextDocument): LineItem[] {
+    const lines: LineItem[] = [];
+    const fileName = path.basename(document.fileName);
+
+    for (let i = 0; i < document.lineCount; i++) {
+        const line = document.lineAt(i);
+        const text = line.text;
+
+        // Skip empty lines
+        if (text.trim().length === 0) {
+            continue;
+        }
+
+        lines.push({
+            label: `${i + 1}: ${text}`,
+            description: fileName,
+            filePath: document.uri.fsPath,
+            lineNumber: i,
+            lineText: text
+        });
+    }
+
+    return lines;
+}
+
+/**
+ * Filter lines by search query with highlighting
+ */
+function filterLines(lines: LineItem[], query: string): LineItem[] {
+    if (!query || query.trim().length === 0) {
+        return lines;
+    }
+
+    const lowerQuery = query.toLowerCase();
+    const queryParts = lowerQuery.split(/\s+/).filter(p => p.length > 0);
+
+    return lines.filter(item => {
+        const lowerText = item.lineText.toLowerCase();
+        // All query parts must match (AND logic for space-separated terms)
+        return queryParts.every(part => lowerText.includes(part));
+    }).map(item => {
+        // Highlight matches in the label
+        let highlightedLabel = item.label;
+        for (const part of queryParts) {
+            const regex = new RegExp(`(${escapeRegex(part)})`, 'gi');
+            highlightedLabel = highlightedLabel.replace(regex, '**$1**');
+        }
+        return {
+            ...item,
+            label: highlightedLabel
+        };
+    });
+}
+
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Navigate to a specific line in a file
+ */
+async function goToLine(filePath: string, lineNumber: number): Promise<void> {
+    const document = await vscode.workspace.openTextDocument(filePath);
+    const editor = await vscode.window.showTextDocument(document);
+
+    const position = new vscode.Position(lineNumber, 0);
+    editor.selection = new vscode.Selection(position, position);
+    editor.revealRange(
+        new vscode.Range(position, position),
+        vscode.TextEditorRevealType.InCenter
+    );
+}
+
+/**
+ * Swiper - Search current file with live preview
+ * Similar to Emacs swiper, shows all matching lines as you type
+ */
+async function swiper(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showWarningMessage('No active editor');
+        return;
+    }
+
+    const document = editor.document;
+    const allLines = getDocumentLines(document);
+
+    // Save original position to restore if cancelled
+    const originalPosition = editor.selection.active;
+
+    const quickPick = vscode.window.createQuickPick<LineItem>();
+    quickPick.placeholder = 'Search current file (type to filter)';
+    quickPick.matchOnDescription = false;
+    quickPick.matchOnDetail = false;
+    quickPick.items = allLines;
+
+    // Live preview: navigate to selected line as user browses
+    quickPick.onDidChangeActive(items => {
+        if (items.length > 0) {
+            const item = items[0];
+            const position = new vscode.Position(item.lineNumber, 0);
+            editor.selection = new vscode.Selection(position, position);
+            editor.revealRange(
+                new vscode.Range(position, position),
+                vscode.TextEditorRevealType.InCenter
+            );
+        }
+    });
+
+    // Filter lines as user types
+    quickPick.onDidChangeValue(value => {
+        quickPick.items = filterLines(allLines, value);
+    });
+
+    // Handle selection
+    quickPick.onDidAccept(() => {
+        const selected = quickPick.selectedItems[0];
+        if (selected) {
+            goToLine(selected.filePath, selected.lineNumber);
+        }
+        quickPick.hide();
+    });
+
+    // Restore position if cancelled
+    quickPick.onDidHide(() => {
+        if (quickPick.selectedItems.length === 0) {
+            // Cancelled - restore original position
+            editor.selection = new vscode.Selection(originalPosition, originalPosition);
+            editor.revealRange(
+                new vscode.Range(originalPosition, originalPosition),
+                vscode.TextEditorRevealType.InCenter
+            );
+        }
+        quickPick.dispose();
+    });
+
+    quickPick.show();
+}
+
+/**
+ * Swiper All - Search all open files with live preview
+ * Similar to Emacs swiper-all, searches across all open buffers
+ */
+async function swiperAll(): Promise<void> {
+    // Get all open text documents
+    const openDocuments = vscode.workspace.textDocuments.filter(doc => {
+        // Filter out internal VS Code documents
+        return doc.uri.scheme === 'file' && !doc.isClosed;
+    });
+
+    if (openDocuments.length === 0) {
+        vscode.window.showWarningMessage('No open files');
+        return;
+    }
+
+    // Collect lines from all open documents
+    const allLines: LineItem[] = [];
+    const separators: Map<string, vscode.QuickPickItem> = new Map();
+
+    for (const doc of openDocuments) {
+        const fileName = path.basename(doc.fileName);
+        separators.set(doc.uri.fsPath, {
+            label: fileName,
+            kind: vscode.QuickPickItemKind.Separator
+        });
+        allLines.push(...getDocumentLines(doc));
+    }
+
+    // Build items with separators grouped by file
+    function buildItemsWithSeparators(lines: LineItem[]): (LineItem | vscode.QuickPickItem)[] {
+        const items: (LineItem | vscode.QuickPickItem)[] = [];
+        let currentFile = '';
+
+        for (const line of lines) {
+            if (line.filePath !== currentFile) {
+                currentFile = line.filePath;
+                const sep = separators.get(currentFile);
+                if (sep) {
+                    items.push(sep);
+                }
+            }
+            items.push(line);
+        }
+
+        return items;
+    }
+
+    const quickPick = vscode.window.createQuickPick<LineItem | vscode.QuickPickItem>();
+    quickPick.placeholder = `Search ${openDocuments.length} open files (type to filter)`;
+    quickPick.matchOnDescription = true;
+    quickPick.matchOnDetail = false;
+    quickPick.items = buildItemsWithSeparators(allLines);
+
+    // Live preview: navigate to selected line
+    quickPick.onDidChangeActive(items => {
+        if (items.length > 0) {
+            const item = items[0] as LineItem;
+            if (item.filePath && item.lineNumber !== undefined) {
+                goToLine(item.filePath, item.lineNumber);
+            }
+        }
+    });
+
+    // Filter lines as user types
+    quickPick.onDidChangeValue(value => {
+        const filtered = filterLines(allLines, value);
+        quickPick.items = buildItemsWithSeparators(filtered);
+    });
+
+    // Handle selection
+    quickPick.onDidAccept(() => {
+        const selected = quickPick.selectedItems[0] as LineItem;
+        if (selected && selected.filePath) {
+            goToLine(selected.filePath, selected.lineNumber);
+        }
+        quickPick.hide();
+    });
+
+    quickPick.onDidHide(() => {
+        quickPick.dispose();
+    });
+
+    quickPick.show();
+}
+
+/**
+ * Swiper Symbol - Search headings/symbols in current file
+ * Like swiper but focused on structure (headings, functions, etc.)
+ */
+async function swiperSymbol(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        vscode.window.showWarningMessage('No active editor');
+        return;
+    }
+
+    const document = editor.document;
+    const lines: LineItem[] = [];
+    const fileName = path.basename(document.fileName);
+
+    // Patterns for different file types
+    const isOrg = document.languageId === 'org';
+    const isMarkdown = document.languageId === 'markdown';
+
+    for (let i = 0; i < document.lineCount; i++) {
+        const line = document.lineAt(i);
+        const text = line.text;
+
+        let isHeading = false;
+        let icon = '';
+
+        if (isOrg) {
+            // Org-mode headings start with *
+            if (/^\*+ /.test(text)) {
+                isHeading = true;
+                const level = text.match(/^\*+/)?.[0].length || 1;
+                icon = '$(symbol-class) '.repeat(Math.min(level, 3));
+            }
+        } else if (isMarkdown) {
+            // Markdown headings start with #
+            if (/^#{1,6} /.test(text)) {
+                isHeading = true;
+                const level = text.match(/^#+/)?.[0].length || 1;
+                icon = '$(symbol-class) '.repeat(Math.min(level, 3));
+            }
+        } else {
+            // For other files, look for function definitions
+            if (/^(function|def|class|interface|type|const|let|var|export|async|public|private|protected)\s/.test(text)) {
+                isHeading = true;
+                icon = '$(symbol-method) ';
+            }
+        }
+
+        if (isHeading) {
+            lines.push({
+                label: `${icon}${i + 1}: ${text.trim()}`,
+                description: fileName,
+                filePath: document.uri.fsPath,
+                lineNumber: i,
+                lineText: text
+            });
+        }
+    }
+
+    if (lines.length === 0) {
+        vscode.window.showInformationMessage('No headings or symbols found');
+        return;
+    }
+
+    const originalPosition = editor.selection.active;
+
+    const quickPick = vscode.window.createQuickPick<LineItem>();
+    quickPick.placeholder = 'Search headings/symbols (type to filter)';
+    quickPick.matchOnDescription = false;
+    quickPick.items = lines;
+
+    quickPick.onDidChangeActive(items => {
+        if (items.length > 0) {
+            const item = items[0];
+            const position = new vscode.Position(item.lineNumber, 0);
+            editor.selection = new vscode.Selection(position, position);
+            editor.revealRange(
+                new vscode.Range(position, position),
+                vscode.TextEditorRevealType.InCenter
+            );
+        }
+    });
+
+    quickPick.onDidChangeValue(value => {
+        quickPick.items = filterLines(lines, value);
+    });
+
+    quickPick.onDidAccept(() => {
+        const selected = quickPick.selectedItems[0];
+        if (selected) {
+            goToLine(selected.filePath, selected.lineNumber);
+        }
+        quickPick.hide();
+    });
+
+    quickPick.onDidHide(() => {
+        if (quickPick.selectedItems.length === 0) {
+            editor.selection = new vscode.Selection(originalPosition, originalPosition);
+            editor.revealRange(
+                new vscode.Range(originalPosition, originalPosition),
+                vscode.TextEditorRevealType.InCenter
+            );
+        }
+        quickPick.dispose();
+    });
+
+    quickPick.show();
+}
+
+/**
+ * Register all swiper commands
+ */
+export function registerSwiperCommands(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.swiper', swiper),
+        vscode.commands.registerCommand('scimax.swiperAll', swiperAll),
+        vscode.commands.registerCommand('scimax.swiperSymbol', swiperSymbol)
+    );
+
+    console.log('Scimax: Swiper commands registered');
+}


### PR DESCRIPTION
Implements three search commands inspired by Emacs swiper:
- scimax.swiper: Search current file with live preview
- scimax.swiperAll: Search all open files, grouped by file
- scimax.swiperSymbol: Search headings/symbols only

Features live filtering, cursor preview during navigation,
and position restore on cancel.