### PR TITLE
Add org-mode speed commands feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,99 @@ Emacs-style text markup with keyboard shortcuts.
 
 ---
 
+### Speed Commands (org-speed-commands)
+
+Single-key shortcuts that work when the cursor is at column 0 of a heading line, just like Emacs org-mode speed commands.
+
+**How it works:** Place your cursor at the very beginning of a heading line (column 0) and press a single key to execute commands instantly—no modifier keys needed.
+
+**Navigation:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `n` | Next heading             | Jump to next visible heading |
+| `p` | Previous heading         | Jump to previous heading     |
+| `f` | Next sibling             | Next heading at same level   |
+| `b` | Previous sibling         | Previous heading at same level |
+| `u` | Parent heading           | Jump to parent heading       |
+| `j` | Jump to heading          | Quick pick any heading       |
+| `g` | Go to menu               | Show navigation submenu      |
+
+**Visibility:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `c` | Cycle global             | Cycle all headings visibility |
+| `C` | Show children            | Expand all children          |
+| `o` | Overview                 | Fold all headings            |
+| `Tab` | Toggle fold            | Cycle fold at current heading |
+
+**Structure Editing:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `U` | Move subtree up          | Swap with previous sibling   |
+| `D` | Move subtree down        | Swap with next sibling       |
+| `r` | Demote subtree           | Increase level of subtree    |
+| `l` | Promote subtree          | Decrease level of subtree    |
+| `R` | Demote heading           | Increase level of heading only |
+| `L` | Promote heading          | Decrease level of heading only |
+| `w` | Kill subtree             | Cut subtree to clipboard     |
+| `y` | Yank subtree             | Paste subtree from clipboard |
+| `W` | Clone subtree            | Duplicate subtree below      |
+
+**TODO & Priority:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `t` | Cycle TODO               | Cycle through TODO states    |
+| `,` | Cycle priority           | Cycle priority up            |
+| `1` | Priority A               | Set priority [#A]            |
+| `2` | Priority B               | Set priority [#B]            |
+| `3` | Priority C               | Set priority [#C]            |
+| `0` | No priority              | Remove priority              |
+
+**Planning:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `s` | Schedule                 | Add/edit SCHEDULED timestamp |
+| `d` | Deadline                 | Add/edit DEADLINE timestamp  |
+| `.` | Insert timestamp         | Insert timestamp at point    |
+
+**Metadata:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `:` | Set tags                 | Edit tags for heading        |
+| `e` | Set effort               | Set Effort property          |
+| `P` | Set property             | Add/edit any property        |
+
+**Clocking:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `I` | Clock in                 | Start clock on this heading  |
+| `O` | Clock out                | Stop current clock           |
+
+**Archive:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `a` | Archive subtree          | Archive to archive file      |
+| `A` | Toggle ARCHIVE tag       | Add/remove :ARCHIVE: tag     |
+| `$` | Archive to sibling       | Archive under Archive sibling |
+
+**Special:**
+| Key | Command                  | Description                  |
+|-----|--------------------------|------------------------------|
+| `N` | Narrow to subtree        | Show only this subtree       |
+| `S` | Widen                    | Show full buffer             |
+| `?` | Speed help               | Show all speed commands      |
+
+**Configuration:**
+```json
+{
+  "scimax.speedCommands.enabled": true
+}
+```
+
+Toggle speed commands on/off with `Ctrl+c Ctrl+x s`.
+
+---
+
 ### Export System
 
 Export org documents to multiple formats.
@@ -659,6 +752,7 @@ The extension supports:
 | Block Manipulation   | scimax-ob          | Full support (split, merge, navigate) |
 | Export               | ox-*               | Full support (HTML, LaTeX, MD, PDF)   |
 | Tables               | org-table          | Full support + export to CSV/HTML     |
+| Speed Commands       | org-speed-commands | Full support (37 commands)            |
 | Clocking             | org-clock          | Partial (basic clocking)              |
 | Contacts             | org-contacts       | Not yet                               |
 | Capture Templates    | org-capture        | Not yet                               |

--- a/package.json
+++ b/package.json
@@ -1623,6 +1623,110 @@
       {
         "command": "scimax.table.sortByColumn",
         "title": "Scimax: Sort by Column"
+      },
+      {
+        "command": "scimax.speed.nextSibling",
+        "title": "Scimax: Next Sibling Heading"
+      },
+      {
+        "command": "scimax.speed.previousSibling",
+        "title": "Scimax: Previous Sibling Heading"
+      },
+      {
+        "command": "scimax.speed.firstHeading",
+        "title": "Scimax: First Heading"
+      },
+      {
+        "command": "scimax.speed.lastHeading",
+        "title": "Scimax: Last Heading"
+      },
+      {
+        "command": "scimax.speed.gotoMenu",
+        "title": "Scimax: Go To Menu"
+      },
+      {
+        "command": "scimax.speed.schedule",
+        "title": "Scimax: Add/Edit SCHEDULED"
+      },
+      {
+        "command": "scimax.speed.deadline",
+        "title": "Scimax: Add/Edit DEADLINE"
+      },
+      {
+        "command": "scimax.speed.setTags",
+        "title": "Scimax: Set Tags"
+      },
+      {
+        "command": "scimax.speed.setEffort",
+        "title": "Scimax: Set Effort"
+      },
+      {
+        "command": "scimax.speed.setProperty",
+        "title": "Scimax: Set Property"
+      },
+      {
+        "command": "scimax.speed.priorityA",
+        "title": "Scimax: Set Priority A"
+      },
+      {
+        "command": "scimax.speed.priorityB",
+        "title": "Scimax: Set Priority B"
+      },
+      {
+        "command": "scimax.speed.priorityC",
+        "title": "Scimax: Set Priority C"
+      },
+      {
+        "command": "scimax.speed.priorityNone",
+        "title": "Scimax: Remove Priority"
+      },
+      {
+        "command": "scimax.speed.showChildren",
+        "title": "Scimax: Show All Children"
+      },
+      {
+        "command": "scimax.speed.overview",
+        "title": "Scimax: Overview (Fold All)"
+      },
+      {
+        "command": "scimax.speed.clockIn",
+        "title": "Scimax: Clock In"
+      },
+      {
+        "command": "scimax.speed.clockOut",
+        "title": "Scimax: Clock Out"
+      },
+      {
+        "command": "scimax.speed.archiveSubtree",
+        "title": "Scimax: Archive Subtree"
+      },
+      {
+        "command": "scimax.speed.toggleArchiveTag",
+        "title": "Scimax: Toggle Archive Tag"
+      },
+      {
+        "command": "scimax.speed.archiveToSibling",
+        "title": "Scimax: Archive to Sibling"
+      },
+      {
+        "command": "scimax.speed.yankSubtree",
+        "title": "Scimax: Yank (Paste) Subtree"
+      },
+      {
+        "command": "scimax.speed.narrowToSubtree",
+        "title": "Scimax: Narrow to Subtree"
+      },
+      {
+        "command": "scimax.speed.widen",
+        "title": "Scimax: Widen"
+      },
+      {
+        "command": "scimax.speed.help",
+        "title": "Scimax: Speed Commands Help"
+      },
+      {
+        "command": "scimax.speed.toggle",
+        "title": "Scimax: Toggle Speed Commands"
       }
     ],
     "keybindings": [
@@ -2263,6 +2367,207 @@
         "key": "ctrl+c ^",
         "mac": "ctrl+c ^",
         "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.inTable"
+      },
+      {
+        "command": "scimax.speed.nextSibling",
+        "key": "f",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.previousSibling",
+        "key": "b",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.nextHeading",
+        "key": "n",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.previousHeading",
+        "key": "p",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.parentHeading",
+        "key": "u",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.jumpToHeading",
+        "key": "j",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.gotoMenu",
+        "key": "g",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.cycleGlobalFold",
+        "key": "c",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.showChildren",
+        "key": "shift+c",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.overview",
+        "key": "o",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.heading.moveUp",
+        "key": "shift+u",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.heading.moveDown",
+        "key": "shift+d",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.heading.demoteSubtree",
+        "key": "r",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.heading.promoteSubtree",
+        "key": "l",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.heading.demote",
+        "key": "shift+r",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.heading.promote",
+        "key": "shift+l",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.killSubtree",
+        "key": "w",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.yankSubtree",
+        "key": "y",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.cloneSubtree",
+        "key": "shift+w",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.cycleTodo",
+        "key": "t",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.shiftTimestampUp",
+        "key": ",",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.priorityA",
+        "key": "1",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.priorityB",
+        "key": "2",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.priorityC",
+        "key": "3",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.priorityNone",
+        "key": "0",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.schedule",
+        "key": "s",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.deadline",
+        "key": "d",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.org.insertTimestamp",
+        "key": ".",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.setTags",
+        "key": "shift+;",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.setEffort",
+        "key": "e",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.setProperty",
+        "key": "shift+p",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.clockIn",
+        "key": "shift+i",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.clockOut",
+        "key": "shift+o",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.archiveSubtree",
+        "key": "a",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.toggleArchiveTag",
+        "key": "shift+a",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.archiveToSibling",
+        "key": "shift+4",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.narrowToSubtree",
+        "key": "shift+n",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.widen",
+        "key": "shift+s",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.help",
+        "key": "shift+/",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/ && scimax.atHeadingStart && scimax.speedCommandsEnabled"
+      },
+      {
+        "command": "scimax.speed.toggle",
+        "key": "ctrl+c ctrl+x s",
+        "mac": "ctrl+c ctrl+x s",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/"
       }
     ],
     "configuration": {
@@ -2460,6 +2765,11 @@
           "type": "boolean",
           "default": false,
           "description": "Sort menu items by their keyboard shortcut"
+        },
+        "scimax.speedCommands.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable org-mode speed commands (single-key shortcuts at beginning of headings)"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import { registerBabelCommands, registerBabelCodeLens } from './org/babelProvide
 import { registerExportCommands } from './org/exportProvider';
 import { registerScimaxOrgCommands } from './org/scimaxOrg';
 import { registerScimaxObCommands } from './org/scimaxOb';
+import { registerSpeedCommands } from './org/speedCommands';
 // Jupyter commands imported dynamically to handle zeromq errors gracefully
 // import { registerJupyterCommands } from './jupyter/commands';
 import { ProjectileManager } from './projectile/projectileManager';
@@ -287,6 +288,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Register Scimax-ob commands (source block manipulation)
     registerScimaxObCommands(context);
+
+    // Register Speed Commands (single-key shortcuts at heading start)
+    registerSpeedCommands(context);
 
     // Track cursor position to set context for keybinding differentiation
     // This enables different keybindings when cursor is in a table vs on a heading

--- a/src/org/speedCommands/__tests__/speedCommands.test.ts
+++ b/src/org/speedCommands/__tests__/speedCommands.test.ts
@@ -1,0 +1,558 @@
+/**
+ * Tests for org-mode speed commands
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    SPEED_COMMAND_DEFINITIONS,
+    getSpeedCommand,
+    getSpeedCommandsByCategory,
+    SpeedCommandDefinition
+} from '../config';
+
+describe('speedCommands config', () => {
+    describe('SPEED_COMMAND_DEFINITIONS', () => {
+        it('contains all expected navigation commands', () => {
+            const navKeys = ['n', 'p', 'f', 'b', 'u', 'j', 'g'];
+            for (const key of navKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('navigation');
+            }
+        });
+
+        it('contains all expected visibility commands', () => {
+            const visKeys = ['c', 'C', 'o', 'Tab'];
+            for (const key of visKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('visibility');
+            }
+        });
+
+        it('contains all expected structure commands', () => {
+            const structKeys = ['U', 'D', 'r', 'l', 'R', 'L', 'w', 'y', 'W'];
+            for (const key of structKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('structure');
+            }
+        });
+
+        it('contains all expected TODO commands', () => {
+            const todoKeys = ['t', ',', '1', '2', '3', '0'];
+            for (const key of todoKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('todo');
+            }
+        });
+
+        it('contains all expected planning commands', () => {
+            const planKeys = ['s', 'd', '.'];
+            for (const key of planKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('planning');
+            }
+        });
+
+        it('contains all expected metadata commands', () => {
+            const metaKeys = [':', 'e', 'P'];
+            for (const key of metaKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('metadata');
+            }
+        });
+
+        it('contains all expected clocking commands', () => {
+            const clockKeys = ['I', 'O'];
+            for (const key of clockKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('clocking');
+            }
+        });
+
+        it('contains all expected special commands', () => {
+            const specialKeys = ['a', 'A', '$', 'N', 'S', '?'];
+            for (const key of specialKeys) {
+                const cmd = getSpeedCommand(key);
+                expect(cmd).toBeDefined();
+                expect(cmd?.category).toBe('special');
+            }
+        });
+
+        it('has unique keys for all commands', () => {
+            const keys = SPEED_COMMAND_DEFINITIONS.map(cmd => cmd.key);
+            const uniqueKeys = new Set(keys);
+            expect(uniqueKeys.size).toBe(keys.length);
+        });
+
+        it('has valid command IDs for all commands', () => {
+            for (const cmd of SPEED_COMMAND_DEFINITIONS) {
+                expect(cmd.command).toMatch(/^scimax\.(speed|org|heading)\./);
+            }
+        });
+
+        it('has descriptions for all commands', () => {
+            for (const cmd of SPEED_COMMAND_DEFINITIONS) {
+                expect(cmd.description.length).toBeGreaterThan(0);
+            }
+        });
+    });
+
+    describe('getSpeedCommand', () => {
+        it('returns the correct command for a valid key', () => {
+            const cmd = getSpeedCommand('n');
+            expect(cmd).toBeDefined();
+            expect(cmd?.key).toBe('n');
+            expect(cmd?.command).toBe('scimax.org.nextHeading');
+            expect(cmd?.description).toBe('Next visible heading');
+        });
+
+        it('returns undefined for an invalid key', () => {
+            const cmd = getSpeedCommand('z');
+            expect(cmd).toBeUndefined();
+        });
+
+        it('is case-sensitive', () => {
+            const lowerCmd = getSpeedCommand('n');
+            const upperCmd = getSpeedCommand('N');
+
+            expect(lowerCmd).toBeDefined();
+            expect(upperCmd).toBeDefined();
+            expect(lowerCmd?.command).not.toBe(upperCmd?.command);
+        });
+    });
+
+    describe('getSpeedCommandsByCategory', () => {
+        it('groups commands by category', () => {
+            const categories = getSpeedCommandsByCategory();
+
+            expect(categories.has('navigation')).toBe(true);
+            expect(categories.has('visibility')).toBe(true);
+            expect(categories.has('structure')).toBe(true);
+            expect(categories.has('todo')).toBe(true);
+            expect(categories.has('planning')).toBe(true);
+            expect(categories.has('metadata')).toBe(true);
+            expect(categories.has('clocking')).toBe(true);
+            expect(categories.has('special')).toBe(true);
+        });
+
+        it('includes all commands in categories', () => {
+            const categories = getSpeedCommandsByCategory();
+            let totalCommands = 0;
+
+            categories.forEach((commands) => {
+                totalCommands += commands.length;
+            });
+
+            expect(totalCommands).toBe(SPEED_COMMAND_DEFINITIONS.length);
+        });
+
+        it('places each command in the correct category', () => {
+            const categories = getSpeedCommandsByCategory();
+
+            const navCommands = categories.get('navigation') || [];
+            expect(navCommands.every(cmd => cmd.category === 'navigation')).toBe(true);
+
+            const visCommands = categories.get('visibility') || [];
+            expect(visCommands.every(cmd => cmd.category === 'visibility')).toBe(true);
+        });
+    });
+});
+
+describe('speed command key mappings', () => {
+    describe('navigation keys', () => {
+        it('n navigates to next heading', () => {
+            const cmd = getSpeedCommand('n');
+            expect(cmd?.command).toBe('scimax.org.nextHeading');
+        });
+
+        it('p navigates to previous heading', () => {
+            const cmd = getSpeedCommand('p');
+            expect(cmd?.command).toBe('scimax.org.previousHeading');
+        });
+
+        it('f navigates to next sibling', () => {
+            const cmd = getSpeedCommand('f');
+            expect(cmd?.command).toBe('scimax.speed.nextSibling');
+        });
+
+        it('b navigates to previous sibling', () => {
+            const cmd = getSpeedCommand('b');
+            expect(cmd?.command).toBe('scimax.speed.previousSibling');
+        });
+
+        it('u navigates to parent heading', () => {
+            const cmd = getSpeedCommand('u');
+            expect(cmd?.command).toBe('scimax.org.parentHeading');
+        });
+
+        it('j jumps to heading', () => {
+            const cmd = getSpeedCommand('j');
+            expect(cmd?.command).toBe('scimax.org.jumpToHeading');
+        });
+    });
+
+    describe('structure keys', () => {
+        it('U moves subtree up', () => {
+            const cmd = getSpeedCommand('U');
+            expect(cmd?.command).toBe('scimax.heading.moveUp');
+        });
+
+        it('D moves subtree down', () => {
+            const cmd = getSpeedCommand('D');
+            expect(cmd?.command).toBe('scimax.heading.moveDown');
+        });
+
+        it('r demotes subtree', () => {
+            const cmd = getSpeedCommand('r');
+            expect(cmd?.command).toBe('scimax.heading.demoteSubtree');
+        });
+
+        it('l promotes subtree', () => {
+            const cmd = getSpeedCommand('l');
+            expect(cmd?.command).toBe('scimax.heading.promoteSubtree');
+        });
+
+        it('w kills subtree', () => {
+            const cmd = getSpeedCommand('w');
+            expect(cmd?.command).toBe('scimax.org.killSubtree');
+        });
+
+        it('y yanks subtree', () => {
+            const cmd = getSpeedCommand('y');
+            expect(cmd?.command).toBe('scimax.speed.yankSubtree');
+        });
+    });
+
+    describe('TODO keys', () => {
+        it('t cycles TODO state', () => {
+            const cmd = getSpeedCommand('t');
+            expect(cmd?.command).toBe('scimax.org.cycleTodo');
+        });
+
+        it('1 sets priority A', () => {
+            const cmd = getSpeedCommand('1');
+            expect(cmd?.command).toBe('scimax.speed.priorityA');
+        });
+
+        it('2 sets priority B', () => {
+            const cmd = getSpeedCommand('2');
+            expect(cmd?.command).toBe('scimax.speed.priorityB');
+        });
+
+        it('3 sets priority C', () => {
+            const cmd = getSpeedCommand('3');
+            expect(cmd?.command).toBe('scimax.speed.priorityC');
+        });
+
+        it('0 removes priority', () => {
+            const cmd = getSpeedCommand('0');
+            expect(cmd?.command).toBe('scimax.speed.priorityNone');
+        });
+    });
+
+    describe('planning keys', () => {
+        it('s adds schedule', () => {
+            const cmd = getSpeedCommand('s');
+            expect(cmd?.command).toBe('scimax.speed.schedule');
+        });
+
+        it('d adds deadline', () => {
+            const cmd = getSpeedCommand('d');
+            expect(cmd?.command).toBe('scimax.speed.deadline');
+        });
+
+        it('. inserts timestamp', () => {
+            const cmd = getSpeedCommand('.');
+            expect(cmd?.command).toBe('scimax.org.insertTimestamp');
+        });
+    });
+
+    describe('metadata keys', () => {
+        it(': sets tags', () => {
+            const cmd = getSpeedCommand(':');
+            expect(cmd?.command).toBe('scimax.speed.setTags');
+        });
+
+        it('e sets effort', () => {
+            const cmd = getSpeedCommand('e');
+            expect(cmd?.command).toBe('scimax.speed.setEffort');
+        });
+
+        it('P sets property', () => {
+            const cmd = getSpeedCommand('P');
+            expect(cmd?.command).toBe('scimax.speed.setProperty');
+        });
+    });
+
+    describe('clocking keys', () => {
+        it('I clocks in', () => {
+            const cmd = getSpeedCommand('I');
+            expect(cmd?.command).toBe('scimax.speed.clockIn');
+        });
+
+        it('O clocks out', () => {
+            const cmd = getSpeedCommand('O');
+            expect(cmd?.command).toBe('scimax.speed.clockOut');
+        });
+    });
+
+    describe('archive keys', () => {
+        it('a archives subtree', () => {
+            const cmd = getSpeedCommand('a');
+            expect(cmd?.command).toBe('scimax.speed.archiveSubtree');
+        });
+
+        it('A toggles archive tag', () => {
+            const cmd = getSpeedCommand('A');
+            expect(cmd?.command).toBe('scimax.speed.toggleArchiveTag');
+        });
+
+        it('$ archives to sibling', () => {
+            const cmd = getSpeedCommand('$');
+            expect(cmd?.command).toBe('scimax.speed.archiveToSibling');
+        });
+    });
+
+    describe('special keys', () => {
+        it('N narrows to subtree', () => {
+            const cmd = getSpeedCommand('N');
+            expect(cmd?.command).toBe('scimax.speed.narrowToSubtree');
+        });
+
+        it('S widens', () => {
+            const cmd = getSpeedCommand('S');
+            expect(cmd?.command).toBe('scimax.speed.widen');
+        });
+
+        it('? shows help', () => {
+            const cmd = getSpeedCommand('?');
+            expect(cmd?.command).toBe('scimax.speed.help');
+        });
+    });
+});
+
+describe('planning helper functions', () => {
+    // These tests verify the timestamp formatting logic from planning.ts
+    describe('timestamp formatting', () => {
+        it('formats date correctly', () => {
+            const date = new Date(2024, 0, 15); // January 15, 2024
+            const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            const dayName = days[date.getDay()];
+
+            const expected = `<${year}-${month}-${day} ${dayName}>`;
+            expect(expected).toBe('<2024-01-15 Mon>');
+        });
+
+        it('pads single digit months and days', () => {
+            const date = new Date(2024, 0, 5); // January 5, 2024
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+
+            expect(month).toBe('01');
+            expect(day).toBe('05');
+        });
+
+        it('formats timestamp with time', () => {
+            const date = new Date(2024, 0, 15, 14, 30);
+            const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            const dayName = days[date.getDay()];
+            const hours = String(date.getHours()).padStart(2, '0');
+            const minutes = String(date.getMinutes()).padStart(2, '0');
+
+            const expected = `<${year}-${month}-${day} ${dayName} ${hours}:${minutes}>`;
+            expect(expected).toBe('<2024-01-15 Mon 14:30>');
+        });
+    });
+});
+
+describe('metadata helper functions', () => {
+    describe('tag extraction', () => {
+        // Test the regex pattern used in metadata.ts for extracting tags
+        const extractTags = (line: string): string[] => {
+            const match = line.match(/:([A-Za-z0-9_@#%:]+):\s*$/);
+            if (!match) return [];
+            return match[1].split(':').filter(t => t.length > 0);
+        };
+
+        it('extracts tags from heading', () => {
+            const line = '* TODO Task :work:urgent:';
+            const tags = extractTags(line);
+            expect(tags).toEqual(['work', 'urgent']);
+        });
+
+        it('extracts single tag', () => {
+            const line = '* Heading :tag:';
+            const tags = extractTags(line);
+            expect(tags).toEqual(['tag']);
+        });
+
+        it('returns empty array for no tags', () => {
+            const line = '* Heading without tags';
+            const tags = extractTags(line);
+            expect(tags).toEqual([]);
+        });
+
+        it('handles special characters in tags', () => {
+            const line = '* Task :@home:#project:';
+            const tags = extractTags(line);
+            expect(tags).toEqual(['@home', '#project']);
+        });
+    });
+
+    describe('tag formatting', () => {
+        const formatTags = (tags: string[]): string => {
+            if (tags.length === 0) return '';
+            return `:${tags.join(':')}:`;
+        };
+
+        it('formats multiple tags', () => {
+            const tags = ['work', 'urgent'];
+            const formatted = formatTags(tags);
+            expect(formatted).toBe(':work:urgent:');
+        });
+
+        it('formats single tag', () => {
+            const tags = ['todo'];
+            const formatted = formatTags(tags);
+            expect(formatted).toBe(':todo:');
+        });
+
+        it('returns empty string for no tags', () => {
+            const tags: string[] = [];
+            const formatted = formatTags(tags);
+            expect(formatted).toBe('');
+        });
+    });
+});
+
+describe('heading level detection', () => {
+    // Test the heading level detection logic
+    const getOrgHeadingLevel = (line: string): number => {
+        const match = line.match(/^(\*+)\s/);
+        return match ? match[1].length : 0;
+    };
+
+    const getMarkdownHeadingLevel = (line: string): number => {
+        const match = line.match(/^(#+)\s/);
+        return match ? match[1].length : 0;
+    };
+
+    describe('org-mode headings', () => {
+        it('detects level 1 heading', () => {
+            expect(getOrgHeadingLevel('* Heading')).toBe(1);
+        });
+
+        it('detects level 2 heading', () => {
+            expect(getOrgHeadingLevel('** Subheading')).toBe(2);
+        });
+
+        it('detects level 3 heading', () => {
+            expect(getOrgHeadingLevel('*** Sub-subheading')).toBe(3);
+        });
+
+        it('returns 0 for non-heading', () => {
+            expect(getOrgHeadingLevel('Just text')).toBe(0);
+        });
+
+        it('returns 0 for heading without space', () => {
+            expect(getOrgHeadingLevel('*No space')).toBe(0);
+        });
+
+        it('handles TODO headings', () => {
+            expect(getOrgHeadingLevel('* TODO Task')).toBe(1);
+            expect(getOrgHeadingLevel('** DONE Completed')).toBe(2);
+        });
+    });
+
+    describe('markdown headings', () => {
+        it('detects h1', () => {
+            expect(getMarkdownHeadingLevel('# Heading')).toBe(1);
+        });
+
+        it('detects h2', () => {
+            expect(getMarkdownHeadingLevel('## Heading')).toBe(2);
+        });
+
+        it('detects h6', () => {
+            expect(getMarkdownHeadingLevel('###### Heading')).toBe(6);
+        });
+
+        it('returns 0 for non-heading', () => {
+            expect(getMarkdownHeadingLevel('Just text')).toBe(0);
+        });
+    });
+});
+
+describe('priority handling', () => {
+    // Test priority regex patterns
+    const hasPriority = (line: string): boolean => {
+        return /\[#[A-Z]\]/.test(line);
+    };
+
+    const getPriority = (line: string): string | null => {
+        const match = line.match(/\[#([A-Z])\]/);
+        return match ? match[1] : null;
+    };
+
+    it('detects priority A', () => {
+        const line = '* TODO [#A] Important task';
+        expect(hasPriority(line)).toBe(true);
+        expect(getPriority(line)).toBe('A');
+    });
+
+    it('detects priority B', () => {
+        const line = '* [#B] Medium priority';
+        expect(hasPriority(line)).toBe(true);
+        expect(getPriority(line)).toBe('B');
+    });
+
+    it('detects priority C', () => {
+        const line = '** TODO [#C] Low priority';
+        expect(hasPriority(line)).toBe(true);
+        expect(getPriority(line)).toBe('C');
+    });
+
+    it('returns null for no priority', () => {
+        const line = '* TODO No priority';
+        expect(hasPriority(line)).toBe(false);
+        expect(getPriority(line)).toBeNull();
+    });
+});
+
+describe('archive tag handling', () => {
+    // Test archive tag detection
+    const hasArchiveTag = (line: string): boolean => {
+        const match = line.match(/:([A-Za-z0-9_@#%:]+):\s*$/);
+        if (!match) return false;
+        const tags = match[1].split(':');
+        return tags.some(t => t.toUpperCase() === 'ARCHIVE');
+    };
+
+    it('detects ARCHIVE tag', () => {
+        expect(hasArchiveTag('* Task :ARCHIVE:')).toBe(true);
+    });
+
+    it('detects archive tag with other tags', () => {
+        expect(hasArchiveTag('* Task :work:ARCHIVE:old:')).toBe(true);
+    });
+
+    it('returns false for no archive tag', () => {
+        expect(hasArchiveTag('* Task :work:')).toBe(false);
+    });
+
+    it('returns false for no tags', () => {
+        expect(hasArchiveTag('* Task')).toBe(false);
+    });
+});

--- a/src/org/speedCommands/archive.ts
+++ b/src/org/speedCommands/archive.ts
@@ -1,0 +1,305 @@
+/**
+ * Speed Command Archive Functions
+ *
+ * Archive subtrees to archive files or sibling headings.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { getHeadingLevel, getSubtreeRange } from './context';
+
+/**
+ * Get the archive file path for a given org file
+ * Default: same directory, filename_archive.org
+ */
+function getArchiveFilePath(filePath: string): string {
+    const dir = path.dirname(filePath);
+    const ext = path.extname(filePath);
+    const base = path.basename(filePath, ext);
+    return path.join(dir, `${base}_archive${ext}`);
+}
+
+/**
+ * Extract tags from a heading line
+ */
+function extractTags(line: string): string[] {
+    const match = line.match(/:([A-Za-z0-9_@#%:]+):\s*$/);
+    if (!match) return [];
+    return match[1].split(':').filter(t => t.length > 0);
+}
+
+/**
+ * Check if heading has :ARCHIVE: tag
+ */
+function hasArchiveTag(line: string): boolean {
+    const tags = extractTags(line);
+    return tags.some(t => t.toUpperCase() === 'ARCHIVE');
+}
+
+/**
+ * Add or remove a tag from a heading line
+ */
+function toggleTag(line: string, tag: string): { newLine: string; added: boolean } {
+    const tags = extractTags(line);
+    const tagUpper = tag.toUpperCase();
+    const hasTag = tags.some(t => t.toUpperCase() === tagUpper);
+
+    // Remove existing tags from line
+    let newLine = line.replace(/\s*:[A-Za-z0-9_@#%:]+:\s*$/, '').trimEnd();
+
+    let newTags: string[];
+    if (hasTag) {
+        // Remove the tag
+        newTags = tags.filter(t => t.toUpperCase() !== tagUpper);
+    } else {
+        // Add the tag
+        newTags = [...tags, tag];
+    }
+
+    if (newTags.length > 0) {
+        const tagStr = `:${newTags.join(':')}:`;
+        newLine = newLine + ' ' + tagStr;
+    }
+
+    return { newLine, added: !hasTag };
+}
+
+/**
+ * Archive subtree to archive file
+ */
+export async function archiveSubtree(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const { startLine, endLine } = getSubtreeRange(document, headingLine);
+
+    // Get subtree content
+    const subtreeRange = new vscode.Range(startLine, 0, endLine + 1, 0);
+    let subtreeText = document.getText(subtreeRange);
+
+    // Add archive metadata
+    const now = new Date();
+    const timestamp = `[${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][now.getDay()]} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}]`;
+    const archiveFile = document.uri.fsPath;
+
+    // Add :ARCHIVE: tag to the heading
+    const headingText = document.lineAt(startLine).text;
+    if (!hasArchiveTag(headingText)) {
+        const { newLine } = toggleTag(headingText, 'ARCHIVE');
+        subtreeText = subtreeText.replace(headingText, newLine);
+    }
+
+    // Add ARCHIVE_TIME and ARCHIVE_FILE properties if they don't exist
+    if (!subtreeText.includes(':PROPERTIES:')) {
+        // Insert properties drawer after heading
+        const firstNewline = subtreeText.indexOf('\n');
+        if (firstNewline >= 0) {
+            subtreeText = subtreeText.slice(0, firstNewline + 1) +
+                ':PROPERTIES:\n' +
+                `:ARCHIVE_TIME: ${timestamp}\n` +
+                `:ARCHIVE_FILE: ${archiveFile}\n` +
+                ':END:\n' +
+                subtreeText.slice(firstNewline + 1);
+        }
+    }
+
+    // Append to archive file
+    const archivePath = getArchiveFilePath(document.uri.fsPath);
+
+    try {
+        // Create archive file if it doesn't exist
+        let archiveContent = '';
+        if (fs.existsSync(archivePath)) {
+            archiveContent = fs.readFileSync(archivePath, 'utf-8');
+        } else {
+            archiveContent = `#+TITLE: Archive\n#+ARCHIVE: ${path.basename(archivePath)}\n\n`;
+        }
+
+        // Append subtree
+        if (!archiveContent.endsWith('\n')) {
+            archiveContent += '\n';
+        }
+        archiveContent += '\n' + subtreeText;
+
+        fs.writeFileSync(archivePath, archiveContent, 'utf-8');
+
+        // Delete from current file
+        await editor.edit(editBuilder => {
+            editBuilder.delete(subtreeRange);
+        });
+
+        vscode.window.showInformationMessage(`Archived to ${path.basename(archivePath)}`);
+    } catch (error: any) {
+        vscode.window.showErrorMessage(`Failed to archive: ${error.message}`);
+    }
+}
+
+/**
+ * Toggle :ARCHIVE: tag on current heading
+ */
+export async function toggleArchiveTag(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const line = document.lineAt(headingLine);
+    const { newLine, added } = toggleTag(line.text, 'ARCHIVE');
+
+    await editor.edit(editBuilder => {
+        editBuilder.replace(line.range, newLine);
+    });
+
+    vscode.window.showInformationMessage(
+        added ? 'Added :ARCHIVE: tag' : 'Removed :ARCHIVE: tag'
+    );
+}
+
+/**
+ * Archive subtree to an "Archive" sibling heading
+ */
+export async function archiveToSibling(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const level = getHeadingLevel(document, headingLine);
+    const { startLine, endLine } = getSubtreeRange(document, headingLine);
+
+    // Find parent level
+    let parentLevel = level - 1;
+    let parentEnd = document.lineCount - 1;
+
+    if (parentLevel > 0) {
+        // Find parent heading
+        for (let i = startLine - 1; i >= 0; i--) {
+            if (getHeadingLevel(document, i) === parentLevel) {
+                // Find end of parent
+                for (let j = i + 1; j < document.lineCount; j++) {
+                    const nextLevel = getHeadingLevel(document, j);
+                    if (nextLevel > 0 && nextLevel <= parentLevel) {
+                        parentEnd = j - 1;
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    // Look for existing Archive sibling
+    let archiveSiblingLine = -1;
+    const archiveLevel = level;
+    const prefix = document.languageId === 'org' ? '*'.repeat(archiveLevel) : '#'.repeat(archiveLevel);
+
+    for (let i = startLine + 1; i <= parentEnd; i++) {
+        const lineLevel = getHeadingLevel(document, i);
+        if (lineLevel === archiveLevel) {
+            const line = document.lineAt(i).text;
+            if (/Archive\s*:ARCHIVE:/.test(line) || /^[*#]+\s+Archive\s/.test(line)) {
+                archiveSiblingLine = i;
+                break;
+            }
+        }
+    }
+
+    // Get subtree content
+    const subtreeRange = new vscode.Range(startLine, 0, endLine + 1, 0);
+    let subtreeText = document.getText(subtreeRange);
+
+    // Demote the subtree by one level
+    const headingPattern = document.languageId === 'org' ? /^(\*+)/gm : /^(#+)/gm;
+    subtreeText = subtreeText.replace(headingPattern, (match, stars) => {
+        return (document.languageId === 'org' ? '*' : '#') + stars;
+    });
+
+    // Add :ARCHIVE: tag to the demoted heading
+    const firstLine = subtreeText.split('\n')[0];
+    if (!hasArchiveTag(firstLine)) {
+        const { newLine } = toggleTag(firstLine, 'ARCHIVE');
+        subtreeText = subtreeText.replace(firstLine, newLine);
+    }
+
+    await editor.edit(async editBuilder => {
+        // Delete original subtree
+        editBuilder.delete(subtreeRange);
+    });
+
+    // Re-read document
+    const docAfter = editor.document;
+
+    // Adjust archive sibling line after deletion
+    const deletedLines = endLine - startLine + 1;
+    if (archiveSiblingLine > endLine) {
+        archiveSiblingLine -= deletedLines;
+    } else if (archiveSiblingLine >= startLine) {
+        archiveSiblingLine = -1; // Was deleted
+    }
+
+    if (archiveSiblingLine >= 0) {
+        // Insert under existing Archive sibling
+        const { endLine: archiveEnd } = getSubtreeRange(docAfter, archiveSiblingLine);
+
+        await editor.edit(editBuilder => {
+            editBuilder.insert(
+                new vscode.Position(archiveEnd + 1, 0),
+                subtreeText
+            );
+        });
+    } else {
+        // Create new Archive sibling at the end of parent
+        const archiveHeading = `${prefix} Archive :ARCHIVE:\n`;
+
+        // Find insertion point (end of parent scope, adjusted for deletion)
+        let insertLine = parentEnd - deletedLines;
+        if (insertLine < startLine) insertLine = startLine;
+        if (insertLine >= docAfter.lineCount) insertLine = docAfter.lineCount - 1;
+
+        // Find actual end of current scope
+        for (let i = startLine; i < docAfter.lineCount; i++) {
+            const nextLevel = getHeadingLevel(docAfter, i);
+            if (nextLevel > 0 && nextLevel <= parentLevel) {
+                insertLine = i;
+                break;
+            }
+            insertLine = i + 1;
+        }
+
+        await editor.edit(editBuilder => {
+            editBuilder.insert(
+                new vscode.Position(insertLine, 0),
+                '\n' + archiveHeading + subtreeText
+            );
+        });
+    }
+
+    vscode.window.showInformationMessage('Archived to sibling');
+}

--- a/src/org/speedCommands/clocking.ts
+++ b/src/org/speedCommands/clocking.ts
@@ -1,0 +1,311 @@
+/**
+ * Speed Command Clocking Functions
+ *
+ * Clock in and clock out of tasks for time tracking.
+ */
+
+import * as vscode from 'vscode';
+import { getHeadingLevel } from './context';
+import { generateClockIn, generateClockOut, parseClockLine } from '../../parser/orgClocking';
+
+// Track the currently running clock globally
+let currentClock: {
+    filePath: string;
+    lineNumber: number;
+    headingLine: number;
+    startTime: Date;
+} | null = null;
+
+/**
+ * Find the LOGBOOK drawer or create one
+ */
+async function ensureLogbookDrawer(
+    editor: vscode.TextEditor,
+    headingLine: number
+): Promise<{ startLine: number; endLine: number }> {
+    const document = editor.document;
+
+    // Search for existing :LOGBOOK: drawer
+    let logbookStart = -1;
+    let logbookEnd = -1;
+
+    for (let i = headingLine + 1; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text.trim();
+
+        // Hit next heading
+        if (getHeadingLevel(document, i) > 0) break;
+
+        // Skip planning lines
+        if (/^(SCHEDULED|DEADLINE|CLOSED):/.test(line)) continue;
+
+        // Skip PROPERTIES drawer
+        if (line === ':PROPERTIES:') {
+            // Find end of properties
+            for (let j = i + 1; j < document.lineCount; j++) {
+                if (document.lineAt(j).text.trim() === ':END:') {
+                    i = j;
+                    break;
+                }
+            }
+            continue;
+        }
+
+        if (line === ':LOGBOOK:') {
+            logbookStart = i;
+        } else if (logbookStart >= 0 && line === ':END:') {
+            logbookEnd = i;
+            break;
+        } else if (logbookStart < 0 && line && !line.startsWith(':')) {
+            // Hit content before finding logbook
+            break;
+        }
+    }
+
+    if (logbookStart >= 0 && logbookEnd >= 0) {
+        return { startLine: logbookStart, endLine: logbookEnd };
+    }
+
+    // Create new logbook drawer
+    // Find insertion point (after heading, planning lines, and properties drawer)
+    let insertLine = headingLine + 1;
+    for (let i = headingLine + 1; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text.trim();
+        const level = getHeadingLevel(document, i);
+        if (level > 0) break;
+
+        if (/^(SCHEDULED|DEADLINE|CLOSED):/.test(line)) {
+            insertLine = i + 1;
+        } else if (line === ':PROPERTIES:') {
+            // Find end of properties
+            for (let j = i + 1; j < document.lineCount; j++) {
+                if (document.lineAt(j).text.trim() === ':END:') {
+                    insertLine = j + 1;
+                    i = j;
+                    break;
+                }
+            }
+        } else if (line && !line.startsWith(':')) {
+            break;
+        }
+    }
+
+    await editor.edit(editBuilder => {
+        editBuilder.insert(
+            new vscode.Position(insertLine, 0),
+            ':LOGBOOK:\n:END:\n'
+        );
+    });
+
+    return { startLine: insertLine, endLine: insertLine + 1 };
+}
+
+/**
+ * Find running clock in the logbook
+ */
+function findRunningClock(
+    document: vscode.TextDocument,
+    logbookStart: number,
+    logbookEnd: number
+): { lineNumber: number; startTime: Date } | null {
+    for (let i = logbookStart + 1; i < logbookEnd; i++) {
+        const line = document.lineAt(i).text;
+        if (line.includes('CLOCK:') && !line.includes('--')) {
+            // Running clock (no end timestamp)
+            const entry = parseClockLine(line.trim());
+            if (entry && !entry.end) {
+                return { lineNumber: i, startTime: entry.start };
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Clock in to the current heading
+ */
+export async function clockIn(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        // Search backward for heading
+        for (let i = position.line - 1; i >= 0; i--) {
+            if (getHeadingLevel(document, i) > 0) {
+                headingLine = i;
+                break;
+            }
+        }
+        if (getHeadingLevel(document, headingLine) === 0) {
+            vscode.window.showInformationMessage('No heading found');
+            return;
+        }
+    }
+
+    // Check if there's already a running clock
+    if (currentClock) {
+        // Clock out of the previous task first
+        const answer = await vscode.window.showQuickPick(
+            ['Clock out and switch', 'Cancel'],
+            { placeHolder: 'A clock is already running. What would you like to do?' }
+        );
+
+        if (answer !== 'Clock out and switch') return;
+        await clockOut();
+    }
+
+    // Ensure logbook drawer exists
+    const logbook = await ensureLogbookDrawer(editor, headingLine);
+
+    // Re-read document after potential edit
+    const docAfter = editor.document;
+
+    // Insert clock-in line at the start of logbook
+    const clockLine = generateClockIn();
+    const insertLine = logbook.startLine + 1;
+
+    await editor.edit(editBuilder => {
+        editBuilder.insert(
+            new vscode.Position(insertLine, 0),
+            clockLine + '\n'
+        );
+    });
+
+    // Track the running clock
+    currentClock = {
+        filePath: document.uri.fsPath,
+        lineNumber: insertLine,
+        headingLine: headingLine,
+        startTime: new Date()
+    };
+
+    // Get heading title for message
+    const headingText = docAfter.lineAt(headingLine).text;
+    const titleMatch = headingText.match(/^\*+\s+(?:TODO|DONE|NEXT|WAITING)?\s*(.*?)(?:\s+:[^:]+:)?\s*$/);
+    const title = titleMatch ? titleMatch[1].trim() : 'task';
+
+    vscode.window.showInformationMessage(`Clocked in: ${title}`);
+}
+
+/**
+ * Clock out of the current task
+ */
+export async function clockOut(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    if (!currentClock) {
+        // Try to find a running clock in the current file
+        const document = editor.document;
+        const position = editor.selection.active;
+
+        // Find the heading
+        let headingLine = position.line;
+        if (getHeadingLevel(document, headingLine) === 0) {
+            for (let i = position.line - 1; i >= 0; i--) {
+                if (getHeadingLevel(document, i) > 0) {
+                    headingLine = i;
+                    break;
+                }
+            }
+        }
+
+        if (getHeadingLevel(document, headingLine) === 0) {
+            vscode.window.showInformationMessage('No running clock found');
+            return;
+        }
+
+        // Look for logbook
+        let logbookStart = -1;
+        let logbookEnd = -1;
+
+        for (let i = headingLine + 1; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text.trim();
+            if (getHeadingLevel(document, i) > 0) break;
+
+            if (line === ':LOGBOOK:') {
+                logbookStart = i;
+            } else if (logbookStart >= 0 && line === ':END:') {
+                logbookEnd = i;
+                break;
+            }
+        }
+
+        if (logbookStart >= 0 && logbookEnd >= 0) {
+            const running = findRunningClock(document, logbookStart, logbookEnd);
+            if (running) {
+                currentClock = {
+                    filePath: document.uri.fsPath,
+                    lineNumber: running.lineNumber,
+                    headingLine: headingLine,
+                    startTime: running.startTime
+                };
+            }
+        }
+
+        if (!currentClock) {
+            vscode.window.showInformationMessage('No running clock found');
+            return;
+        }
+    }
+
+    // Find the document with the running clock
+    let clockEditor = editor;
+    if (editor.document.uri.fsPath !== currentClock.filePath) {
+        // Need to open the file with the running clock
+        const doc = await vscode.workspace.openTextDocument(currentClock.filePath);
+        clockEditor = await vscode.window.showTextDocument(doc);
+    }
+
+    const document = clockEditor.document;
+
+    // Find the running clock line
+    const line = document.lineAt(currentClock.lineNumber);
+    const clockEntry = parseClockLine(line.text.trim());
+
+    if (!clockEntry || clockEntry.end) {
+        // Clock was already closed or not found
+        currentClock = null;
+        vscode.window.showInformationMessage('Clock already closed');
+        return;
+    }
+
+    // Generate clock-out line
+    const clockOutLine = generateClockOut(currentClock.startTime);
+
+    await clockEditor.edit(editBuilder => {
+        editBuilder.replace(line.range, clockOutLine);
+    });
+
+    // Calculate duration for message
+    const duration = Math.round((new Date().getTime() - currentClock.startTime.getTime()) / 60000);
+    const hours = Math.floor(duration / 60);
+    const mins = duration % 60;
+    const durationStr = `${hours}:${String(mins).padStart(2, '0')}`;
+
+    currentClock = null;
+
+    vscode.window.showInformationMessage(`Clocked out: ${durationStr}`);
+}
+
+/**
+ * Get current clock status
+ */
+export function getClockStatus(): { running: boolean; duration?: string; task?: string } {
+    if (!currentClock) {
+        return { running: false };
+    }
+
+    const duration = Math.round((new Date().getTime() - currentClock.startTime.getTime()) / 60000);
+    const hours = Math.floor(duration / 60);
+    const mins = duration % 60;
+
+    return {
+        running: true,
+        duration: `${hours}:${String(mins).padStart(2, '0')}`
+    };
+}

--- a/src/org/speedCommands/config.ts
+++ b/src/org/speedCommands/config.ts
@@ -1,0 +1,101 @@
+/**
+ * Speed Command Configuration
+ *
+ * Defines all available speed commands and their mappings.
+ */
+
+export interface SpeedCommandDefinition {
+    /** The key that triggers this command */
+    key: string;
+    /** Command ID to execute */
+    command: string;
+    /** Description for help display */
+    description: string;
+    /** Category for grouping in help */
+    category: 'navigation' | 'visibility' | 'structure' | 'todo' | 'planning' | 'metadata' | 'clocking' | 'special';
+    /** Whether this command is a built-in VS Code command */
+    isBuiltin?: boolean;
+}
+
+/**
+ * All speed command definitions
+ */
+export const SPEED_COMMAND_DEFINITIONS: SpeedCommandDefinition[] = [
+    // Navigation
+    { key: 'n', command: 'scimax.org.nextHeading', description: 'Next visible heading', category: 'navigation' },
+    { key: 'p', command: 'scimax.org.previousHeading', description: 'Previous visible heading', category: 'navigation' },
+    { key: 'f', command: 'scimax.speed.nextSibling', description: 'Next heading same level', category: 'navigation' },
+    { key: 'b', command: 'scimax.speed.previousSibling', description: 'Previous heading same level', category: 'navigation' },
+    { key: 'u', command: 'scimax.org.parentHeading', description: 'Parent heading', category: 'navigation' },
+    { key: 'j', command: 'scimax.org.jumpToHeading', description: 'Jump to heading', category: 'navigation' },
+    { key: 'g', command: 'scimax.speed.gotoMenu', description: 'Go to... (submenu)', category: 'navigation' },
+
+    // Visibility/Folding
+    { key: 'c', command: 'scimax.org.cycleGlobalFold', description: 'Cycle global visibility', category: 'visibility' },
+    { key: 'C', command: 'scimax.speed.showChildren', description: 'Show all children', category: 'visibility' },
+    { key: 'o', command: 'scimax.speed.overview', description: 'Overview (fold all)', category: 'visibility' },
+    { key: 'Tab', command: 'scimax.org.toggleFold', description: 'Cycle fold at point', category: 'visibility' },
+
+    // Structure Editing
+    { key: 'U', command: 'scimax.heading.moveUp', description: 'Move subtree up', category: 'structure' },
+    { key: 'D', command: 'scimax.heading.moveDown', description: 'Move subtree down', category: 'structure' },
+    { key: 'r', command: 'scimax.heading.demoteSubtree', description: 'Demote subtree', category: 'structure' },
+    { key: 'l', command: 'scimax.heading.promoteSubtree', description: 'Promote subtree', category: 'structure' },
+    { key: 'R', command: 'scimax.heading.demote', description: 'Demote heading', category: 'structure' },
+    { key: 'L', command: 'scimax.heading.promote', description: 'Promote heading', category: 'structure' },
+    { key: 'w', command: 'scimax.org.killSubtree', description: 'Kill (cut) subtree', category: 'structure' },
+    { key: 'y', command: 'scimax.speed.yankSubtree', description: 'Yank (paste) subtree', category: 'structure' },
+    { key: 'W', command: 'scimax.org.cloneSubtree', description: 'Clone subtree', category: 'structure' },
+
+    // TODO/State
+    { key: 't', command: 'scimax.org.cycleTodo', description: 'Cycle TODO state', category: 'todo' },
+    { key: ',', command: 'scimax.org.shiftTimestampUp', description: 'Cycle priority up', category: 'todo' },
+    { key: '1', command: 'scimax.speed.priorityA', description: 'Set priority [#A]', category: 'todo' },
+    { key: '2', command: 'scimax.speed.priorityB', description: 'Set priority [#B]', category: 'todo' },
+    { key: '3', command: 'scimax.speed.priorityC', description: 'Set priority [#C]', category: 'todo' },
+    { key: '0', command: 'scimax.speed.priorityNone', description: 'Remove priority', category: 'todo' },
+
+    // Planning
+    { key: 's', command: 'scimax.speed.schedule', description: 'Add/edit SCHEDULED', category: 'planning' },
+    { key: 'd', command: 'scimax.speed.deadline', description: 'Add/edit DEADLINE', category: 'planning' },
+    { key: '.', command: 'scimax.org.insertTimestamp', description: 'Insert timestamp', category: 'planning' },
+
+    // Metadata
+    { key: ':', command: 'scimax.speed.setTags', description: 'Set tags', category: 'metadata' },
+    { key: 'e', command: 'scimax.speed.setEffort', description: 'Set effort', category: 'metadata' },
+    { key: 'P', command: 'scimax.speed.setProperty', description: 'Set property', category: 'metadata' },
+
+    // Clocking
+    { key: 'I', command: 'scimax.speed.clockIn', description: 'Clock in', category: 'clocking' },
+    { key: 'O', command: 'scimax.speed.clockOut', description: 'Clock out', category: 'clocking' },
+
+    // Special
+    { key: 'a', command: 'scimax.speed.archiveSubtree', description: 'Archive subtree', category: 'special' },
+    { key: 'A', command: 'scimax.speed.toggleArchiveTag', description: 'Toggle :ARCHIVE: tag', category: 'special' },
+    { key: '$', command: 'scimax.speed.archiveToSibling', description: 'Archive to sibling', category: 'special' },
+    { key: 'N', command: 'scimax.speed.narrowToSubtree', description: 'Narrow to subtree', category: 'special' },
+    { key: 'S', command: 'scimax.speed.widen', description: 'Widen (show all)', category: 'special' },
+    { key: '?', command: 'scimax.speed.help', description: 'Speed commands help', category: 'special' },
+];
+
+/**
+ * Get speed command by key
+ */
+export function getSpeedCommand(key: string): SpeedCommandDefinition | undefined {
+    return SPEED_COMMAND_DEFINITIONS.find(cmd => cmd.key === key);
+}
+
+/**
+ * Get all speed commands grouped by category
+ */
+export function getSpeedCommandsByCategory(): Map<string, SpeedCommandDefinition[]> {
+    const categories = new Map<string, SpeedCommandDefinition[]>();
+
+    for (const cmd of SPEED_COMMAND_DEFINITIONS) {
+        const existing = categories.get(cmd.category) || [];
+        existing.push(cmd);
+        categories.set(cmd.category, existing);
+    }
+
+    return categories;
+}

--- a/src/org/speedCommands/context.ts
+++ b/src/org/speedCommands/context.ts
@@ -1,0 +1,268 @@
+/**
+ * Speed Command Context Detection and Registration
+ *
+ * Detects when cursor is at the beginning (column 0) of a heading line
+ * and sets up context for speed command keybindings.
+ */
+
+import * as vscode from 'vscode';
+import { SPEED_COMMAND_DEFINITIONS, getSpeedCommandsByCategory } from './config';
+import * as navigation from './navigation';
+import * as planning from './planning';
+import * as metadata from './metadata';
+import * as visibility from './visibility';
+import * as clocking from './clocking';
+import * as archive from './archive';
+import * as structure from './structure';
+
+/**
+ * Check if cursor is at the start of a heading (column 0)
+ */
+export function isAtHeadingStart(document: vscode.TextDocument, position: vscode.Position): boolean {
+    // Must be at column 0
+    if (position.character !== 0) return false;
+
+    const line = document.lineAt(position.line).text;
+
+    if (document.languageId === 'org') {
+        return /^\*+\s/.test(line);
+    } else if (document.languageId === 'markdown') {
+        return /^#+\s/.test(line);
+    }
+
+    return false;
+}
+
+/**
+ * Get heading level from line
+ */
+export function getHeadingLevel(document: vscode.TextDocument, lineNum: number): number {
+    const line = document.lineAt(lineNum).text;
+
+    if (document.languageId === 'org') {
+        const match = line.match(/^(\*+)\s/);
+        return match ? match[1].length : 0;
+    } else if (document.languageId === 'markdown') {
+        const match = line.match(/^(#+)\s/);
+        return match ? match[1].length : 0;
+    }
+
+    return 0;
+}
+
+/**
+ * Get the range of a subtree (heading + all children)
+ */
+export function getSubtreeRange(document: vscode.TextDocument, line: number): { startLine: number; endLine: number } {
+    const level = getHeadingLevel(document, line);
+
+    if (level === 0) {
+        // Not on a heading, find the parent heading
+        for (let i = line - 1; i >= 0; i--) {
+            if (getHeadingLevel(document, i) > 0) {
+                return getSubtreeRange(document, i);
+            }
+        }
+        return { startLine: line, endLine: line };
+    }
+
+    let endLine = line;
+
+    // Find end of subtree (next heading at same or higher level, or end of file)
+    for (let i = line + 1; i < document.lineCount; i++) {
+        const nextLevel = getHeadingLevel(document, i);
+        if (nextLevel > 0 && nextLevel <= level) {
+            break;
+        }
+        endLine = i;
+    }
+
+    return { startLine: line, endLine };
+}
+
+/**
+ * Setup speed command context tracking
+ */
+export function setupSpeedCommandContext(context: vscode.ExtensionContext): void {
+    // Check if speed commands are enabled
+    const config = vscode.workspace.getConfiguration('scimax.speedCommands');
+    const enabled = config.get<boolean>('enabled', true);
+
+    // Set initial context
+    vscode.commands.executeCommand('setContext', 'scimax.speedCommandsEnabled', enabled);
+
+    // Track cursor position for atHeadingStart context
+    context.subscriptions.push(
+        vscode.window.onDidChangeTextEditorSelection(e => {
+            const editor = e.textEditor;
+            const document = editor.document;
+
+            // Only check for org/markdown files
+            if (!['org', 'markdown'].includes(document.languageId)) {
+                vscode.commands.executeCommand('setContext', 'scimax.atHeadingStart', false);
+                return;
+            }
+
+            const position = editor.selection.active;
+            const atStart = isAtHeadingStart(document, position) && editor.selection.isEmpty;
+            vscode.commands.executeCommand('setContext', 'scimax.atHeadingStart', atStart);
+        })
+    );
+
+    // Watch for configuration changes
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('scimax.speedCommands.enabled')) {
+                const newConfig = vscode.workspace.getConfiguration('scimax.speedCommands');
+                const newEnabled = newConfig.get<boolean>('enabled', true);
+                vscode.commands.executeCommand('setContext', 'scimax.speedCommandsEnabled', newEnabled);
+            }
+        })
+    );
+}
+
+/**
+ * Show speed commands help
+ */
+async function showSpeedHelp(): Promise<void> {
+    const categories = getSpeedCommandsByCategory();
+    const categoryOrder = ['navigation', 'visibility', 'structure', 'todo', 'planning', 'metadata', 'clocking', 'special'];
+
+    const items: vscode.QuickPickItem[] = [];
+
+    for (const category of categoryOrder) {
+        const commands = categories.get(category);
+        if (!commands) continue;
+
+        // Add category header
+        items.push({
+            label: category.charAt(0).toUpperCase() + category.slice(1),
+            kind: vscode.QuickPickItemKind.Separator
+        });
+
+        // Add commands in this category
+        for (const cmd of commands) {
+            items.push({
+                label: cmd.key,
+                description: cmd.description
+            });
+        }
+    }
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Speed Commands - Press a key at column 0 of a heading',
+        matchOnDescription: true
+    });
+
+    if (selected && selected.kind !== vscode.QuickPickItemKind.Separator) {
+        const cmd = SPEED_COMMAND_DEFINITIONS.find(c => c.key === selected.label);
+        if (cmd) {
+            await vscode.commands.executeCommand(cmd.command);
+        }
+    }
+}
+
+/**
+ * Show goto submenu
+ */
+async function showGotoMenu(): Promise<void> {
+    const items: (vscode.QuickPickItem & { command: string })[] = [
+        { label: 'n', description: 'Next heading', command: 'scimax.org.nextHeading' },
+        { label: 'p', description: 'Previous heading', command: 'scimax.org.previousHeading' },
+        { label: 'f', description: 'Next sibling', command: 'scimax.speed.nextSibling' },
+        { label: 'b', description: 'Previous sibling', command: 'scimax.speed.previousSibling' },
+        { label: 'u', description: 'Parent heading', command: 'scimax.org.parentHeading' },
+        { label: 'j', description: 'Jump to any heading', command: 'scimax.org.jumpToHeading' },
+        { label: '1', description: 'First heading', command: 'scimax.speed.firstHeading' },
+        { label: '$', description: 'Last heading', command: 'scimax.speed.lastHeading' },
+    ];
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Go to...'
+    });
+
+    if (selected) {
+        await vscode.commands.executeCommand(selected.command);
+    }
+}
+
+/**
+ * Register all speed commands
+ */
+export function registerSpeedCommands(context: vscode.ExtensionContext): void {
+    // Setup context tracking
+    setupSpeedCommandContext(context);
+
+    // Navigation commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.nextSibling', navigation.nextSiblingHeading),
+        vscode.commands.registerCommand('scimax.speed.previousSibling', navigation.previousSiblingHeading),
+        vscode.commands.registerCommand('scimax.speed.firstHeading', navigation.firstHeading),
+        vscode.commands.registerCommand('scimax.speed.lastHeading', navigation.lastHeading),
+        vscode.commands.registerCommand('scimax.speed.gotoMenu', showGotoMenu)
+    );
+
+    // Planning commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.schedule', planning.addSchedule),
+        vscode.commands.registerCommand('scimax.speed.deadline', planning.addDeadline)
+    );
+
+    // Metadata commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.setTags', metadata.setTags),
+        vscode.commands.registerCommand('scimax.speed.setEffort', metadata.setEffort),
+        vscode.commands.registerCommand('scimax.speed.setProperty', metadata.setProperty)
+    );
+
+    // Priority commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.priorityA', () => metadata.setPriority('A')),
+        vscode.commands.registerCommand('scimax.speed.priorityB', () => metadata.setPriority('B')),
+        vscode.commands.registerCommand('scimax.speed.priorityC', () => metadata.setPriority('C')),
+        vscode.commands.registerCommand('scimax.speed.priorityNone', () => metadata.setPriority(''))
+    );
+
+    // Visibility commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.showChildren', visibility.showAllChildren),
+        vscode.commands.registerCommand('scimax.speed.overview', visibility.showOverview)
+    );
+
+    // Clocking commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.clockIn', clocking.clockIn),
+        vscode.commands.registerCommand('scimax.speed.clockOut', clocking.clockOut)
+    );
+
+    // Archive commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.archiveSubtree', archive.archiveSubtree),
+        vscode.commands.registerCommand('scimax.speed.toggleArchiveTag', archive.toggleArchiveTag),
+        vscode.commands.registerCommand('scimax.speed.archiveToSibling', archive.archiveToSibling)
+    );
+
+    // Structure commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.yankSubtree', structure.yankSubtree),
+        vscode.commands.registerCommand('scimax.speed.narrowToSubtree', structure.narrowToSubtree),
+        vscode.commands.registerCommand('scimax.speed.widen', structure.widen)
+    );
+
+    // Help command
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.help', showSpeedHelp)
+    );
+
+    // Toggle speed commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('scimax.speed.toggle', async () => {
+            const config = vscode.workspace.getConfiguration('scimax.speedCommands');
+            const enabled = config.get<boolean>('enabled', true);
+            await config.update('enabled', !enabled, vscode.ConfigurationTarget.Global);
+            vscode.window.showInformationMessage(
+                `Speed commands ${!enabled ? 'enabled' : 'disabled'}`
+            );
+        })
+    );
+}

