### PR TITLE
Add notebook link support (nb:) for cross-project navigation

### DIFF
--- a/docs/05-links.org
+++ b/docs/05-links.org
@@ -149,13 +149,14 @@ CLOSED: [2026-01-15 Thu 19:40]
 
 | Link Type    | Behavior                              |
 |--------------+---------------------------------------|
-| https://    | Opens in default browser              |
-| http://     | Opens in default browser              |
-| file:       | Opens in VS Code or associated app    |
-| mailto:     | Opens default email client            |
-| #custom-id  | Jumps to heading with CUSTOM_ID       |
-| *Heading    | Jumps to heading with that title      |
-| id:         | Jumps to entry with that ID property  |
+| https://     | Opens in default browser              |
+| http://      | Opens in default browser              |
+| file:        | Opens in VS Code or associated app    |
+| mailto:      | Opens default email client            |
+| #custom-id   | Jumps to heading with CUSTOM_ID       |
+| *Heading     | Jumps to heading with that title      |
+| id:          | Jumps to entry with that ID property  |
+| nb:          | Opens file in a notebook project      |
 
 * ✅ Link Targets and Anchors
 CLOSED: [2026-01-14 Wed 20:53]
@@ -359,6 +360,80 @@ Universal identifiers for cross-file linking:
 [[id:550e8400-e29b-41d4-a716-446655440000][Section in another file]]
 
 
