### PR TITLE
Add hydra/transient menu framework (Emacs-style)

### DIFF
--- a/package.json
+++ b/package.json
@@ -791,6 +791,26 @@
       {
         "command": "scimax.editmarks.summary",
         "title": "Scimax: Show Edit Marks Summary"
+      },
+      {
+        "command": "scimax.hydra.show",
+        "title": "Scimax: Show Hydra Menu"
+      },
+      {
+        "command": "scimax.hydra.hide",
+        "title": "Scimax: Hide Hydra Menu"
+      },
+      {
+        "command": "scimax.hydra.back",
+        "title": "Scimax: Hydra Menu Back"
+      },
+      {
+        "command": "scimax.hydra.main",
+        "title": "Scimax: Main Menu"
+      },
+      {
+        "command": "scimax.hydra.contextMenu",
+        "title": "Scimax: Context Menu"
       }
     ],
     "keybindings": [
@@ -1171,6 +1191,16 @@
         "key": "ctrl+c e s",
         "mac": "ctrl+c e s",
         "when": "editorTextFocus"
+      },
+      {
+        "command": "scimax.hydra.main",
+        "key": "ctrl+c m",
+        "mac": "ctrl+c m"
+      },
+      {
+        "command": "scimax.hydra.contextMenu",
+        "key": "ctrl+c ctrl+m",
+        "mac": "ctrl+c ctrl+m"
       }
     ],
     "configuration": {
@@ -1313,6 +1343,26 @@
           "type": "boolean",
           "default": true,
           "description": "Automatically detect projects in workspace"
+        },
+        "scimax.hydra.showKeyHints": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show keyboard shortcuts inline with menu items"
+        },
+        "scimax.hydra.singleKeySelection": {
+          "type": "boolean",
+          "default": true,
+          "description": "Select menu items with a single keypress (no Enter needed)"
+        },
+        "scimax.hydra.dimNonMatching": {
+          "type": "boolean",
+          "default": true,
+          "description": "Dim menu items that don't match the current filter"
+        },
+        "scimax.hydra.sortByKey": {
+          "type": "boolean",
+          "default": false,
+          "description": "Sort menu items by their keyboard shortcut"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,8 +39,10 @@ import { registerJumpCommands } from './jump/commands';
 import { registerCitationManipulationCommands, checkCitationContext } from './references/citationManipulation';
 import { SpellChecker, registerSpellCheckCommands, SpellingCodeActionProvider } from './spelling/spellChecker';
 import { registerEditmarkCommands } from './editmarks/editmarks';
+import { HydraManager, registerHydraCommands, scimaxMenus } from './hydra';
 
 let journalManager: JournalManager;
+let hydraManager: HydraManager;
 let journalStatusBar: JournalStatusBar;
 let scimaxDb: ScimaxDb;
 let referenceManager: ReferenceManager;
@@ -386,6 +388,13 @@ export async function activate(context: vscode.ExtensionContext) {
     // Register Editmark Commands (track changes)
     registerEditmarkCommands(context);
     console.log('Scimax: Editmarks initialized');
+
+    // Initialize Hydra Menu Framework
+    hydraManager = new HydraManager(context);
+    hydraManager.registerMenus(scimaxMenus);
+    registerHydraCommands(context, hydraManager);
+    context.subscriptions.push({ dispose: () => hydraManager.dispose() });
+    console.log('Scimax: Hydra menu framework initialized');
 }
 
 export async function deactivate() {

--- a/src/hydra/__tests__/hydra.test.ts
+++ b/src/hydra/__tests__/hydra.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests for the Hydra Menu Framework
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HydraMenuDefinition, HydraMenuItem, HydraMenuGroup } from '../types';
+
+// Mock VS Code API
+vi.mock('vscode', () => ({
+    window: {
+        createQuickPick: vi.fn(() => ({
+            title: '',
+            placeholder: '',
+            matchOnDescription: false,
+            matchOnDetail: false,
+            items: [],
+            onDidChangeValue: vi.fn(),
+            onDidAccept: vi.fn(),
+            onDidHide: vi.fn(),
+            show: vi.fn(),
+            hide: vi.fn(),
+            dispose: vi.fn(),
+            selectedItems: [],
+        })),
+        showQuickPick: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+    },
+    commands: {
+        executeCommand: vi.fn(),
+        registerCommand: vi.fn(),
+    },
+    workspace: {
+        getConfiguration: vi.fn(() => ({
+            get: vi.fn((key: string, defaultValue: unknown) => defaultValue),
+        })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+    EventEmitter: vi.fn(() => ({
+        event: vi.fn(),
+        fire: vi.fn(),
+        dispose: vi.fn(),
+    })),
+    QuickPickItemKind: {
+        Separator: -1,
+        Default: 0,
+    },
+}));
+
+describe('Hydra Types', () => {
+    describe('HydraMenuItem', () => {
+        it('should have required properties', () => {
+            const item: HydraMenuItem = {
+                key: 'a',
+                label: 'Test Action',
+                exit: 'exit',
+                action: 'test.command',
+            };
+
+            expect(item.key).toBe('a');
+            expect(item.label).toBe('Test Action');
+            expect(item.exit).toBe('exit');
+            expect(item.action).toBe('test.command');
+        });
+
+        it('should support optional properties', () => {
+            const item: HydraMenuItem = {
+                key: 'b',
+                label: 'With Options',
+                description: 'Description text',
+                icon: 'search',
+                exit: 'stay',
+                action: async () => { /* async action */ },
+                args: ['arg1', 'arg2'],
+                when: () => true,
+                isToggle: true,
+                getToggleState: async () => true,
+            };
+
+            expect(item.description).toBe('Description text');
+            expect(item.icon).toBe('search');
+            expect(item.isToggle).toBe(true);
+        });
+
+        it('should support submenu exit behavior', () => {
+            const item: HydraMenuItem = {
+                key: 's',
+                label: 'Submenu',
+                exit: 'submenu',
+                action: 'my.submenu.id',
+            };
+
+            expect(item.exit).toBe('submenu');
+        });
+    });
+
+    describe('HydraMenuGroup', () => {
+        it('should have items array', () => {
+            const group: HydraMenuGroup = {
+                items: [
+                    { key: 'a', label: 'Item A', exit: 'exit', action: 'cmd.a' },
+                    { key: 'b', label: 'Item B', exit: 'exit', action: 'cmd.b' },
+                ],
+            };
+
+            expect(group.items).toHaveLength(2);
+        });
+
+        it('should support optional title and when', () => {
+            const group: HydraMenuGroup = {
+                title: 'My Group',
+                items: [],
+                when: () => true,
+            };
+
+            expect(group.title).toBe('My Group');
+            expect(group.when?.()).toBe(true);
+        });
+    });
+
+    describe('HydraMenuDefinition', () => {
+        it('should have required properties', () => {
+            const menu: HydraMenuDefinition = {
+                id: 'test.menu',
+                title: 'Test Menu',
+                groups: [
+                    {
+                        items: [
+                            { key: 'a', label: 'Action', exit: 'exit', action: 'test.action' },
+                        ],
+                    },
+                ],
+            };
+
+            expect(menu.id).toBe('test.menu');
+            expect(menu.title).toBe('Test Menu');
+            expect(menu.groups).toHaveLength(1);
+        });
+
+        it('should support hierarchical menus', () => {
+            const menu: HydraMenuDefinition = {
+                id: 'child.menu',
+                title: 'Child Menu',
+                parent: 'parent.menu',
+                showBack: true,
+                groups: [],
+            };
+
+            expect(menu.parent).toBe('parent.menu');
+            expect(menu.showBack).toBe(true);
+        });
+
+        it('should support lifecycle hooks', () => {
+            const onShowSpy = vi.fn();
+            const onHideSpy = vi.fn();
+
+            const menu: HydraMenuDefinition = {
+                id: 'hooks.menu',
+                title: 'With Hooks',
+                groups: [],
+                onShow: onShowSpy,
+                onHide: onHideSpy,
+            };
+
+            menu.onShow?.();
+            menu.onHide?.();
+
+            expect(onShowSpy).toHaveBeenCalled();
+            expect(onHideSpy).toHaveBeenCalled();
+        });
+    });
+});
+
+describe('Menu Building', () => {
+    it('should create a complete menu structure', () => {
+        const menu: HydraMenuDefinition = {
+            id: 'scimax.test',
+            title: 'Test Menu',
+            hint: 'Press a key to select',
+            groups: [
+                {
+                    title: 'Navigation',
+                    items: [
+                        {
+                            key: 'f',
+                            label: 'Find File',
+                            description: 'Open file picker',
+                            icon: 'search',
+                            exit: 'exit',
+                            action: 'workbench.action.quickOpen',
+                        },
+                        {
+                            key: 's',
+                            label: 'Settings',
+                            exit: 'submenu',
+                            action: 'scimax.settings',
+                        },
+                    ],
+                },
+                {
+                    title: 'Actions',
+                    items: [
+                        {
+                            key: 'r',
+                            label: 'Refresh',
+                            exit: 'stay',
+                            action: async () => console.log('refresh'),
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(menu.groups).toHaveLength(2);
+        expect(menu.groups[0].items).toHaveLength(2);
+        expect(menu.groups[1].items).toHaveLength(1);
+        expect(menu.groups[0].items[1].exit).toBe('submenu');
+        expect(menu.groups[1].items[0].exit).toBe('stay');
+    });
+
+    it('should support conditional visibility', () => {
+        let isEnabled = true;
+
+        const item: HydraMenuItem = {
+            key: 'x',
+            label: 'Conditional',
+            exit: 'exit',
+            action: 'test.cmd',
+            when: () => isEnabled,
+        };
+
+        expect(item.when?.()).toBe(true);
+
+        isEnabled = false;
+        expect(item.when?.()).toBe(false);
+    });
+
+    it('should support toggle items', async () => {
+        let toggleState = false;
+
+        const item: HydraMenuItem = {
+            key: 't',
+            label: 'Toggle Feature',
+            exit: 'stay',
+            action: () => { toggleState = !toggleState; },
+            isToggle: true,
+            getToggleState: () => toggleState,
+        };
+
+        expect(await item.getToggleState?.()).toBe(false);
+
+        if (typeof item.action === 'function') {
+            await item.action();
+        }
+
+        expect(await item.getToggleState?.()).toBe(true);
+    });
+});
+
+describe('Exit Behaviors', () => {
+    it('should distinguish exit behaviors', () => {
+        const exitItem: HydraMenuItem = {
+            key: 'e',
+            label: 'Exit after',
+            exit: 'exit',
+            action: 'cmd',
+        };
+
+        const stayItem: HydraMenuItem = {
+            key: 's',
+            label: 'Stay open',
+            exit: 'stay',
+            action: 'cmd',
+        };
+
+        const submenuItem: HydraMenuItem = {
+            key: 'm',
+            label: 'Open submenu',
+            exit: 'submenu',
+            action: 'menu.id',
+        };
+
+        expect(exitItem.exit).toBe('exit');
+        expect(stayItem.exit).toBe('stay');
+        expect(submenuItem.exit).toBe('submenu');
+    });
+});
+
+describe('Action Types', () => {
+    it('should support string command actions', () => {
+        const item: HydraMenuItem = {
+            key: 'c',
+            label: 'Command',
+            exit: 'exit',
+            action: 'scimax.journal.today',
+            args: [new Date()],
+        };
+
+        expect(typeof item.action).toBe('string');
+        expect(item.args).toHaveLength(1);
+    });
+
+    it('should support function actions', () => {
+        const actionFn = vi.fn();
+
+        const item: HydraMenuItem = {
+            key: 'f',
+            label: 'Function',
+            exit: 'exit',
+            action: actionFn,
+        };
+
+        expect(typeof item.action).toBe('function');
+
+        if (typeof item.action === 'function') {
+            item.action();
+            expect(actionFn).toHaveBeenCalled();
+        }
+    });
+
+    it('should support async function actions', async () => {
+        const asyncAction = vi.fn().mockResolvedValue('done');
+
+        const item: HydraMenuItem = {
+            key: 'a',
+            label: 'Async',
+            exit: 'exit',
+            action: asyncAction,
+        };
+
+        if (typeof item.action === 'function') {
+            await item.action();
+            expect(asyncAction).toHaveBeenCalled();
+        }
+    });
+});
+
+describe('Menu Hierarchy', () => {
+    it('should support parent-child relationships', () => {
+        const parentMenu: HydraMenuDefinition = {
+            id: 'parent',
+            title: 'Parent Menu',
+            groups: [
+                {
+                    items: [
+                        { key: 'c', label: 'Child', exit: 'submenu', action: 'child' },
+                    ],
+                },
+            ],
+        };
+
+        const childMenu: HydraMenuDefinition = {
+            id: 'child',
+            title: 'Child Menu',
+            parent: 'parent',
+            showBack: true,
+            groups: [],
+        };
+
+        expect(childMenu.parent).toBe(parentMenu.id);
+        expect(childMenu.showBack).toBe(true);
+    });
+
+    it('should support deep nesting', () => {
+        const level1: HydraMenuDefinition = { id: 'l1', title: 'Level 1', groups: [] };
+        const level2: HydraMenuDefinition = { id: 'l2', title: 'Level 2', parent: 'l1', groups: [] };
+        const level3: HydraMenuDefinition = { id: 'l3', title: 'Level 3', parent: 'l2', groups: [] };
+
+        expect(level3.parent).toBe('l2');
+        expect(level2.parent).toBe('l1');
+        expect(level1.parent).toBeUndefined();
+    });
+});

--- a/src/hydra/commands.ts
+++ b/src/hydra/commands.ts
@@ -1,0 +1,119 @@
+/**
+ * Hydra Commands - VS Code command registrations for the hydra menu system
+ */
+
+import * as vscode from 'vscode';
+import { HydraManager } from './hydraManager';
+import { HydraShowOptions } from './types';
+
+/**
+ * Register all hydra-related commands
+ */
+export function registerHydraCommands(
+    context: vscode.ExtensionContext,
+    manager: HydraManager
+): void {
+    // Show a specific menu by ID
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'scimax.hydra.show',
+            async (menuId: string, options?: HydraShowOptions) => {
+                if (!menuId) {
+                    // Show menu picker if no ID provided
+                    const menuIds = manager.getMenuIds();
+                    if (menuIds.length === 0) {
+                        vscode.window.showInformationMessage('No hydra menus registered');
+                        return;
+                    }
+
+                    const items = menuIds.map((id) => {
+                        const menu = manager.getMenu(id);
+                        return {
+                            label: menu?.title || id,
+                            description: id,
+                            menuId: id,
+                        };
+                    });
+
+                    const selected = await vscode.window.showQuickPick(items, {
+                        placeHolder: 'Select a menu to show',
+                    });
+
+                    if (selected) {
+                        await manager.show(selected.menuId, options);
+                    }
+                } else {
+                    await manager.show(menuId, options);
+                }
+            }
+        )
+    );
+
+    // Hide the current menu
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.hydra.hide', () => {
+            manager.hide();
+        })
+    );
+
+    // Navigate back in menu hierarchy
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.hydra.back', async () => {
+            await manager.back();
+        })
+    );
+
+    // Toggle menu visibility
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.hydra.toggle', async (menuId: string) => {
+            if (manager.isMenuVisible()) {
+                manager.hide();
+            } else if (menuId) {
+                await manager.show(menuId);
+            }
+        })
+    );
+
+    // Show the main menu (scimax.main if registered)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.hydra.main', async () => {
+            const mainMenu = manager.getMenu('scimax.main');
+            if (mainMenu) {
+                await manager.show('scimax.main');
+            } else {
+                // Fall back to menu picker
+                await vscode.commands.executeCommand('scimax.hydra.show');
+            }
+        })
+    );
+
+    // Show context-aware menu based on current file type
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.hydra.contextMenu', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                await vscode.commands.executeCommand('scimax.hydra.main');
+                return;
+            }
+
+            const languageId = editor.document.languageId;
+            const contextMenuId = `scimax.${languageId}`;
+
+            // Try language-specific menu first
+            if (manager.getMenu(contextMenuId)) {
+                await manager.show(contextMenuId);
+            } else if (manager.getMenu('scimax.main')) {
+                await manager.show('scimax.main');
+            } else {
+                await vscode.commands.executeCommand('scimax.hydra.show');
+            }
+        })
+    );
+
+    // Navigate to a submenu (used internally)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.hydra.submenu', async (submenuId: string) => {
+            await manager.navigateToSubmenu(submenuId);
+        })
+    );
+}