--- a/src/org/speedCommands/index.ts
+++ b/src/org/speedCommands/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Org-mode Speed Commands
+ *
+ * Speed commands are single-letter shortcuts that work when the cursor
+ * is at column 0 of a heading line, similar to Emacs org-mode.
+ */
+
+export { registerSpeedCommands, setupSpeedCommandContext } from './context';
+export { SPEED_COMMAND_DEFINITIONS, SpeedCommandDefinition } from './config';

--- a/src/org/speedCommands/metadata.ts
+++ b/src/org/speedCommands/metadata.ts
@@ -1,0 +1,349 @@
+/**
+ * Speed Command Metadata Functions
+ *
+ * Set tags, effort, properties, and priority.
+ */
+
+import * as vscode from 'vscode';
+import { getHeadingLevel } from './context';
+
+/**
+ * Extract tags from a heading line
+ * Tags are in format :tag1:tag2:tag3: at the end of the line
+ */
+function extractTags(line: string): string[] {
+    const match = line.match(/:([A-Za-z0-9_@#%:]+):\s*$/);
+    if (!match) return [];
+    return match[1].split(':').filter(t => t.length > 0);
+}
+
+/**
+ * Format tags for insertion into heading
+ */
+function formatTags(tags: string[]): string {
+    if (tags.length === 0) return '';
+    return `:${tags.join(':')}:`;
+}
+
+/**
+ * Set tags on the current heading
+ */
+export async function setTags(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading we're on
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const line = document.lineAt(headingLine);
+    const currentTags = extractTags(line.text);
+
+    // Prompt for new tags
+    const input = await vscode.window.showInputBox({
+        prompt: 'Enter tags (colon-separated, e.g., work:urgent:project)',
+        value: currentTags.join(':'),
+        placeHolder: 'tag1:tag2:tag3'
+    });
+
+    if (input === undefined) return; // Cancelled
+
+    const newTags = input.split(':').map(t => t.trim()).filter(t => t.length > 0);
+
+    // Remove existing tags from line
+    let newLineText = line.text.replace(/\s*:[A-Za-z0-9_@#%:]+:\s*$/, '');
+
+    // Add new tags if any
+    if (newTags.length > 0) {
+        // Ensure proper spacing before tags (align to column 77 like Emacs)
+        const tagStr = formatTags(newTags);
+        const targetCol = 77;
+        const currentLen = newLineText.trimEnd().length;
+
+        if (currentLen < targetCol - tagStr.length) {
+            // Add spaces to align
+            const spaces = ' '.repeat(targetCol - tagStr.length - currentLen);
+            newLineText = newLineText.trimEnd() + spaces + tagStr;
+        } else {
+            // Just add single space
+            newLineText = newLineText.trimEnd() + ' ' + tagStr;
+        }
+    }
+
+    await editor.edit(editBuilder => {
+        editBuilder.replace(line.range, newLineText);
+    });
+}
+
+/**
+ * Find or create PROPERTIES drawer for a heading
+ */
+async function ensurePropertiesDrawer(
+    editor: vscode.TextEditor,
+    headingLine: number
+): Promise<{ startLine: number; endLine: number }> {
+    const document = editor.document;
+
+    // Search for existing :PROPERTIES: drawer
+    let propertiesStart = -1;
+    let propertiesEnd = -1;
+
+    for (let i = headingLine + 1; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text.trim();
+
+        // Hit next heading
+        if (getHeadingLevel(document, i) > 0) break;
+
+        // Skip planning lines
+        if (/^(SCHEDULED|DEADLINE|CLOSED):/.test(line)) continue;
+
+        if (line === ':PROPERTIES:') {
+            propertiesStart = i;
+        } else if (propertiesStart >= 0 && line === ':END:') {
+            propertiesEnd = i;
+            break;
+        } else if (propertiesStart < 0 && line && !line.startsWith(':')) {
+            // Hit content before finding properties drawer
+            break;
+        }
+    }
+
+    if (propertiesStart >= 0 && propertiesEnd >= 0) {
+        return { startLine: propertiesStart, endLine: propertiesEnd };
+    }
+
+    // Create new properties drawer
+    // Find insertion point (after heading and planning lines)
+    let insertLine = headingLine + 1;
+    for (let i = headingLine + 1; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text.trim();
+        const level = getHeadingLevel(document, i);
+        if (level > 0) break;
+
+        if (/^(SCHEDULED|DEADLINE|CLOSED):/.test(line)) {
+            insertLine = i + 1;
+        } else {
+            break;
+        }
+    }
+
+    await editor.edit(editBuilder => {
+        editBuilder.insert(
+            new vscode.Position(insertLine, 0),
+            ':PROPERTIES:\n:END:\n'
+        );
+    });
+
+    return { startLine: insertLine, endLine: insertLine + 1 };
+}
+
+/**
+ * Set effort property on current heading
+ */
+export async function setEffort(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    // Common effort estimates
+    const options: (vscode.QuickPickItem & { value: string })[] = [
+        { label: '0:15', description: '15 minutes', value: '0:15' },
+        { label: '0:30', description: '30 minutes', value: '0:30' },
+        { label: '1:00', description: '1 hour', value: '1:00' },
+        { label: '2:00', description: '2 hours', value: '2:00' },
+        { label: '4:00', description: '4 hours (half day)', value: '4:00' },
+        { label: '8:00', description: '8 hours (full day)', value: '8:00' },
+        { label: 'Custom...', description: 'Enter custom effort', value: '' },
+    ];
+
+    const selected = await vscode.window.showQuickPick(options, {
+        placeHolder: 'Set effort estimate'
+    });
+
+    if (!selected) return;
+
+    let effort = selected.value;
+    if (!effort) {
+        const custom = await vscode.window.showInputBox({
+            prompt: 'Enter effort (H:MM format)',
+            placeHolder: '1:30',
+            validateInput: (value) => {
+                if (!value) return null;
+                if (!/^\d+:\d{2}$/.test(value)) {
+                    return 'Use H:MM format (e.g., 1:30)';
+                }
+                return null;
+            }
+        });
+        if (!custom) return;
+        effort = custom;
+    }
+
+    await setPropertyValue(editor, headingLine, 'Effort', effort);
+    vscode.window.showInformationMessage(`Effort: ${effort}`);
+}
+
+/**
+ * Set any property on current heading
+ */
+export async function setProperty(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    // Common properties
+    const commonProps = ['ID', 'CUSTOM_ID', 'Effort', 'CATEGORY', 'LOGGING', 'COLUMNS'];
+
+    const propertyName = await vscode.window.showInputBox({
+        prompt: 'Property name',
+        placeHolder: 'Enter property name (e.g., ID, CATEGORY)',
+        validateInput: (value) => {
+            if (!value) return null;
+            if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(value)) {
+                return 'Property name must start with a letter and contain only letters, numbers, underscores, and hyphens';
+            }
+            return null;
+        }
+    });
+
+    if (!propertyName) return;
+
+    const propertyValue = await vscode.window.showInputBox({
+        prompt: `Value for ${propertyName}`,
+        placeHolder: 'Enter property value'
+    });
+
+    if (propertyValue === undefined) return;
+
+    await setPropertyValue(editor, headingLine, propertyName, propertyValue);
+    vscode.window.showInformationMessage(`Set ${propertyName}: ${propertyValue}`);
+}
+
+/**
+ * Set a property value in the properties drawer
+ */
+async function setPropertyValue(
+    editor: vscode.TextEditor,
+    headingLine: number,
+    propertyName: string,
+    value: string
+): Promise<void> {
+    const document = editor.document;
+
+    // Ensure properties drawer exists
+    const drawer = await ensurePropertiesDrawer(editor, headingLine);
+
+    // Re-read document after potential edit
+    const docAfter = editor.document;
+
+    // Search for existing property
+    const propPattern = new RegExp(`^\\s*:${propertyName}:\\s*(.*)$`, 'i');
+    let existingLine = -1;
+
+    for (let i = drawer.startLine + 1; i < drawer.endLine; i++) {
+        const line = docAfter.lineAt(i).text;
+        if (propPattern.test(line)) {
+            existingLine = i;
+            break;
+        }
+    }
+
+    if (existingLine >= 0) {
+        // Update existing property
+        const line = docAfter.lineAt(existingLine);
+        const newText = `:${propertyName}: ${value}`;
+        await editor.edit(editBuilder => {
+            editBuilder.replace(line.range, newText);
+        });
+    } else {
+        // Insert new property before :END:
+        const endLine = drawer.endLine;
+        await editor.edit(editBuilder => {
+            editBuilder.insert(
+                new vscode.Position(endLine, 0),
+                `:${propertyName}: ${value}\n`
+            );
+        });
+    }
+}
+
+/**
+ * Set priority on current heading
+ */
+export async function setPriority(priority: string): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const line = document.lineAt(headingLine);
+    let lineText = line.text;
+
+    // Check for existing priority
+    const priorityMatch = lineText.match(/\[#[A-Z]\]/);
+
+    if (priority === '') {
+        // Remove priority
+        if (priorityMatch) {
+            lineText = lineText.replace(/\s*\[#[A-Z]\]\s*/, ' ');
+        }
+    } else {
+        const newPriority = `[#${priority}]`;
+        if (priorityMatch) {
+            // Replace existing priority
+            lineText = lineText.replace(/\[#[A-Z]\]/, newPriority);
+        } else {
+            // Insert priority after TODO keyword or after stars
+            const headingMatch = lineText.match(/^(\*+)\s+(TODO|DONE|NEXT|WAITING|HOLD|SOMEDAY|CANCELLED|CANCELED)?\s*/);
+            if (headingMatch) {
+                const insertPos = headingMatch[0].length;
+                lineText = lineText.slice(0, insertPos) + newPriority + ' ' + lineText.slice(insertPos);
+            }
+        }
+    }
+
+    // Clean up extra spaces
+    lineText = lineText.replace(/  +/g, ' ');
+
+    await editor.edit(editBuilder => {
+        editBuilder.replace(line.range, lineText);
+    });
+
+    if (priority) {
+        vscode.window.showInformationMessage(`Priority: [#${priority}]`);
+    } else {
+        vscode.window.showInformationMessage('Priority removed');
+    }
+}

--- a/src/org/speedCommands/navigation.ts
+++ b/src/org/speedCommands/navigation.ts
@@ -1,0 +1,124 @@
+/**
+ * Speed Command Navigation Functions
+ *
+ * Sibling navigation and other navigation helpers.
+ */
+
+import * as vscode from 'vscode';
+import { getHeadingLevel } from './context';
+
+/**
+ * Navigate to the next sibling heading (same level)
+ */
+export async function nextSiblingHeading(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const currentLine = editor.selection.active.line;
+    const currentLevel = getHeadingLevel(document, currentLine);
+
+    if (currentLevel === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    // Search forward for heading at same level
+    for (let i = currentLine + 1; i < document.lineCount; i++) {
+        const level = getHeadingLevel(document, i);
+        if (level === currentLevel) {
+            // Found sibling
+            const pos = new vscode.Position(i, 0);
+            editor.selection = new vscode.Selection(pos, pos);
+            editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+            return;
+        }
+        if (level > 0 && level < currentLevel) {
+            // Hit a parent heading, stop
+            vscode.window.showInformationMessage('No next sibling');
+            return;
+        }
+    }
+
+    vscode.window.showInformationMessage('No next sibling');
+}
+
+/**
+ * Navigate to the previous sibling heading (same level)
+ */
+export async function previousSiblingHeading(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const currentLine = editor.selection.active.line;
+    const currentLevel = getHeadingLevel(document, currentLine);
+
+    if (currentLevel === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    // Search backward for heading at same level
+    for (let i = currentLine - 1; i >= 0; i--) {
+        const level = getHeadingLevel(document, i);
+        if (level === currentLevel) {
+            // Found sibling
+            const pos = new vscode.Position(i, 0);
+            editor.selection = new vscode.Selection(pos, pos);
+            editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+            return;
+        }
+        if (level > 0 && level < currentLevel) {
+            // Hit a parent heading, stop
+            vscode.window.showInformationMessage('No previous sibling');
+            return;
+        }
+    }
+
+    vscode.window.showInformationMessage('No previous sibling');
+}
+
+/**
+ * Navigate to the first heading in the document
+ */
+export async function firstHeading(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+
+    for (let i = 0; i < document.lineCount; i++) {
+        const level = getHeadingLevel(document, i);
+        if (level > 0) {
+            const pos = new vscode.Position(i, 0);
+            editor.selection = new vscode.Selection(pos, pos);
+            editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+            return;
+        }
+    }
+
+    vscode.window.showInformationMessage('No headings found');
+}
+
+/**
+ * Navigate to the last heading in the document
+ */
+export async function lastHeading(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+
+    for (let i = document.lineCount - 1; i >= 0; i--) {
+        const level = getHeadingLevel(document, i);
+        if (level > 0) {
+            const pos = new vscode.Position(i, 0);
+            editor.selection = new vscode.Selection(pos, pos);
+            editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+            return;
+        }
+    }
+
+    vscode.window.showInformationMessage('No headings found');
+}

--- a/src/org/speedCommands/planning.ts
+++ b/src/org/speedCommands/planning.ts
@@ -1,0 +1,230 @@
+/**
+ * Speed Command Planning Functions
+ *
+ * Add/edit SCHEDULED and DEADLINE timestamps.
+ */
+
+import * as vscode from 'vscode';
+import { getHeadingLevel } from './context';
+
+/**
+ * Format a date as an org-mode timestamp
+ */
+function formatOrgTimestamp(date: Date, includeTime = false): string {
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const dayName = days[date.getDay()];
+
+    if (includeTime) {
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `<${year}-${month}-${day} ${dayName} ${hours}:${minutes}>`;
+    }
+
+    return `<${year}-${month}-${day} ${dayName}>`;
+}
+
+/**
+ * Parse an ISO date string to a Date object
+ */
+function parseDate(dateStr: string): Date | null {
+    const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    return new Date(parseInt(match[1]), parseInt(match[2]) - 1, parseInt(match[3]));
+}
+
+/**
+ * Find existing SCHEDULED or DEADLINE line for a heading
+ */
+function findPlanningLine(
+    document: vscode.TextDocument,
+    headingLine: number,
+    keyword: 'SCHEDULED' | 'DEADLINE'
+): { lineNumber: number; text: string } | null {
+    const headingLevel = getHeadingLevel(document, headingLine);
+
+    // Search in lines below heading until next heading or content
+    for (let i = headingLine + 1; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text;
+
+        // Check if we've hit the next heading
+        const nextLevel = getHeadingLevel(document, i);
+        if (nextLevel > 0) break;
+
+        // Check if line contains the keyword
+        const pattern = new RegExp(`^\\s*${keyword}:\\s*`);
+        if (pattern.test(line)) {
+            return { lineNumber: i, text: line };
+        }
+
+        // If we've hit content (non-empty, non-planning line), stop searching
+        // Planning lines should be immediately after heading
+        if (line.trim() && !/^\s*(SCHEDULED|DEADLINE|CLOSED):/.test(line)) {
+            // Unless it's a drawer or property
+            if (!/^\s*:/.test(line)) break;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Get the indent for planning lines based on heading
+ */
+function getPlanningIndent(document: vscode.TextDocument, headingLine: number): string {
+    // In org-mode, planning lines are typically not indented
+    // But we check if there's an existing pattern
+    for (let i = headingLine + 1; i < document.lineCount; i++) {
+        const line = document.lineAt(i).text;
+        const nextLevel = getHeadingLevel(document, i);
+        if (nextLevel > 0) break;
+
+        const match = line.match(/^(\s*)(SCHEDULED|DEADLINE|CLOSED):/);
+        if (match) {
+            return match[1];
+        }
+
+        if (line.trim() && !/^\s*:/.test(line)) break;
+    }
+
+    return '';
+}
+
+/**
+ * Prompt user for a date using quick pick
+ */
+async function promptForDate(title: string): Promise<Date | null> {
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const nextWeek = new Date(today);
+    nextWeek.setDate(nextWeek.getDate() + 7);
+    const nextMonth = new Date(today);
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+
+    const formatDisplay = (d: Date) => {
+        const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${days[d.getDay()]}`;
+    };
+
+    const options: (vscode.QuickPickItem & { date?: Date })[] = [
+        { label: 'Today', description: formatDisplay(today), date: today },
+        { label: 'Tomorrow', description: formatDisplay(tomorrow), date: tomorrow },
+        { label: 'Next week', description: formatDisplay(nextWeek), date: nextWeek },
+        { label: 'Next month', description: formatDisplay(nextMonth), date: nextMonth },
+        { label: 'Pick date...', description: 'Enter a custom date' },
+    ];
+
+    const selected = await vscode.window.showQuickPick(options, {
+        placeHolder: title
+    });
+
+    if (!selected) return null;
+
+    if (selected.date) {
+        return selected.date;
+    }
+
+    // Custom date input
+    const input = await vscode.window.showInputBox({
+        prompt: 'Enter date (YYYY-MM-DD)',
+        placeHolder: formatDisplay(today).split(' ')[0],
+        validateInput: (value) => {
+            if (!value) return null;
+            const parsed = parseDate(value);
+            if (!parsed) return 'Invalid date format. Use YYYY-MM-DD';
+            return null;
+        }
+    });
+
+    if (!input) return null;
+    return parseDate(input);
+}
+
+/**
+ * Add or edit a planning timestamp (SCHEDULED or DEADLINE)
+ */
+async function addPlanningTimestamp(keyword: 'SCHEDULED' | 'DEADLINE'): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading we're on or below
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        // Search backward for heading
+        for (let i = position.line - 1; i >= 0; i--) {
+            if (getHeadingLevel(document, i) > 0) {
+                headingLine = i;
+                break;
+            }
+        }
+        if (getHeadingLevel(document, headingLine) === 0) {
+            vscode.window.showInformationMessage('No heading found');
+            return;
+        }
+    }
+
+    // Prompt for date
+    const date = await promptForDate(`Set ${keyword}`);
+    if (!date) return;
+
+    const timestamp = formatOrgTimestamp(date);
+    const indent = getPlanningIndent(document, headingLine);
+
+    // Check for existing planning line
+    const existing = findPlanningLine(document, headingLine, keyword);
+
+    if (existing) {
+        // Replace existing timestamp
+        const line = document.lineAt(existing.lineNumber);
+        const newLine = line.text.replace(/<[^>]+>/, timestamp);
+
+        await editor.edit(editBuilder => {
+            editBuilder.replace(line.range, newLine);
+        });
+    } else {
+        // Insert new planning line
+        // Find the best position to insert (after heading, before content)
+        let insertLine = headingLine + 1;
+
+        // Check for existing planning lines and insert after them
+        for (let i = headingLine + 1; i < document.lineCount; i++) {
+            const line = document.lineAt(i).text;
+            const nextLevel = getHeadingLevel(document, i);
+            if (nextLevel > 0) break;
+
+            if (/^\s*(SCHEDULED|DEADLINE|CLOSED):/.test(line)) {
+                insertLine = i + 1;
+            } else if (line.trim() && !/^\s*:/.test(line)) {
+                break;
+            }
+        }
+
+        const newLine = `${indent}${keyword}: ${timestamp}\n`;
+
+        await editor.edit(editBuilder => {
+            editBuilder.insert(new vscode.Position(insertLine, 0), newLine);
+        });
+    }
+
+    vscode.window.showInformationMessage(`${keyword}: ${timestamp}`);
+}
+
+/**
+ * Add or edit SCHEDULED timestamp
+ */
+export async function addSchedule(): Promise<void> {
+    await addPlanningTimestamp('SCHEDULED');
+}
+
+/**
+ * Add or edit DEADLINE timestamp
+ */
+export async function addDeadline(): Promise<void> {
+    await addPlanningTimestamp('DEADLINE');
+}

--- a/src/org/speedCommands/structure.ts
+++ b/src/org/speedCommands/structure.ts
@@ -1,0 +1,235 @@
+/**
+ * Speed Command Structure Functions
+ *
+ * Yank (paste) subtrees and narrow/widen view.
+ */
+
+import * as vscode from 'vscode';
+import { getHeadingLevel, getSubtreeRange } from './context';
+
+// Store narrowed state
+let narrowedRange: { uri: string; startLine: number; endLine: number } | null = null;
+
+/**
+ * Yank (paste) subtree from clipboard
+ */
+export async function yankSubtree(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Get clipboard content
+    const clipboardText = await vscode.env.clipboard.readText();
+
+    if (!clipboardText.trim()) {
+        vscode.window.showInformationMessage('Clipboard is empty');
+        return;
+    }
+
+    // Check if clipboard contains a heading
+    const isOrg = document.languageId === 'org';
+    const headingPattern = isOrg ? /^\*+\s/ : /^#+\s/;
+
+    if (!headingPattern.test(clipboardText)) {
+        // Not a subtree, just paste normally
+        await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
+        return;
+    }
+
+    // Find the current heading level context
+    let currentLevel = 0;
+    let insertAfterLine = position.line;
+
+    // If on a heading, insert after current subtree
+    const lineLevel = getHeadingLevel(document, position.line);
+    if (lineLevel > 0) {
+        currentLevel = lineLevel;
+        const { endLine } = getSubtreeRange(document, position.line);
+        insertAfterLine = endLine;
+    } else {
+        // Find the nearest heading above
+        for (let i = position.line - 1; i >= 0; i--) {
+            const level = getHeadingLevel(document, i);
+            if (level > 0) {
+                currentLevel = level;
+                const { endLine } = getSubtreeRange(document, i);
+                insertAfterLine = endLine;
+                break;
+            }
+        }
+    }
+
+    // Adjust heading levels in clipboard to match context
+    const clipboardLevel = getClipboardHeadingLevel(clipboardText, isOrg);
+    let adjustedText = clipboardText;
+
+    if (currentLevel > 0 && clipboardLevel > 0 && clipboardLevel !== currentLevel) {
+        const levelDiff = currentLevel - clipboardLevel;
+        adjustedText = adjustHeadingLevels(clipboardText, levelDiff, isOrg);
+    }
+
+    // Ensure text ends with newline
+    if (!adjustedText.endsWith('\n')) {
+        adjustedText += '\n';
+    }
+
+    // Insert at the end of current subtree
+    await editor.edit(editBuilder => {
+        editBuilder.insert(
+            new vscode.Position(insertAfterLine + 1, 0),
+            adjustedText
+        );
+    });
+
+    vscode.window.showInformationMessage('Subtree yanked');
+}
+
+/**
+ * Get the level of the first heading in text
+ */
+function getClipboardHeadingLevel(text: string, isOrg: boolean): number {
+    const pattern = isOrg ? /^(\*+)\s/m : /^(#+)\s/m;
+    const match = text.match(pattern);
+    return match ? match[1].length : 0;
+}
+
+/**
+ * Adjust all heading levels in text by delta
+ */
+function adjustHeadingLevels(text: string, delta: number, isOrg: boolean): string {
+    const char = isOrg ? '*' : '#';
+    const pattern = new RegExp(`^(${char}+)(\\s)`, 'gm');
+
+    return text.replace(pattern, (match, stars, space) => {
+        const newLevel = Math.max(1, stars.length + delta);
+        return char.repeat(newLevel) + space;
+    });
+}
+
+/**
+ * Narrow view to current subtree
+ * This uses VS Code's folding to simulate narrowing
+ */
+export async function narrowToSubtree(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        // Search backward for heading
+        for (let i = position.line - 1; i >= 0; i--) {
+            if (getHeadingLevel(document, i) > 0) {
+                headingLine = i;
+                break;
+            }
+        }
+        if (getHeadingLevel(document, headingLine) === 0) {
+            vscode.window.showInformationMessage('No heading found');
+            return;
+        }
+    }
+
+    const { startLine, endLine } = getSubtreeRange(document, headingLine);
+
+    // Store narrowed state
+    narrowedRange = {
+        uri: document.uri.toString(),
+        startLine,
+        endLine
+    };
+
+    // Fold everything except the subtree
+    await vscode.commands.executeCommand('editor.foldAll');
+
+    // Unfold the target subtree
+    await vscode.commands.executeCommand('editor.unfold', {
+        selectionLines: Array.from({ length: endLine - startLine + 1 }, (_, i) => startLine + i),
+        direction: 'down',
+        levels: 100
+    });
+
+    // Move cursor to start of subtree
+    const newPos = new vscode.Position(startLine, 0);
+    editor.selection = new vscode.Selection(newPos, newPos);
+    editor.revealRange(new vscode.Range(newPos, newPos), vscode.TextEditorRevealType.InCenter);
+
+    vscode.window.setStatusBarMessage('Narrowed to subtree (press S to widen)', 3000);
+}
+
+/**
+ * Widen view (undo narrowing)
+ */
+export async function widen(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    // Unfold everything
+    await vscode.commands.executeCommand('editor.unfoldAll');
+
+    // Clear narrowed state
+    narrowedRange = null;
+
+    vscode.window.setStatusBarMessage('Widened', 2000);
+}
+
+/**
+ * Copy subtree to clipboard
+ */
+export async function copySubtree(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const { startLine, endLine } = getSubtreeRange(document, headingLine);
+
+    // Get subtree content
+    const subtreeRange = new vscode.Range(startLine, 0, endLine, document.lineAt(endLine).text.length);
+    const subtreeText = document.getText(subtreeRange);
+
+    // Copy to clipboard
+    await vscode.env.clipboard.writeText(subtreeText);
+
+    vscode.window.showInformationMessage('Subtree copied to clipboard');
+}
+
+/**
+ * Mark subtree for cut/copy operations
+ */
+export async function markSubtree(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const { startLine, endLine } = getSubtreeRange(document, headingLine);
+
+    // Select the subtree
+    const startPos = new vscode.Position(startLine, 0);
+    const endPos = new vscode.Position(endLine, document.lineAt(endLine).text.length);
+    editor.selection = new vscode.Selection(startPos, endPos);
+
+    vscode.window.showInformationMessage('Subtree selected');
+}

--- a/src/org/speedCommands/visibility.ts
+++ b/src/org/speedCommands/visibility.ts
@@ -1,0 +1,71 @@
+/**
+ * Speed Command Visibility Functions
+ *
+ * Control folding and visibility of headings and content.
+ */
+
+import * as vscode from 'vscode';
+import { getHeadingLevel, getSubtreeRange } from './context';
+
+/**
+ * Show all children of the current subtree
+ */
+export async function showAllChildren(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) return;
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Find the heading
+    let headingLine = position.line;
+    if (getHeadingLevel(document, headingLine) === 0) {
+        vscode.window.showInformationMessage('Not on a heading');
+        return;
+    }
+
+    const { startLine, endLine } = getSubtreeRange(document, headingLine);
+
+    // Unfold all lines in the subtree
+    await vscode.commands.executeCommand('editor.unfold', {
+        selectionLines: Array.from({ length: endLine - startLine + 1 }, (_, i) => startLine + i),
+        direction: 'down',
+        levels: 100  // Unfold all levels
+    });
+
+    vscode.window.setStatusBarMessage('Showing all children', 2000);
+}
+
+/**
+ * Fold everything to show only top-level headings (overview)
+ */
+export async function showOverview(): Promise<void> {
+    await vscode.commands.executeCommand('editor.foldAll');
+    vscode.window.setStatusBarMessage('Overview: All folded', 2000);
+}
+
+/**
+ * Fold to show only headings up to a certain level
+ */
+export async function foldToLevel(level: number): Promise<void> {
+    // First unfold everything, then fold to level
+    await vscode.commands.executeCommand('editor.unfoldAll');
+    await vscode.commands.executeCommand(`editor.foldLevel${level}`);
+    vscode.window.setStatusBarMessage(`Showing level ${level}`, 2000);
+}
+
+/**
+ * Show contents (fold to level 2 - shows first two heading levels)
+ */
+export async function showContents(): Promise<void> {
+    await foldToLevel(2);
+    vscode.window.setStatusBarMessage('Contents: Level 2', 2000);
+}
+
+/**
+ * Expand all headings
+ */
+export async function showAll(): Promise<void> {
+    await vscode.commands.executeCommand('editor.unfoldAll');
+    vscode.window.setStatusBarMessage('Show all: Expanded', 2000);
+}


### PR DESCRIPTION
Implements single-key shortcuts that work when cursor is at column 0 of
a heading line, mirroring Emacs org-mode speed commands behavior.

Features:
- Navigation: n/p (next/prev heading), f/b (siblings), u (parent), j (jump)
- Visibility: c (cycle global), C (show children), o (overview)
- Structure: U/D (move subtree), r/l (demote/promote), w/y (cut/yank)
- TODO: t (cycle), 1/2/3/0 (set priority A/B/C/none)
- Planning: s (schedule), d (deadline), . (timestamp)
- Metadata: : (tags), e (effort), P (property)
- Clocking: I (clock in), O (clock out)
- Archive: a (archive subtree), A (toggle tag), $ (archive to sibling)
- Special: N (narrow), S (widen), ? (help)

Includes:
- Context detection (scimax.atHeadingStart, scimax.speedCommandsEnabled)
- 37 speed command keybindings in package.json
- Configuration option to enable/disable (scimax.speedCommands.enabled)
- Comprehensive tests for config and helper functions
- Full documentation in README.md