+** ⚠️ Notebook Links
+
+Notebook links provide cross-project navigation using the =nb:= link type. Inspired
+by scimax-notebook in Emacs, they allow you to link to files within registered
+notebook projects.
+
+*** Link Format
+
+#+BEGIN_SRC org
+[[nb:project-name::relative-file-path::target][description]]
+#+END_SRC
+
+| Component       | Description                                       |
+|-----------------+---------------------------------------------------|
+| project-name    | Name of the notebook/project                      |
+| relative-path   | Path to file relative to project root             |
+| target          | Optional: line number, char offset, heading or ID |
+
+*** Examples
+
+| Link                                 | Description                        |
+|--------------------------------------+------------------------------------|
+| [[nb:my-research::README.org]]       | Open README.org in my-research     |
+| [[nb:my-research::data/notes.org]]   | Open notes.org in data/ subfolder  |
+| [[nb:my-research::paper.org::10]]    | Jump to line 10                    |
+| [[nb:my-research::paper.org::c453]]  | Jump to character offset 453       |
+| [[nb:my-research::paper.org::*Methods]] | Jump to "Methods" heading       |
+| [[nb:my-research::doc.org::#intro]]  | Jump to custom ID "intro"          |
+
+*** Target Syntax
+
+The target component (after the second =::=) supports:
+
+| Syntax     | Description             |
+|------------+-------------------------|
+| =123=      | Jump to line 123        |
+| =c456=     | Jump to character 456   |
+| =*Heading= | Jump to heading by name |
+| =#id=      | Jump to custom ID       |
+
+*** Commands
+
+| Key       | Command                       | Description                |
+|-----------+-------------------------------+----------------------------|
+| C-c C-o   | scimax.org.openLink           | Open notebook link         |
+| (none)    | scimax.notebook.insertLink    | Insert a notebook link     |
+
+*** Inserting Notebook Links
+
+Use the command =Scimax: Insert Notebook Link= to interactively create links:
+
+1. Select a project from registered notebooks
+2. Select a file within that project
+3. Optionally specify a target (line, heading, ID)
+
+The link is inserted at the cursor position.
+
+*** Project Resolution
+
+The =project-name= is matched against registered notebooks by:
+
+1. Exact name match (from =.scimax/config.json= or directory name)
+2. Case-insensitive name match
+3. Directory name at the end of the path
+
+If multiple projects match, you'll be prompted to select one.
+
+*** Related Commands
+
+See also [[file:15-notebook.org][Notebooks]] for:
+- Creating and managing notebooks
+- Registering existing projects
+- Notebook search and navigation
+
 * ✅ Link Descriptions
 CLOSED: [2026-01-15 Thu 19:42]
 
@@ -532,18 +607,19 @@ CLOSED: [2026-01-15 Thu 19:53]
 ** ✅ Link Syntax Summary
 CLOSED: [2026-01-15 Thu 19:53]
 
-| Format               | Example             |
-|----------------------+---------------------|
-| URL with description | [[url][desc]]       |
-| URL only             | [[url]]             |
-| Angle brackets       | <url>               |
-| Heading link         | [[*Heading]]        |
-| Custom ID link       | [[#id]]             |
-| ID link              | [[id:uuid]]         |
-| File link            | [[file:path]]       |
-| File with line       | [[file:path::123]]  |
-| File with search     | [[file:path::text]] |
-| Target               | [[target-name]]     |
+| Format               | Example                      |
+|----------------------+------------------------------|
+| URL with description | [[url][desc]]                |
+| URL only             | [[url]]                      |
+| Angle brackets       | <url>                        |
+| Heading link         | [[*Heading]]                 |
+| Custom ID link       | [[#id]]                      |
+| ID link              | [[id:uuid]]                  |
+| File link            | [[file:path]]                |
+| File with line       | [[file:path::123]]           |
+| File with search     | [[file:path::text]]          |
+| Target               | [[target-name]]              |
+| Notebook link        | [[nb:project::file::target]] |
 
 * ✅ Related Topics
 

--- a/src/org/completionProvider.ts
+++ b/src/org/completionProvider.ts
@@ -54,7 +54,7 @@ const DOC_KEYWORDS = [
 const LINK_TYPES = [
     'file', 'http', 'https', 'ftp', 'mailto', 'doi', 'cite', 'id',
     'shell', 'elisp', 'info', 'help', 'news', 'bbdb', 'irc', 'rmail',
-    'mhe', 'gnus', 'attachment', 'docview',
+    'mhe', 'gnus', 'attachment', 'docview', 'nb',
 ];
 
 /**

--- a/src/org/scimaxOrg.ts
+++ b/src/org/scimaxOrg.ts
@@ -3026,6 +3026,9 @@ export async function openLinkAtPoint(): Promise<void> {
     // Handle different link types
     if (url.startsWith('http://') || url.startsWith('https://')) {
         vscode.env.openExternal(vscode.Uri.parse(url));
+    } else if (url.startsWith('nb:')) {
+        // Notebook link - delegate to notebook module command
+        await vscode.commands.executeCommand('scimax.notebook.openLink', url.slice(3));
     } else if (url.startsWith('file:')) {
         await openFileLink(url, document);
     } else if (url.startsWith('cite:') || url.startsWith('citep:') || url.startsWith('citet:')) {

--- a/src/parser/__tests__/orgLinkTypes.test.ts
+++ b/src/parser/__tests__/orgLinkTypes.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for org-mode link type handlers, especially notebook links
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    linkTypeRegistry,
+    notebookHandler,
+    type LinkContext,
+    type NotebookInfo,
+} from '../orgLinkTypes';
+
+describe('orgLinkTypes', () => {
+    describe('linkTypeRegistry', () => {
+        it('should have notebook handler registered', () => {
+            expect(linkTypeRegistry.hasType('nb')).toBe(true);
+        });
+
+        it('should return notebook handler for nb type', () => {
+            const handler = linkTypeRegistry.getHandler('nb');
+            expect(handler).toBeDefined();
+            expect(handler?.type).toBe('nb');
+        });
+    });
+
+    describe('notebookHandler', () => {
+        const mockNotebooks: NotebookInfo[] = [
+            { id: 'nb-1', name: 'my-research', path: '/home/user/projects/my-research' },
+            { id: 'nb-2', name: 'scimax', path: '/home/user/projects/scimax' },
+            { id: 'nb-3', name: 'data-analysis', path: '/home/user/projects/data-analysis' },
+        ];
+
+        const createContext = (notebooks: NotebookInfo[] = mockNotebooks): LinkContext => ({
+            getNotebooks: () => notebooks,
+            listNotebookFiles: async (notebookPath: string) => [
+                `${notebookPath}/README.org`,
+                `${notebookPath}/notes.org`,
+                `${notebookPath}/data/results.org`,
+            ],
+        });
+
+        describe('resolve', () => {
+            it('should resolve valid notebook link', () => {
+                const result = notebookHandler.resolve('my-research::README.org', createContext());
+                expect(result.exists).toBe(true);
+                expect(result.displayText).toBe('my-research::README.org');
+                expect(result.url).toContain('/home/user/projects/my-research/README.org');
+            });
+
+            it('should resolve link with nested file path', () => {
+                const result = notebookHandler.resolve('my-research::data/results.org', createContext());
+                expect(result.exists).toBe(true);
+                expect(result.url).toContain('/home/user/projects/my-research/data/results.org');
+            });
+
+            it('should resolve link with line number target', () => {
+                const result = notebookHandler.resolve('my-research::notes.org::42', createContext());
+                expect(result.exists).toBe(true);
+                expect(result.metadata?.target).toBe('42');
+                expect(result.tooltip).toContain('42');
+            });
+
+            it('should resolve link with character offset target', () => {
+                const result = notebookHandler.resolve('my-research::notes.org::c1234', createContext());
+                expect(result.exists).toBe(true);
+                expect(result.metadata?.target).toBe('c1234');
+            });
+
+            it('should resolve link with heading target', () => {
+                const result = notebookHandler.resolve('my-research::paper.org::*Methods', createContext());
+                expect(result.exists).toBe(true);
+                expect(result.metadata?.target).toBe('*Methods');
+            });
+
+            it('should resolve link with custom ID target', () => {
+                const result = notebookHandler.resolve('my-research::paper.org::#intro', createContext());
+                expect(result.exists).toBe(true);
+                expect(result.metadata?.target).toBe('#intro');
+            });
+
+            it('should handle case-insensitive project name matching', () => {
+                const result = notebookHandler.resolve('MY-RESEARCH::README.org', createContext());
+                expect(result.exists).toBe(true);
+            });
+
+            it('should report project not found', () => {
+                const result = notebookHandler.resolve('unknown-project::file.org', createContext());
+                expect(result.exists).toBe(false);
+                expect(result.tooltip).toContain('not found');
+            });
+
+            it('should report invalid link format (missing file)', () => {
+                const result = notebookHandler.resolve('my-research', createContext());
+                expect(result.exists).toBe(false);
+                expect(result.tooltip).toContain('Invalid');
+            });
+
+            it('should handle ambiguous project matches', () => {
+                const duplicateNotebooks: NotebookInfo[] = [
+                    { id: 'nb-1', name: 'project', path: '/path/a/project' },
+                    { id: 'nb-2', name: 'project', path: '/path/b/project' },
+                ];
+                const result = notebookHandler.resolve('project::file.org', createContext(duplicateNotebooks));
+                expect(result.metadata?.ambiguous).toBe(true);
+                expect(result.metadata?.candidates).toHaveLength(2);
+            });
+
+            it('should work with empty notebooks list', () => {
+                const result = notebookHandler.resolve('project::file.org', createContext([]));
+                expect(result.exists).toBe(false);
+            });
+
+            it('should work without getNotebooks callback', () => {
+                const result = notebookHandler.resolve('project::file.org', {});
+                expect(result.exists).toBe(false);
+            });
+        });
+
+        describe('export', () => {
+            it('should export to HTML', () => {
+                const html = notebookHandler.export!(
+                    'my-research::paper.org',
+                    'Research Paper',
+                    'html',
+                    createContext()
+                );
+                expect(html).toContain('Research Paper');
+                expect(html).toContain('paper.html');
+            });
+
+            it('should export to HTML without description', () => {
+                const html = notebookHandler.export!(
+                    'my-research::paper.org',
+                    undefined,
+                    'html',
+                    createContext()
+                );
+                expect(html).toContain('my-research::paper.org');
+            });
+
+            it('should export to LaTeX', () => {
+                const latex = notebookHandler.export!(
+                    'my-research::paper.org',
+                    'Research Paper',
+                    'latex',
+                    createContext()
+                );
+                expect(latex).toContain('\\texttt{');
+                expect(latex).toContain('Research Paper');
+            });
+
+            it('should export to text', () => {
+                const text = notebookHandler.export!(
+                    'my-research::paper.org',
+                    'Research Paper',
+                    'text',
+                    createContext()
+                );
+                expect(text).toBe('Research Paper');
+            });
+        });
+
+        describe('complete', () => {
+            it('should complete project names', async () => {
+                const completions = await notebookHandler.complete!('my-', createContext());
+                expect(completions.length).toBeGreaterThan(0);
+                expect(completions[0].text).toContain('my-research::');
+            });
+
+            it('should complete file paths after project name', async () => {
+                const completions = await notebookHandler.complete!('my-research::README', createContext());
+                expect(completions.some(c => c.text.includes('README.org'))).toBe(true);
+            });
+
+            it('should return empty for unknown prefix', async () => {
+                const completions = await notebookHandler.complete!('xyz', createContext());
+                expect(completions).toHaveLength(0);
+            });
+
+            it('should work without callbacks', async () => {
+                const completions = await notebookHandler.complete!('my-', {});
+                expect(completions).toHaveLength(0);
+            });
+        });
+    });
+
+    describe('parseNotebookLinkPath edge cases', () => {
+        // Test through resolve since parseNotebookLinkPath is internal
+        const mockContext: LinkContext = {
+            getNotebooks: () => [
+                { id: 'nb-1', name: 'test', path: '/test' },
+            ],
+        };
+
+        it('should handle empty project name', () => {
+            const result = notebookHandler.resolve('::file.org', mockContext);
+            expect(result.exists).toBe(false);
+        });
+
+        it('should handle empty file path', () => {
+            const result = notebookHandler.resolve('test::', mockContext);
+            expect(result.exists).toBe(false);
+        });
+
+        it('should handle multiple :: separators', () => {
+            const result = notebookHandler.resolve('test::file.org::123::extra', mockContext);
+            // Should parse: project=test, file=file.org, target=123::extra
+            expect(result.metadata?.projectName).toBe('test');
+            expect(result.metadata?.filePath).toBe('file.org');
+            expect(result.metadata?.target).toBe('123::extra');
+        });
+
+        it('should handle paths with spaces (URL encoded)', () => {
+            const result = notebookHandler.resolve('test::my file.org', mockContext);
+            expect(result.metadata?.filePath).toBe('my file.org');
+        });
+
+        it('should handle Windows-style backslashes in path', () => {
+            const windowsNotebooks: NotebookInfo[] = [
+                { id: 'nb-1', name: 'project', path: 'C:\\Users\\test\\project' },
+            ];
+            const result = notebookHandler.resolve('project::file.org', {
+                getNotebooks: () => windowsNotebooks,
+            });
+            expect(result.exists).toBe(true);
+            // Path should be normalized to forward slashes
+            expect(result.url).toContain('/');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Implements notebook links (`nb:` link type) for cross-project navigation in Scimax, inspired by scimax-notebook in Emacs. This allows users to link to files within registered notebook projects using a standardized format.

## Key Changes

### Documentation
- Updated `docs/05-links.org` with comprehensive notebook link documentation including:
  - Link format specification: `[[nb:project-name::relative-file-path::target]]`
  - Target syntax supporting line numbers, character offsets, headings, and custom IDs
  - Interactive command for inserting notebook links
  - Project resolution rules and examples
  - Added `nb:` to link type summary table

### Core Implementation
- **Link Type Handler** (`src/parser/orgLinkTypes.ts`):
  - Added `notebookHandler` with full support for resolving, exporting, completing, and following notebook links
  - Implemented `parseNotebookLinkPath()` to parse the `project::file::target` format
  - Supports case-insensitive project matching and ambiguous project resolution
  - Handles multiple target types: line numbers, character offsets (`c123`), headings (`*Heading`), and custom IDs (`#id`)

- **Commands** (`src/notebook/commands.ts`):
  - Added `scimax.notebook.openLink` command to open notebook links with target navigation
  - Added `scimax.notebook.insertLink` command for interactive link creation with project/file selection
  - Implemented `openNotebookLink()` and `navigateToTarget()` functions for link resolution and navigation

- **Link Opening** (`src/org/scimaxOrg.ts`):
  - Integrated notebook link handling into `openLinkAtPoint()` to delegate `nb:` links to the notebook module

- **Completion** (`src/org/completionProvider.ts`):
  - Added `nb` to the list of recognized link types for syntax highlighting and completion

### Testing
- Added comprehensive test suite (`src/parser/__tests__/orgLinkTypes.test.ts`) covering:
  - Link resolution with various target types
  - Project name matching (exact, case-insensitive, path-based)
  - Ambiguous project handling
  - Export to HTML, LaTeX, and text formats
  - Completion for project names and file paths
  - Edge cases (empty components, multiple separators, Windows paths)

## Implementation Details

- **Project Resolution**: Matches project names by exact match, case-insensitive match, or directory name at path end
- **Target Navigation**: Supports org-mode and markdown heading syntax, custom IDs in property drawers, and numeric line/character offsets
- **Ambiguity Handling**: When multiple projects match, users are prompted to select one
- **File Listing**: Integrates with existing `NotebookManager.listNotebookFiles()` for completion
- **Export Support**: Converts notebook links to appropriate formats for HTML (file links), LaTeX (monospace), and text (plain text)

## Related Interfaces
- Extended `LinkContext` with `getNotebooks()` and `listNotebookFiles()` callbacks
- Added `NotebookInfo` interface for notebook metadata