--- a/src/hydra/hydraManager.ts
+++ b/src/hydra/hydraManager.ts
@@ -1,0 +1,518 @@
+/**
+ * HydraManager - Core manager for the hydra/transient menu system
+ *
+ * Provides registration, display, and execution of modal keyboard-driven menus.
+ */
+
+import * as vscode from 'vscode';
+import {
+    HydraMenuDefinition,
+    HydraMenuItem,
+    HydraMenuGroup,
+    HydraMenuRegistry,
+    HydraShowOptions,
+    HydraQuickPickItem,
+    HydraState,
+    HydraStateChangeEvent,
+    HydraConfig,
+    HydraMenuBuilder,
+} from './types';
+
+export class HydraManager {
+    private registry: HydraMenuRegistry = {};
+    private state: HydraState = {
+        activeMenuId: null,
+        menuStack: [],
+        context: {},
+        isVisible: false,
+    };
+    private config: HydraConfig;
+    private quickPick: vscode.QuickPick<HydraQuickPickItem> | null = null;
+    private keyBuffer: string = '';
+    private keyBufferTimeout: NodeJS.Timeout | null = null;
+
+    private readonly _onStateChange = new vscode.EventEmitter<HydraStateChangeEvent>();
+    public readonly onStateChange = this._onStateChange.event;
+
+    constructor(private context: vscode.ExtensionContext) {
+        this.config = this.loadConfig();
+
+        // Listen for config changes
+        context.subscriptions.push(
+            vscode.workspace.onDidChangeConfiguration((e) => {
+                if (e.affectsConfiguration('scimax.hydra')) {
+                    this.config = this.loadConfig();
+                }
+            })
+        );
+    }
+
+    private loadConfig(): HydraConfig {
+        const config = vscode.workspace.getConfiguration('scimax.hydra');
+        return {
+            showKeyHints: config.get('showKeyHints', true),
+            singleKeySelection: config.get('singleKeySelection', true),
+            dimNonMatching: config.get('dimNonMatching', true),
+            sortByKey: config.get('sortByKey', false),
+        };
+    }
+
+    /**
+     * Register a menu definition
+     */
+    public registerMenu(menu: HydraMenuDefinition): void {
+        this.registry[menu.id] = menu;
+    }
+
+    /**
+     * Register multiple menus at once
+     */
+    public registerMenus(menus: HydraMenuDefinition[]): void {
+        for (const menu of menus) {
+            this.registerMenu(menu);
+        }
+    }
+
+    /**
+     * Unregister a menu
+     */
+    public unregisterMenu(menuId: string): void {
+        delete this.registry[menuId];
+    }
+
+    /**
+     * Get a registered menu by ID
+     */
+    public getMenu(menuId: string): HydraMenuDefinition | undefined {
+        return this.registry[menuId];
+    }
+
+    /**
+     * Get all registered menu IDs
+     */
+    public getMenuIds(): string[] {
+        return Object.keys(this.registry);
+    }
+
+    /**
+     * Show a hydra menu
+     */
+    public async show(menuId: string, options: HydraShowOptions = {}): Promise<void> {
+        const menu = this.registry[menuId];
+        if (!menu) {
+            vscode.window.showErrorMessage(`Hydra menu not found: ${menuId}`);
+            return;
+        }
+
+        // Update state
+        const previousState = { ...this.state };
+        if (options.parentMenuId) {
+            this.state.menuStack.push(options.parentMenuId);
+        }
+        this.state.activeMenuId = menuId;
+        this.state.context = { ...this.state.context, ...options.context };
+        this.state.isVisible = true;
+
+        this._onStateChange.fire({
+            previousState,
+            newState: { ...this.state },
+            reason: 'show',
+        });
+
+        // Call onShow hook
+        if (menu.onShow) {
+            await menu.onShow();
+        }
+
+        // Build and show the quick pick
+        await this.showQuickPick(menu, options);
+    }
+
+    /**
+     * Hide the current menu
+     */
+    public hide(): void {
+        if (this.quickPick) {
+            this.quickPick.hide();
+            this.quickPick.dispose();
+            this.quickPick = null;
+        }
+
+        const previousState = { ...this.state };
+        this.state.activeMenuId = null;
+        this.state.menuStack = [];
+        this.state.isVisible = false;
+
+        this._onStateChange.fire({
+            previousState,
+            newState: { ...this.state },
+            reason: 'hide',
+        });
+    }
+
+    /**
+     * Navigate back to parent menu
+     */
+    public async back(): Promise<void> {
+        if (this.state.menuStack.length === 0) {
+            this.hide();
+            return;
+        }
+
+        const parentId = this.state.menuStack.pop()!;
+        const previousState = { ...this.state };
+
+        this._onStateChange.fire({
+            previousState,
+            newState: { ...this.state },
+            reason: 'navigate',
+        });
+
+        // Close current and show parent
+        if (this.quickPick) {
+            this.quickPick.hide();
+            this.quickPick.dispose();
+            this.quickPick = null;
+        }
+
+        await this.show(parentId);
+    }
+
+    /**
+     * Navigate to a submenu
+     */
+    public async navigateToSubmenu(submenuId: string): Promise<void> {
+        const currentMenuId = this.state.activeMenuId;
+
+        // Close current menu
+        if (this.quickPick) {
+            this.quickPick.hide();
+            this.quickPick.dispose();
+            this.quickPick = null;
+        }
+
+        // Show submenu with current menu as parent
+        await this.show(submenuId, {
+            parentMenuId: currentMenuId || undefined,
+        });
+    }
+
+    private async showQuickPick(
+        menu: HydraMenuDefinition,
+        options: HydraShowOptions
+    ): Promise<void> {
+        // Dispose any existing quick pick
+        if (this.quickPick) {
+            this.quickPick.dispose();
+        }
+
+        this.quickPick = vscode.window.createQuickPick<HydraQuickPickItem>();
+        this.quickPick.title = options.title || menu.title;
+        this.quickPick.placeholder = menu.hint || 'Press a key to select an action';
+        this.quickPick.matchOnDescription = true;
+        this.quickPick.matchOnDetail = true;
+
+        // Build items from menu definition
+        const items = await this.buildQuickPickItems(menu);
+        this.quickPick.items = items;
+
+        // Reset key buffer
+        this.keyBuffer = '';
+
+        // Handle keyboard input for single-key selection
+        if (this.config.singleKeySelection) {
+            this.quickPick.onDidChangeValue(async (value) => {
+                if (!value) {
+                    this.keyBuffer = '';
+                    return;
+                }
+
+                // Check if the typed key matches any item
+                const key = value.toLowerCase();
+                const matchingItem = items.find(
+                    (item) => item.menuItem.key.toLowerCase() === key
+                );
+
+                if (matchingItem) {
+                    // Clear the input and execute
+                    this.quickPick!.value = '';
+                    await this.executeItem(matchingItem.menuItem, menu);
+                } else {
+                    // Let the filter work normally
+                    this.keyBuffer = value;
+                }
+            });
+        }
+
+        // Handle selection via Enter or click
+        this.quickPick.onDidAccept(async () => {
+            const selected = this.quickPick?.selectedItems[0];
+            if (selected) {
+                await this.executeItem(selected.menuItem, menu);
+            }
+        });
+
+        // Handle hide
+        this.quickPick.onDidHide(async () => {
+            if (menu.onHide) {
+                await menu.onHide();
+            }
+
+            if (this.quickPick) {
+                this.quickPick.dispose();
+                this.quickPick = null;
+            }
+
+            const previousState = { ...this.state };
+            this.state.activeMenuId = null;
+            this.state.isVisible = false;
+
+            this._onStateChange.fire({
+                previousState,
+                newState: { ...this.state },
+                reason: 'hide',
+            });
+        });
+
+        this.quickPick.show();
+    }
+
+    private async buildQuickPickItems(menu: HydraMenuDefinition): Promise<HydraQuickPickItem[]> {
+        const items: HydraQuickPickItem[] = [];
+
+        // Add back item if there's a parent
+        if ((menu.parent || this.state.menuStack.length > 0) && menu.showBack !== false) {
+            items.push({
+                label: '$(arrow-left) Back',
+                description: '',
+                keyDisplay: '←',
+                menuItem: {
+                    key: 'Backspace',
+                    label: 'Back',
+                    exit: 'exit',
+                    action: async () => {
+                        await this.back();
+                    },
+                },
+            });
+        }
+
+        for (const group of menu.groups) {
+            // Check group visibility
+            if (group.when && !group.when()) {
+                continue;
+            }
+
+            // Add separator with group title if present
+            if (group.title && items.length > 0) {
+                items.push({
+                    label: group.title,
+                    kind: vscode.QuickPickItemKind.Separator,
+                    keyDisplay: '',
+                    menuItem: {
+                        key: '',
+                        label: group.title,
+                        exit: 'exit',
+                        action: '',
+                    },
+                });
+            }
+
+            for (const item of group.items) {
+                // Check item visibility
+                if (item.when && !item.when()) {
+                    continue;
+                }
+
+                const quickPickItem = await this.menuItemToQuickPickItem(item);
+                items.push(quickPickItem);
+            }
+        }
+
+        // Sort by key if configured
+        if (this.config.sortByKey) {
+            items.sort((a, b) => {
+                if (a.kind === vscode.QuickPickItemKind.Separator) return -1;
+                if (b.kind === vscode.QuickPickItemKind.Separator) return 1;
+                return a.menuItem.key.localeCompare(b.menuItem.key);
+            });
+        }
+
+        return items;
+    }
+
+    private async menuItemToQuickPickItem(item: HydraMenuItem): Promise<HydraQuickPickItem> {
+        const icon = item.icon ? `$(${item.icon}) ` : '';
+        const keyHint = this.config.showKeyHints ? `[${item.key}] ` : '';
+
+        // Handle toggle state
+        let toggleIndicator = '';
+        if (item.isToggle && item.getToggleState) {
+            const isOn = await item.getToggleState();
+            toggleIndicator = isOn ? ' $(check)' : ' $(circle-outline)';
+        }
+
+        // Exit behavior indicator
+        const exitIndicator = item.exit === 'stay' ? ' $(sync)' : '';
+
+        return {
+            label: `${icon}${keyHint}${item.label}${toggleIndicator}${exitIndicator}`,
+            description: item.description,
+            keyDisplay: item.key,
+            menuItem: item,
+        };
+    }
+
+    private async executeItem(item: HydraMenuItem, menu: HydraMenuDefinition): Promise<void> {
+        const previousState = { ...this.state };
+
+        // Handle different exit behaviors
+        if (item.exit === 'submenu') {
+            // Navigate to submenu
+            if (typeof item.action === 'string') {
+                await this.navigateToSubmenu(item.action);
+            }
+            return;
+        }
+
+        if (item.exit === 'exit') {
+            // Close menu before executing
+            this.hide();
+        }
+
+        // Execute the action
+        try {
+            if (typeof item.action === 'function') {
+                await item.action();
+            } else if (typeof item.action === 'string') {
+                await vscode.commands.executeCommand(item.action, ...(item.args || []));
+            }
+        } catch (error) {
+            vscode.window.showErrorMessage(
+                `Error executing action: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+
+        // If staying in menu, refresh items (for toggles, etc.)
+        if (item.exit === 'stay' && this.quickPick && this.state.activeMenuId) {
+            const currentMenu = this.registry[this.state.activeMenuId];
+            if (currentMenu) {
+                this.quickPick.items = await this.buildQuickPickItems(currentMenu);
+            }
+        }
+
+        this._onStateChange.fire({
+            previousState,
+            newState: { ...this.state },
+            reason: 'action',
+        });
+    }
+
+    /**
+     * Create a menu builder for fluent API
+     */
+    public createMenuBuilder(id: string): HydraMenuBuilder {
+        return new MenuBuilder(id);
+    }
+
+    /**
+     * Get current state
+     */
+    public getState(): Readonly<HydraState> {
+        return { ...this.state };
+    }
+
+    /**
+     * Check if a menu is currently visible
+     */
+    public isMenuVisible(): boolean {
+        return this.state.isVisible;
+    }
+
+    public dispose(): void {
+        this.hide();
+        this._onStateChange.dispose();
+    }
+}
+
+/**
+ * Fluent builder for creating menu definitions
+ */
+class MenuBuilder implements HydraMenuBuilder {
+    private menu: HydraMenuDefinition;
+    private currentGroup: HydraMenuGroup;
+
+    constructor(id: string) {
+        this.currentGroup = { items: [] };
+        this.menu = {
+            id,
+            title: id,
+            groups: [this.currentGroup],
+        };
+    }
+
+    title(title: string): HydraMenuBuilder {
+        this.menu.title = title;
+        return this;
+    }
+
+    hint(hint: string): HydraMenuBuilder {
+        this.menu.hint = hint;
+        return this;
+    }
+
+    group(title: string | undefined, items: HydraMenuItem[]): HydraMenuBuilder {
+        this.currentGroup = { title, items };
+        this.menu.groups.push(this.currentGroup);
+        return this;
+    }
+
+    item(item: HydraMenuItem): HydraMenuBuilder {
+        this.currentGroup.items.push(item);
+        return this;
+    }
+
+    command(key: string, label: string, command: string, args?: unknown[]): HydraMenuBuilder {
+        this.currentGroup.items.push({
+            key,
+            label,
+            exit: 'exit',
+            action: command,
+            args,
+        });
+        return this;
+    }
+
+    persistentCommand(key: string, label: string, command: string, args?: unknown[]): HydraMenuBuilder {
+        this.currentGroup.items.push({
+            key,
+            label,
+            exit: 'stay',
+            action: command,
+            args,
+        });
+        return this;
+    }
+
+    submenu(key: string, label: string, menuId: string): HydraMenuBuilder {
+        this.currentGroup.items.push({
+            key,
+            label,
+            icon: 'chevron-right',
+            exit: 'submenu',
+            action: menuId,
+        });
+        return this;
+    }
+
+    parent(menuId: string): HydraMenuBuilder {
+        this.menu.parent = menuId;
+        return this;
+    }
+
+    build(): HydraMenuDefinition {
+        // Filter out empty groups
+        this.menu.groups = this.menu.groups.filter((g) => g.items.length > 0);
+        return this.menu;
+    }
+}

--- a/src/hydra/index.ts
+++ b/src/hydra/index.ts
@@ -1,0 +1,85 @@
+/**
+ * Hydra Menu Framework
+ *
+ * A modal keyboard-driven menu system inspired by Emacs hydra/transient.
+ * Provides declarative menu definitions with keyboard shortcuts and hierarchical navigation.
+ *
+ * Usage:
+ *
+ * ```typescript
+ * import { HydraManager, registerHydraCommands, scimaxMenus } from './hydra';
+ *
+ * // In extension.ts activate():
+ * const hydraManager = new HydraManager(context);
+ * hydraManager.registerMenus(scimaxMenus);
+ * registerHydraCommands(context, hydraManager);
+ *
+ * // Show a menu:
+ * await vscode.commands.executeCommand('scimax.hydra.show', 'scimax.main');
+ * ```
+ *
+ * Creating custom menus:
+ *
+ * ```typescript
+ * const myMenu: HydraMenuDefinition = {
+ *     id: 'my.menu',
+ *     title: 'My Menu',
+ *     groups: [{
+ *         items: [
+ *             { key: 'a', label: 'Action A', exit: 'exit', action: 'my.command.a' },
+ *             { key: 'b', label: 'Action B', exit: 'stay', action: 'my.command.b' },
+ *             { key: 's', label: 'Submenu', exit: 'submenu', action: 'my.submenu' },
+ *         ]
+ *     }]
+ * };
+ *
+ * hydraManager.registerMenu(myMenu);
+ * ```
+ *
+ * Using the fluent builder:
+ *
+ * ```typescript
+ * const menu = hydraManager.createMenuBuilder('my.menu')
+ *     .title('My Menu')
+ *     .command('a', 'Action A', 'my.command.a')
+ *     .persistentCommand('b', 'Action B (stay open)', 'my.command.b')
+ *     .submenu('s', 'Submenu', 'my.submenu')
+ *     .build();
+ *
+ * hydraManager.registerMenu(menu);
+ * ```
+ */
+
+// Core types
+export type {
+    HydraMenuDefinition,
+    HydraMenuItem,
+    HydraMenuGroup,
+    HydraMenuRegistry,
+    HydraShowOptions,
+    HydraQuickPickItem,
+    HydraState,
+    HydraStateChangeEvent,
+    HydraConfig,
+    HydraMenuBuilder,
+    HydraExitBehavior,
+} from './types';
+
+// Manager
+export { HydraManager } from './hydraManager';
+
+// Commands
+export { registerHydraCommands } from './commands';
+
+// Pre-built menus
+export {
+    scimaxMenus,
+    mainMenu,
+    journalMenu,
+    referencesMenu,
+    notebookMenu,
+    projectileMenu,
+    searchMenu,
+    jumpMenu,
+    databaseMenu,
+} from './menus';

--- a/src/hydra/menus/databaseMenu.ts
+++ b/src/hydra/menus/databaseMenu.ts
@@ -1,0 +1,119 @@
+/**
+ * Database Menu - Org database operations
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const databaseMenu: HydraMenuDefinition = {
+    id: 'scimax.database',
+    title: 'Database',
+    hint: 'Org file database operations',
+    parent: 'scimax.main',
+    groups: [
+        {
+            title: 'Search',
+            items: [
+                {
+                    key: 's',
+                    label: 'Full-text Search',
+                    description: 'Search all content',
+                    icon: 'search',
+                    exit: 'exit',
+                    action: 'scimax.db.search',
+                },
+                {
+                    key: 'v',
+                    label: 'Vector Search',
+                    description: 'Semantic similarity search',
+                    icon: 'sparkle',
+                    exit: 'exit',
+                    action: 'scimax.db.vectorSearch',
+                },
+                {
+                    key: 'h',
+                    label: 'Search Headings',
+                    description: 'Search by heading text',
+                    icon: 'list-tree',
+                    exit: 'exit',
+                    action: 'scimax.db.searchHeadings',
+                },
+            ],
+        },
+        {
+            title: 'Tasks',
+            items: [
+                {
+                    key: 't',
+                    label: 'Search TODOs',
+                    description: 'Find TODO items',
+                    icon: 'checklist',
+                    exit: 'exit',
+                    action: 'scimax.db.searchTodos',
+                },
+                {
+                    key: 'a',
+                    label: 'Agenda',
+                    description: 'View scheduled items',
+                    icon: 'calendar',
+                    exit: 'exit',
+                    action: 'scimax.db.agenda',
+                },
+            ],
+        },
+        {
+            title: 'Links',
+            items: [
+                {
+                    key: 'l',
+                    label: 'Search Links',
+                    description: 'Find org links',
+                    icon: 'link',
+                    exit: 'exit',
+                    action: 'scimax.db.searchLinks',
+                },
+                {
+                    key: 'b',
+                    label: 'Backlinks',
+                    description: 'Find backlinks to current file',
+                    icon: 'references',
+                    exit: 'exit',
+                    action: 'scimax.db.backlinks',
+                },
+            ],
+        },
+        {
+            title: 'Index',
+            items: [
+                {
+                    key: 'i',
+                    label: 'Index Current File',
+                    description: 'Re-index the current file',
+                    icon: 'refresh',
+                    exit: 'exit',
+                    action: 'scimax.db.indexFile',
+                },
+                {
+                    key: 'I',
+                    label: 'Index All Files',
+                    description: 'Re-index all files',
+                    icon: 'sync',
+                    exit: 'exit',
+                    action: 'scimax.db.indexAll',
+                },
+            ],
+        },
+        {
+            title: 'Statistics',
+            items: [
+                {
+                    key: 'S',
+                    label: 'Database Stats',
+                    description: 'Show database statistics',
+                    icon: 'graph',
+                    exit: 'exit',
+                    action: 'scimax.db.stats',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/menus/index.ts
+++ b/src/hydra/menus/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Hydra Menus - Pre-built menus for Scimax features
+ */
+
+import { HydraMenuDefinition } from '../types';
+import { mainMenu } from './mainMenu';
+import { journalMenu } from './journalMenu';
+import { referencesMenu } from './referencesMenu';
+import { notebookMenu } from './notebookMenu';
+import { projectileMenu } from './projectileMenu';
+import { searchMenu } from './searchMenu';
+import { jumpMenu } from './jumpMenu';
+import { databaseMenu } from './databaseMenu';
+
+/**
+ * All pre-built Scimax menus
+ */
+export const scimaxMenus: HydraMenuDefinition[] = [
+    mainMenu,
+    journalMenu,
+    referencesMenu,
+    notebookMenu,
+    projectileMenu,
+    searchMenu,
+    jumpMenu,
+    databaseMenu,
+];
+
+export {
+    mainMenu,
+    journalMenu,
+    referencesMenu,
+    notebookMenu,
+    projectileMenu,
+    searchMenu,
+    jumpMenu,
+    databaseMenu,
+};

--- a/src/hydra/menus/journalMenu.ts
+++ b/src/hydra/menus/journalMenu.ts
@@ -1,0 +1,114 @@
+/**
+ * Journal Menu - Date-based journaling operations
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const journalMenu: HydraMenuDefinition = {
+    id: 'scimax.journal',
+    title: 'Journal',
+    hint: 'Date-based journaling system',
+    parent: 'scimax.main',
+    groups: [
+        {
+            title: 'Open Entry',
+            items: [
+                {
+                    key: 't',
+                    label: 'Today',
+                    description: 'Open today\'s journal entry',
+                    icon: 'calendar',
+                    exit: 'exit',
+                    action: 'scimax.journal.today',
+                },
+                {
+                    key: 'y',
+                    label: 'Yesterday',
+                    description: 'Open yesterday\'s entry',
+                    icon: 'history',
+                    exit: 'exit',
+                    action: 'scimax.journal.yesterday',
+                },
+                {
+                    key: 'w',
+                    label: 'Tomorrow',
+                    description: 'Open tomorrow\'s entry',
+                    icon: 'arrow-right',
+                    exit: 'exit',
+                    action: 'scimax.journal.tomorrow',
+                },
+                {
+                    key: 'g',
+                    label: 'Go to Date',
+                    description: 'Open entry for specific date',
+                    icon: 'milestone',
+                    exit: 'exit',
+                    action: 'scimax.journal.goto',
+                },
+            ],
+        },
+        {
+            title: 'Navigation',
+            items: [
+                {
+                    key: 'p',
+                    label: 'Previous Entry',
+                    description: 'Navigate to previous entry',
+                    icon: 'arrow-left',
+                    exit: 'exit',
+                    action: 'scimax.journal.previousEntry',
+                },
+                {
+                    key: 'n',
+                    label: 'Next Entry',
+                    description: 'Navigate to next entry',
+                    icon: 'arrow-right',
+                    exit: 'exit',
+                    action: 'scimax.journal.nextEntry',
+                },
+                {
+                    key: 'v',
+                    label: 'Week View',
+                    description: 'View entries for the week',
+                    icon: 'calendar',
+                    exit: 'exit',
+                    action: 'scimax.journal.weekView',
+                },
+            ],
+        },
+        {
+            title: 'Create & Search',
+            items: [
+                {
+                    key: 'c',
+                    label: 'New Entry',
+                    description: 'Create new entry with template',
+                    icon: 'new-file',
+                    exit: 'exit',
+                    action: 'scimax.journal.new',
+                },
+                {
+                    key: 's',
+                    label: 'Search',
+                    description: 'Search journal entries',
+                    icon: 'search',
+                    exit: 'exit',
+                    action: 'scimax.journal.search',
+                },
+            ],
+        },
+        {
+            title: 'Insert',
+            items: [
+                {
+                    key: 'h',
+                    label: 'Insert Heading',
+                    description: 'Insert timestamped heading',
+                    icon: 'list-tree',
+                    exit: 'exit',
+                    action: 'scimax.journal.insertHeading',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/menus/jumpMenu.ts
+++ b/src/hydra/menus/jumpMenu.ts
@@ -1,0 +1,77 @@
+/**
+ * Jump Menu - Avy-style quick navigation
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const jumpMenu: HydraMenuDefinition = {
+    id: 'scimax.jump',
+    title: 'Jump (Avy)',
+    hint: 'Quick navigation with character hints',
+    parent: 'scimax.main',
+    groups: [
+        {
+            title: 'Jump to Character',
+            items: [
+                {
+                    key: 'c',
+                    label: 'Jump to Char',
+                    description: 'Jump to a character',
+                    icon: 'debug-step-into',
+                    exit: 'exit',
+                    action: 'scimax.jump.char',
+                },
+                {
+                    key: '2',
+                    label: 'Jump to 2 Chars',
+                    description: 'Jump to two characters',
+                    icon: 'debug-step-into',
+                    exit: 'exit',
+                    action: 'scimax.jump.char2',
+                },
+            ],
+        },
+        {
+            title: 'Jump to Word',
+            items: [
+                {
+                    key: 'w',
+                    label: 'Jump to Word',
+                    description: 'Jump to start of word',
+                    icon: 'symbol-text',
+                    exit: 'exit',
+                    action: 'scimax.jump.word',
+                },
+            ],
+        },
+        {
+            title: 'Jump to Line',
+            items: [
+                {
+                    key: 'l',
+                    label: 'Jump to Line',
+                    description: 'Jump to a line',
+                    icon: 'list-ordered',
+                    exit: 'exit',
+                    action: 'scimax.jump.line',
+                },
+                {
+                    key: 'a',
+                    label: 'Jump Above',
+                    description: 'Jump to line above cursor',
+                    icon: 'arrow-up',
+                    exit: 'exit',
+                    action: 'scimax.jump.lineAbove',
+                },
+                {
+                    key: 'b',
+                    label: 'Jump Below',
+                    description: 'Jump to line below cursor',
+                    icon: 'arrow-down',
+                    exit: 'exit',
+                    action: 'scimax.jump.lineBelow',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/menus/mainMenu.ts
+++ b/src/hydra/menus/mainMenu.ts
@@ -1,0 +1,84 @@
+/**
+ * Main Scimax Menu - Entry point for all features
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const mainMenu: HydraMenuDefinition = {
+    id: 'scimax.main',
+    title: 'Scimax',
+    hint: 'Press a key to select, or type to filter',
+    groups: [
+        {
+            title: 'Features',
+            items: [
+                {
+                    key: 'j',
+                    label: 'Journal',
+                    description: 'Date-based journaling',
+                    icon: 'calendar',
+                    exit: 'submenu',
+                    action: 'scimax.journal',
+                },
+                {
+                    key: 'r',
+                    label: 'References',
+                    description: 'Bibliography management',
+                    icon: 'book',
+                    exit: 'submenu',
+                    action: 'scimax.references',
+                },
+                {
+                    key: 'n',
+                    label: 'Notebook',
+                    description: 'Project notebooks',
+                    icon: 'notebook',
+                    exit: 'submenu',
+                    action: 'scimax.notebook',
+                },
+                {
+                    key: 'p',
+                    label: 'Projects',
+                    description: 'Project switching (projectile)',
+                    icon: 'folder',
+                    exit: 'submenu',
+                    action: 'scimax.projectile',
+                },
+            ],
+        },
+        {
+            title: 'Search & Navigation',
+            items: [
+                {
+                    key: 's',
+                    label: 'Search',
+                    description: 'Search across files',
+                    icon: 'search',
+                    exit: 'submenu',
+                    action: 'scimax.search',
+                },
+                {
+                    key: 'g',
+                    label: 'Jump (Avy)',
+                    description: 'Quick navigation',
+                    icon: 'zap',
+                    exit: 'submenu',
+                    action: 'scimax.jump',
+                },
+            ],
+        },
+        {
+            title: 'Database',
+            items: [
+                {
+                    key: 'd',
+                    label: 'Database',
+                    description: 'Org database operations',
+                    icon: 'database',
+                    exit: 'submenu',
+                    action: 'scimax.database',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/menus/notebookMenu.ts
+++ b/src/hydra/menus/notebookMenu.ts
@@ -1,0 +1,90 @@
+/**
+ * Notebook Menu - Project notebook operations
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const notebookMenu: HydraMenuDefinition = {
+    id: 'scimax.notebook',
+    title: 'Notebook',
+    hint: 'Project-based organization',
+    parent: 'scimax.main',
+    groups: [
+        {
+            title: 'Navigation',
+            items: [
+                {
+                    key: 'o',
+                    label: 'Open Notebook',
+                    description: 'Open an existing notebook',
+                    icon: 'notebook',
+                    exit: 'exit',
+                    action: 'scimax.notebook.open',
+                },
+                {
+                    key: 'l',
+                    label: 'List Notebooks',
+                    description: 'Show all notebooks',
+                    icon: 'list-flat',
+                    exit: 'exit',
+                    action: 'scimax.notebook.list',
+                },
+            ],
+        },
+        {
+            title: 'Create',
+            items: [
+                {
+                    key: 'n',
+                    label: 'New Notebook',
+                    description: 'Create a new notebook',
+                    icon: 'new-file',
+                    exit: 'exit',
+                    action: 'scimax.notebook.new',
+                },
+                {
+                    key: 'e',
+                    label: 'New Entry',
+                    description: 'Add entry to current notebook',
+                    icon: 'add',
+                    exit: 'exit',
+                    action: 'scimax.notebook.newEntry',
+                },
+            ],
+        },
+        {
+            title: 'Search',
+            items: [
+                {
+                    key: 's',
+                    label: 'Search Notebook',
+                    description: 'Search within current notebook',
+                    icon: 'search',
+                    exit: 'exit',
+                    action: 'scimax.notebook.search',
+                },
+            ],
+        },
+        {
+            title: 'Files',
+            items: [
+                {
+                    key: 'f',
+                    label: 'Open File',
+                    description: 'Open file from notebook',
+                    icon: 'file',
+                    exit: 'exit',
+                    action: 'scimax.notebook.openFile',
+                },
+                {
+                    key: 'r',
+                    label: 'Recent Files',
+                    description: 'Show recent notebook files',
+                    icon: 'history',
+                    exit: 'exit',
+                    action: 'scimax.notebook.recentFiles',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/menus/projectileMenu.ts
+++ b/src/hydra/menus/projectileMenu.ts
@@ -1,0 +1,77 @@
+/**
+ * Projectile Menu - Project switching operations
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const projectileMenu: HydraMenuDefinition = {
+    id: 'scimax.projectile',
+    title: 'Projects (Projectile)',
+    hint: 'Project management and switching',
+    parent: 'scimax.main',
+    groups: [
+        {
+            title: 'Switch',
+            items: [
+                {
+                    key: 'p',
+                    label: 'Switch Project',
+                    description: 'Switch to another project',
+                    icon: 'folder-opened',
+                    exit: 'exit',
+                    action: 'scimax.projectile.switch',
+                },
+            ],
+        },
+        {
+            title: 'Manage',
+            items: [
+                {
+                    key: 'a',
+                    label: 'Add Project',
+                    description: 'Add current folder as project',
+                    icon: 'add',
+                    exit: 'exit',
+                    action: 'scimax.projectile.add',
+                },
+                {
+                    key: 'r',
+                    label: 'Remove Project',
+                    description: 'Remove a project from list',
+                    icon: 'remove',
+                    exit: 'exit',
+                    action: 'scimax.projectile.remove',
+                },
+                {
+                    key: 's',
+                    label: 'Scan for Projects',
+                    description: 'Scan directories for projects',
+                    icon: 'search',
+                    exit: 'exit',
+                    action: 'scimax.projectile.scan',
+                },
+            ],
+        },
+        {
+            title: 'Files',
+            items: [
+                {
+                    key: 'f',
+                    label: 'Find File',
+                    description: 'Find file in project',
+                    icon: 'file-symlink-file',
+                    exit: 'exit',
+                    action: 'scimax.projectile.findFile',
+                },
+                {
+                    key: 'g',
+                    label: 'Search in Project',
+                    description: 'Search text in project',
+                    icon: 'search',
+                    exit: 'exit',
+                    action: 'scimax.projectile.searchInProject',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/menus/referencesMenu.ts
+++ b/src/hydra/menus/referencesMenu.ts
@@ -1,0 +1,127 @@
+/**
+ * References Menu - Bibliography management operations
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const referencesMenu: HydraMenuDefinition = {
+    id: 'scimax.references',
+    title: 'References',
+    hint: 'Bibliography and citation management',
+    parent: 'scimax.main',
+    groups: [
+        {
+            title: 'Citations',
+            items: [
+                {
+                    key: 'c',
+                    label: 'Insert Citation',
+                    description: 'Search and insert a citation',
+                    icon: 'quote',
+                    exit: 'exit',
+                    action: 'scimax.ref.insertCitation',
+                },
+                {
+                    key: 'o',
+                    label: 'Open Entry',
+                    description: 'Open a bibliography entry',
+                    icon: 'book',
+                    exit: 'exit',
+                    action: 'scimax.ref.openEntry',
+                },
+                {
+                    key: 'u',
+                    label: 'Open URL',
+                    description: 'Open URL for reference',
+                    icon: 'link-external',
+                    exit: 'exit',
+                    action: 'scimax.ref.openUrl',
+                },
+            ],
+        },
+        {
+            title: 'Add References',
+            items: [
+                {
+                    key: 'd',
+                    label: 'Fetch from DOI',
+                    description: 'Add entry from DOI',
+                    icon: 'cloud-download',
+                    exit: 'exit',
+                    action: 'scimax.ref.fetchFromDOI',
+                },
+                {
+                    key: 'b',
+                    label: 'Fetch from BibTeX',
+                    description: 'Add entry from BibTeX string',
+                    icon: 'file-code',
+                    exit: 'exit',
+                    action: 'scimax.ref.fetchFromBibtex',
+                },
+                {
+                    key: 'n',
+                    label: 'New Entry',
+                    description: 'Create new bibliography entry',
+                    icon: 'new-file',
+                    exit: 'exit',
+                    action: 'scimax.ref.newEntry',
+                },
+            ],
+        },
+        {
+            title: 'Search',
+            items: [
+                {
+                    key: 's',
+                    label: 'Search References',
+                    description: 'Search bibliography',
+                    icon: 'search',
+                    exit: 'exit',
+                    action: 'scimax.ref.searchReferences',
+                },
+                {
+                    key: 'w',
+                    label: 'Citing Works',
+                    description: 'Find works citing this reference',
+                    icon: 'references',
+                    exit: 'exit',
+                    action: 'scimax.ref.showCitingWorks',
+                },
+                {
+                    key: 'r',
+                    label: 'Related Works',
+                    description: 'Find related works',
+                    icon: 'git-compare',
+                    exit: 'exit',
+                    action: 'scimax.ref.showRelatedWorks',
+                },
+            ],
+        },
+        {
+            title: 'Citation Actions',
+            items: [
+                {
+                    key: 'a',
+                    label: 'Citation Actions',
+                    description: 'Actions for citation at point',
+                    icon: 'wand',
+                    exit: 'exit',
+                    action: 'scimax.ref.citationActions',
+                },
+            ],
+        },
+        {
+            title: 'Management',
+            items: [
+                {
+                    key: 'l',
+                    label: 'Reload Bibliography',
+                    description: 'Reload all bibliography files',
+                    icon: 'refresh',
+                    exit: 'exit',
+                    action: 'scimax.ref.reload',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/menus/searchMenu.ts
+++ b/src/hydra/menus/searchMenu.ts
@@ -1,0 +1,85 @@
+/**
+ * Search Menu - Search and navigation operations
+ */
+
+import { HydraMenuDefinition } from '../types';
+
+export const searchMenu: HydraMenuDefinition = {
+    id: 'scimax.search',
+    title: 'Search',
+    hint: 'Search across files and content',
+    parent: 'scimax.main',
+    groups: [
+        {
+            title: 'Fuzzy Search',
+            items: [
+                {
+                    key: 'f',
+                    label: 'Search Current File',
+                    description: 'Fuzzy search in current file',
+                    icon: 'file-text',
+                    exit: 'exit',
+                    action: 'scimax.fuzzySearch.currentFile',
+                },
+                {
+                    key: 'o',
+                    label: 'Search Open Files',
+                    description: 'Search across all open files',
+                    icon: 'files',
+                    exit: 'exit',
+                    action: 'scimax.fuzzySearch.openFiles',
+                },
+                {
+                    key: 'h',
+                    label: 'Search Headings',
+                    description: 'Search headings in current file',
+                    icon: 'list-tree',
+                    exit: 'exit',
+                    action: 'scimax.fuzzySearch.headings',
+                },
+            ],
+        },
+        {
+            title: 'Database Search',
+            items: [
+                {
+                    key: 's',
+                    label: 'Full-text Search',
+                    description: 'Search all indexed content',
+                    icon: 'search',
+                    exit: 'exit',
+                    action: 'scimax.db.search',
+                },
+                {
+                    key: 'v',
+                    label: 'Vector Search',
+                    description: 'Semantic similarity search',
+                    icon: 'sparkle',
+                    exit: 'exit',
+                    action: 'scimax.db.vectorSearch',
+                },
+            ],
+        },
+        {
+            title: 'Tasks & Agenda',
+            items: [
+                {
+                    key: 't',
+                    label: 'Search TODOs',
+                    description: 'Find TODO items',
+                    icon: 'checklist',
+                    exit: 'exit',
+                    action: 'scimax.db.searchTodos',
+                },
+                {
+                    key: 'a',
+                    label: 'Agenda',
+                    description: 'View agenda items',
+                    icon: 'calendar',
+                    exit: 'exit',
+                    action: 'scimax.db.agenda',
+                },
+            ],
+        },
+    ],
+};

--- a/src/hydra/types.ts
+++ b/src/hydra/types.ts
@@ -1,0 +1,209 @@
+/**
+ * Hydra/Transient Menu Framework Types
+ *
+ * Inspired by Emacs hydra and transient packages, this provides a modal
+ * menu system for VS Code with keyboard-driven navigation.
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * Behavior after executing a menu item action
+ */
+export type HydraExitBehavior =
+    | 'exit'      // Close menu after action (blue head in hydra)
+    | 'stay'      // Keep menu open after action (red head in hydra)
+    | 'submenu';  // Navigate to a submenu
+
+/**
+ * A single item in a hydra menu
+ */
+export interface HydraMenuItem {
+    /** Single character key to trigger this item */
+    key: string;
+
+    /** Display label for the item */
+    label: string;
+
+    /** Optional description shown after the label */
+    description?: string;
+
+    /** Icon to display (VS Code codicon name without $()) */
+    icon?: string;
+
+    /** What happens after executing this item */
+    exit: HydraExitBehavior;
+
+    /**
+     * Action to perform. Can be:
+     * - A VS Code command string (e.g., 'scimax.journal.today')
+     * - A function to execute
+     * - A submenu ID (when exit is 'submenu')
+     */
+    action: string | (() => void | Promise<void>);
+
+    /** Arguments to pass if action is a command string */
+    args?: unknown[];
+
+    /** Condition for showing this item */
+    when?: () => boolean;
+
+    /** Whether this is a toggle (shows on/off state) */
+    isToggle?: boolean;
+
+    /** Function to get toggle state (true = on) */
+    getToggleState?: () => boolean | Promise<boolean>;
+}
+
+/**
+ * A group of related menu items with an optional header
+ */
+export interface HydraMenuGroup {
+    /** Optional group title */
+    title?: string;
+
+    /** Items in this group */
+    items: HydraMenuItem[];
+
+    /** Condition for showing this group */
+    when?: () => boolean;
+}
+
+/**
+ * Definition of a complete hydra menu
+ */
+export interface HydraMenuDefinition {
+    /** Unique identifier for this menu */
+    id: string;
+
+    /** Title displayed at the top of the menu */
+    title: string;
+
+    /** Optional hint text shown below the title */
+    hint?: string;
+
+    /** Groups of menu items */
+    groups: HydraMenuGroup[];
+
+    /** Parent menu ID for back navigation */
+    parent?: string;
+
+    /** Whether to show a back option when there's a parent */
+    showBack?: boolean;
+
+    /** Custom columns layout (default: auto) */
+    columns?: number;
+
+    /** Called when menu is shown */
+    onShow?: () => void | Promise<void>;
+
+    /** Called when menu is hidden */
+    onHide?: () => void | Promise<void>;
+}
+
+/**
+ * Registry of all available menus
+ */
+export interface HydraMenuRegistry {
+    [menuId: string]: HydraMenuDefinition;
+}
+
+/**
+ * Options for showing a hydra menu
+ */
+export interface HydraShowOptions {
+    /** Override the title */
+    title?: string;
+
+    /** Context data passed to actions */
+    context?: Record<string, unknown>;
+
+    /** Parent menu to return to on back */
+    parentMenuId?: string;
+}
+
+/**
+ * QuickPick item extended with hydra metadata
+ */
+export interface HydraQuickPickItem extends vscode.QuickPickItem {
+    /** The original menu item */
+    menuItem: HydraMenuItem;
+
+    /** Formatted key display */
+    keyDisplay: string;
+}
+
+/**
+ * State of the hydra menu system
+ */
+export interface HydraState {
+    /** Currently active menu ID */
+    activeMenuId: string | null;
+
+    /** Stack of parent menus for back navigation */
+    menuStack: string[];
+
+    /** Current context data */
+    context: Record<string, unknown>;
+
+    /** Whether a menu is currently visible */
+    isVisible: boolean;
+}
+
+/**
+ * Event emitted when hydra state changes
+ */
+export interface HydraStateChangeEvent {
+    previousState: HydraState;
+    newState: HydraState;
+    reason: 'show' | 'hide' | 'navigate' | 'action';
+}
+
+/**
+ * Configuration options for the hydra system
+ */
+export interface HydraConfig {
+    /** Show key hints inline with labels */
+    showKeyHints: boolean;
+
+    /** Use single-key selection (no Enter needed) */
+    singleKeySelection: boolean;
+
+    /** Dim items that don't match current filter */
+    dimNonMatching: boolean;
+
+    /** Sort items by key or keep definition order */
+    sortByKey: boolean;
+}
+
+/**
+ * Builder interface for creating menus fluently
+ */
+export interface HydraMenuBuilder {
+    /** Set the menu title */
+    title(title: string): HydraMenuBuilder;
+
+    /** Set the menu hint */
+    hint(hint: string): HydraMenuBuilder;
+
+    /** Add a group of items */
+    group(title: string | undefined, items: HydraMenuItem[]): HydraMenuBuilder;
+
+    /** Add a single item */
+    item(item: HydraMenuItem): HydraMenuBuilder;
+
+    /** Add a command item (exits menu) */
+    command(key: string, label: string, command: string, args?: unknown[]): HydraMenuBuilder;
+
+    /** Add a persistent command item (stays in menu) */
+    persistentCommand(key: string, label: string, command: string, args?: unknown[]): HydraMenuBuilder;
+
+    /** Add a submenu link */
+    submenu(key: string, label: string, menuId: string): HydraMenuBuilder;
+
+    /** Set the parent menu */
+    parent(menuId: string): HydraMenuBuilder;
+
+    /** Build the final menu definition */
+    build(): HydraMenuDefinition;
+}


### PR DESCRIPTION
Implements a modal keyboard-driven menu system inspired by Emacs hydra
and transient packages:

- HydraManager: Core manager for menu registration and display
- Declarative menu definitions with groups and items
- Three exit behaviors: exit (close), stay (keep open), submenu
- Single-key selection for fast navigation
- Toggle items with dynamic state
- Hierarchical menus with back navigation
- Fluent builder API for creating menus

Pre-built menus for all Scimax features:
- Main menu (ctrl+c m): Entry point to all features
- Journal, References, Notebook, Projectile submenus
- Search, Jump, Database submenus

Keybindings:
- ctrl+c m: Show main hydra menu
- ctrl+c ctrl+m: Show context-aware menu

Includes configuration options and unit tests (17 tests passing).