### PR TITLE
Add custom exporter system with template-based backends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@libsql/client": "^0.17.0",
         "@xenova/transformers": "^2.17.0",
         "date-fns": "^2.30.0",
+        "handlebars": "^4.7.8",
         "minimatch": "^9.0.0",
         "uuid": "^9.0.0",
         "zeromq": "^6.0.0-beta.19"
@@ -232,7 +233,6 @@
       "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.7.21.tgz",
       "integrity": "sha512-Vobv2/Yfnn6C6BVO/pvj7madQ7Mfzl83/jAWwixbemGF6ZThhGMz8++FD9hWHyHXDMYuLGa6fK68c2VsolZmTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
@@ -1940,7 +1940,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2487,7 +2486,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3783,7 +3781,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4622,6 +4619,27 @@
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4773,7 +4791,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5800,6 +5818,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
     },
     "node_modules/node-abi": {
       "version": "3.85.0",
@@ -6934,7 +6958,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -7229,6 +7253,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -7598,7 +7631,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7731,7 +7763,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7746,6 +7777,19 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/underscore": {
       "version": "1.13.7",
@@ -7838,7 +7882,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7932,7 +7975,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8132,6 +8174,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,11 @@
       {
         "scopeName": "scimax.latex.citations",
         "path": "./syntaxes/latex-citations.tmLanguage.json",
-        "injectTo": ["text.tex.latex", "text.tex", "source.latex"]
+        "injectTo": [
+          "text.tex.latex",
+          "text.tex",
+          "source.latex"
+        ]
       }
     ],
     "themes": [
@@ -884,6 +888,23 @@
         "command": "scimax.org.previewHtml",
         "title": "Scimax: Preview HTML",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "scimax.export.custom",
+        "title": "Scimax: Export with Custom Exporter",
+        "icon": "$(export)"
+      },
+      {
+        "command": "scimax.export.reloadCustomExporters",
+        "title": "Scimax: Reload Custom Exporters"
+      },
+      {
+        "command": "scimax.export.openExportersFolder",
+        "title": "Scimax: Open Custom Exporters Folder"
+      },
+      {
+        "command": "scimax.export.createExampleExporter",
+        "title": "Scimax: Create Example Custom Exporter"
       },
       {
         "command": "scimax.jupyter.showKernels",
@@ -4854,14 +4875,22 @@
         },
         "scimax.org.logRepeat": {
           "type": "string",
-          "enum": ["false", "time", "note"],
+          "enum": [
+            "false",
+            "time",
+            "note"
+          ],
           "default": "false",
           "markdownDescription": "Controls logging when repeating tasks cycle back to TODO:\n- `false` (default): No logging\n- `time`: Log timestamp and state change\n- `note`: Log timestamp, state change, and prompt for a note\n\nCan be overridden per-file with `#+STARTUP: logrepeat` or per-heading with `:LOGGING: logrepeat` property."
         },
         "scimax.org.logIntoDrawer": {
           "oneOf": [
-            { "type": "boolean" },
-            { "type": "string" }
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
           ],
           "default": false,
           "markdownDescription": "Where to log state changes:\n- `false` (default): Log in body text after properties\n- `true`: Log into `:LOGBOOK:` drawer\n- `\"CUSTOM\"`: Log into a custom-named drawer\n\nCan be overridden per-file with `#+STARTUP: logdrawer`."
@@ -4875,7 +4904,12 @@
         },
         "scimax.logLevel": {
           "type": "string",
-          "enum": ["debug", "info", "warn", "error"],
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
           "default": "info",
           "description": "Log level for Scimax output. 'debug' shows all messages, 'error' shows only errors. Errors are always logged regardless of this setting."
         },
@@ -5139,6 +5173,14 @@
           ],
           "default": "show",
           "markdownDescription": "How to handle editmarks during export:\n- `show`: Render with visual markup (insertions, deletions, comments)\n- `accept`: Apply all changes (keep insertions, remove deletions)\n- `reject`: Revert all changes (remove insertions, keep deletions)\n- `hide`: Remove all editmarks without any replacement"
+        },
+        "scimax.export.customExporterPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Additional directories to search for custom exporters. Each exporter should be a subdirectory containing a `manifest.json` and template files. Default locations (`~/.scimax/exporters/` and workspace `.scimax/exporters/`) are always searched.\n\nExample: `[\"/path/to/my/exporters\", \"~/custom-exporters\"]`"
         },
         "scimax.latexPreview.enabled": {
           "type": "boolean",
@@ -5715,6 +5757,7 @@
     "@libsql/client": "^0.17.0",
     "@xenova/transformers": "^2.17.0",
     "date-fns": "^2.30.0",
+    "handlebars": "^4.7.8",
     "minimatch": "^9.0.0",
     "uuid": "^9.0.0",
     "zeromq": "^6.0.0-beta.19"

--- a/src/export/__tests__/customExporter.test.ts
+++ b/src/export/__tests__/customExporter.test.ts
@@ -1,0 +1,773 @@
+/**
+ * Tests for Custom Exporter System
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+// Import the module under test
+import {
+    compileTemplate,
+    renderTemplate,
+    extractCustomKeywords,
+    ExporterRegistry,
+    getDefaultExporterPaths,
+    initializeExporterRegistry,
+    EXAMPLE_CMU_MEMO_MANIFEST,
+    EXAMPLE_CMU_MEMO_TEMPLATE,
+    TemplateContext,
+    KeywordDefinition,
+    ExporterManifest,
+} from '../customExporter';
+
+describe('Custom Exporter Template Engine', () => {
+    describe('compileTemplate', () => {
+        it('should compile a simple template', () => {
+            const template = compileTemplate('Hello {{name}}!');
+            expect(template).toBeDefined();
+            expect(typeof template).toBe('function');
+        });
+
+        it('should compile template with conditionals', () => {
+            const template = compileTemplate('{{#if show}}Visible{{/if}}');
+            expect(template).toBeDefined();
+        });
+
+        it('should compile template with each loops', () => {
+            const template = compileTemplate('{{#each items}}{{this}}{{/each}}');
+            expect(template).toBeDefined();
+        });
+    });
+
+    describe('renderTemplate', () => {
+        it('should render simple variable substitution', () => {
+            const template = compileTemplate('Hello {{name}}!');
+            const context: TemplateContext = {
+                title: '',
+                author: '',
+                date: '',
+                language: 'en',
+                body: '',
+                name: 'World',
+            };
+            const result = renderTemplate(template, context);
+            expect(result).toBe('Hello World!');
+        });
+
+        it('should render multiple variables', () => {
+            const template = compileTemplate('{{title}} by {{author}}');
+            const context: TemplateContext = {
+                title: 'My Document',
+                author: 'John Doe',
+                date: '2024-01-01',
+                language: 'en',
+                body: '',
+            };
+            const result = renderTemplate(template, context);
+            expect(result).toBe('My Document by John Doe');
+        });
+
+        it('should render conditionals with truthy values', () => {
+            const template = compileTemplate('{{#if showIntro}}Introduction{{/if}}');
+            const context: TemplateContext = {
+                title: '',
+                author: '',
+                date: '',
+                language: 'en',
+                body: '',
+                showIntro: true,
+            };
+            const result = renderTemplate(template, context);
+            expect(result).toBe('Introduction');
+        });
+
+        it('should not render conditionals with falsy values', () => {
+            const template = compileTemplate('{{#if showIntro}}Introduction{{/if}}');
+            const context: TemplateContext = {
+                title: '',
+                author: '',
+                date: '',
+                language: 'en',
+                body: '',
+                showIntro: false,
+            };
+            const result = renderTemplate(template, context);
+            expect(result).toBe('');
+        });
+
+        it('should render else branch when condition is falsy', () => {
+            const template = compileTemplate('{{#if premium}}Pro{{else}}Free{{/if}}');
+            const context: TemplateContext = {
+                title: '',
+                author: '',
+                date: '',
+                language: 'en',
+                body: '',
+                premium: false,
+            };
+            const result = renderTemplate(template, context);
+            expect(result).toBe('Free');
+        });
+
+        it('should render each loops', () => {
+            const template = compileTemplate('{{#each items}}[{{this}}]{{/each}}');
+            const context: TemplateContext = {
+                title: '',
+                author: '',
+                date: '',
+                language: 'en',
+                body: '',
+                items: ['a', 'b', 'c'],
+            };
+            const result = renderTemplate(template, context);
+            expect(result).toBe('[a][b][c]');
+        });
+
+        it('should render raw body content with triple braces', () => {
+            const template = compileTemplate('{{{body}}}');
+            const context: TemplateContext = {
+                title: '',
+                author: '',
+                date: '',
+                language: 'en',
+                body: '<div>HTML content</div>',
+            };
+            const result = renderTemplate(template, context);
+            expect(result).toBe('<div>HTML content</div>');
+        });
+
+        it('should handle missing variables gracefully', () => {
+            const template = compileTemplate('Value: {{missing}}');
+            const context: TemplateContext = {
+                title: '',
+                author: '',
+                date: '',
+                language: 'en',
+                body: '',
+            };
+            const result = renderTemplate(template, context);
+            // Handlebars returns empty string for missing variables by default
+            expect(result).toBe('Value: ');
+        });
+    });
+
+    describe('Handlebars Helpers', () => {
+        describe('default helper', () => {
+            it('should return value when present', () => {
+                const template = compileTemplate('{{default name "Anonymous"}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    name: 'John',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('John');
+            });
+
+            it('should return default when value is missing', () => {
+                const template = compileTemplate('{{default name "Anonymous"}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('Anonymous');
+            });
+
+            it('should return default when value is empty string', () => {
+                const template = compileTemplate('{{default name "Anonymous"}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    name: '',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('Anonymous');
+            });
+        });
+
+        describe('required helper', () => {
+            it('should return value when present', () => {
+                const template = compileTemplate('{{required name "name"}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    name: 'John',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('John');
+            });
+
+            it('should return NOT FOUND placeholder when missing', () => {
+                const template = compileTemplate('{{required name "name"}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('[NOT FOUND: name]');
+            });
+        });
+
+        describe('join helper', () => {
+            it('should join array with separator', () => {
+                const template = compileTemplate('{{join items ", "}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    items: ['apple', 'banana', 'cherry'],
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('apple, banana, cherry');
+            });
+
+            it('should return empty string for non-array', () => {
+                const template = compileTemplate('{{join notArray ", "}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    notArray: 'string',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('');
+            });
+        });
+
+        describe('ifeq helper', () => {
+            it('should render content when values are equal', () => {
+                const template = compileTemplate('{{#ifeq status "active"}}Active{{/ifeq}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    status: 'active',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('Active');
+            });
+
+            it('should not render content when values differ', () => {
+                const template = compileTemplate('{{#ifeq status "active"}}Active{{/ifeq}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    status: 'inactive',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('');
+            });
+        });
+
+        describe('upper/lower helpers', () => {
+            it('should convert to uppercase', () => {
+                const template = compileTemplate('{{upper name}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    name: 'hello',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('HELLO');
+            });
+
+            it('should convert to lowercase', () => {
+                const template = compileTemplate('{{lower name}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    name: 'HELLO',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe('hello');
+            });
+        });
+
+        describe('today/year helpers', () => {
+            it('should return current date in ISO format', () => {
+                const template = compileTemplate('{{today}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+            });
+
+            it('should return current year', () => {
+                const template = compileTemplate('{{year}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toBe(String(new Date().getFullYear()));
+            });
+        });
+
+        describe('latex helper', () => {
+            it('should escape special LaTeX characters', () => {
+                const template = compileTemplate('{{latex text}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    text: 'Price: $100 & 50%',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toContain('\\$');
+                expect(result).toContain('\\&');
+                expect(result).toContain('\\%');
+            });
+        });
+
+        describe('html helper', () => {
+            it('should escape HTML special characters', () => {
+                const template = compileTemplate('{{html text}}');
+                const context: TemplateContext = {
+                    title: '',
+                    author: '',
+                    date: '',
+                    language: 'en',
+                    body: '',
+                    text: '<script>alert("xss")</script>',
+                };
+                const result = renderTemplate(template, context);
+                expect(result).toContain('&lt;');
+                expect(result).toContain('&gt;');
+                expect(result).toContain('&quot;');
+            });
+        });
+    });
+});
+
+describe('extractCustomKeywords', () => {
+    // Create a minimal mock document
+    function createMockDoc(keywords: Record<string, string> = {}): any {
+        return {
+            type: 'org-data',
+            keywords,
+            children: [],
+        };
+    }
+
+    it('should extract keyword with value', () => {
+        const doc = createMockDoc({ DEPARTMENT: 'Chemical Engineering' });
+        const defs: Record<string, KeywordDefinition> = {
+            department: { description: 'Department name' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.department).toBe('Chemical Engineering');
+    });
+
+    it('should use default value when keyword is missing', () => {
+        const doc = createMockDoc({});
+        const defs: Record<string, KeywordDefinition> = {
+            department: { default: 'Default Department' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.department).toBe('Default Department');
+    });
+
+    it('should mark required missing fields with NOT FOUND', () => {
+        const doc = createMockDoc({});
+        const defs: Record<string, KeywordDefinition> = {
+            recipient: { required: true },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.recipient).toBe('[NOT FOUND: recipient]');
+    });
+
+    it('should parse boolean type', () => {
+        const doc = createMockDoc({ SIGNATURE: 'true' });
+        const defs: Record<string, KeywordDefinition> = {
+            signature: { type: 'boolean' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.signature).toBe(true);
+    });
+
+    it('should parse boolean type with "yes"', () => {
+        const doc = createMockDoc({ SIGNATURE: 'yes' });
+        const defs: Record<string, KeywordDefinition> = {
+            signature: { type: 'boolean' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.signature).toBe(true);
+    });
+
+    it('should parse boolean type with "t"', () => {
+        const doc = createMockDoc({ SIGNATURE: 't' });
+        const defs: Record<string, KeywordDefinition> = {
+            signature: { type: 'boolean' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.signature).toBe(true);
+    });
+
+    it('should parse number type', () => {
+        const doc = createMockDoc({ COUNT: '42' });
+        const defs: Record<string, KeywordDefinition> = {
+            count: { type: 'number' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.count).toBe(42);
+    });
+
+    it('should return 0 for invalid number', () => {
+        const doc = createMockDoc({ COUNT: 'not-a-number' });
+        const defs: Record<string, KeywordDefinition> = {
+            count: { type: 'number' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.count).toBe(0);
+    });
+
+    it('should handle case-insensitive keyword lookup', () => {
+        const doc = createMockDoc({ MYKEY: 'value' });
+        const defs: Record<string, KeywordDefinition> = {
+            mykey: { description: 'Test' },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.mykey).toBe('value');
+    });
+
+    it('should extract multiple keywords', () => {
+        const doc = createMockDoc({
+            TO: 'Recipient',
+            FROM: 'Sender',
+            SUBJECT: 'Test Subject',
+        });
+        const defs: Record<string, KeywordDefinition> = {
+            to: { required: true },
+            from: { required: true },
+            subject: { required: true },
+        };
+        const result = extractCustomKeywords(doc, defs);
+        expect(result.to).toBe('Recipient');
+        expect(result.from).toBe('Sender');
+        expect(result.subject).toBe('Test Subject');
+    });
+});
+
+describe('getDefaultExporterPaths', () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalXdgConfig = process.env.XDG_CONFIG_HOME;
+
+    afterEach(() => {
+        process.env.HOME = originalHome;
+        process.env.USERPROFILE = originalUserProfile;
+        process.env.XDG_CONFIG_HOME = originalXdgConfig;
+    });
+
+    it('should include ~/.scimax/exporters when HOME is set', () => {
+        process.env.HOME = '/home/testuser';
+        delete process.env.USERPROFILE;
+        delete process.env.XDG_CONFIG_HOME;
+
+        const paths = getDefaultExporterPaths();
+        expect(paths).toContain('/home/testuser/.scimax/exporters');
+    });
+
+    it('should include XDG config path when set', () => {
+        process.env.HOME = '/home/testuser';
+        process.env.XDG_CONFIG_HOME = '/home/testuser/.config';
+
+        const paths = getDefaultExporterPaths();
+        expect(paths).toContain('/home/testuser/.config/scimax/exporters');
+    });
+
+    it('should use USERPROFILE on Windows', () => {
+        delete process.env.HOME;
+        process.env.USERPROFILE = 'C:\\Users\\testuser';
+        delete process.env.XDG_CONFIG_HOME;
+
+        const paths = getDefaultExporterPaths();
+        expect(paths.some(p => p.includes('testuser'))).toBe(true);
+    });
+});
+
+describe('ExporterRegistry', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+        // Create a temporary directory for test exporters
+        tempDir = path.join(os.tmpdir(), `scimax-test-${Date.now()}`);
+        await fs.promises.mkdir(tempDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        // Clean up temporary directory
+        try {
+            await fs.promises.rm(tempDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+        // Clear the singleton
+        ExporterRegistry.getInstance().clear();
+    });
+
+    it('should be a singleton', () => {
+        const registry1 = ExporterRegistry.getInstance();
+        const registry2 = ExporterRegistry.getInstance();
+        expect(registry1).toBe(registry2);
+    });
+
+    it('should load exporter from directory', async () => {
+        // Create a test exporter
+        const exporterDir = path.join(tempDir, 'test-exporter');
+        await fs.promises.mkdir(exporterDir);
+
+        const manifest: ExporterManifest = {
+            id: 'test-exporter',
+            name: 'Test Exporter',
+            parent: 'latex',
+            outputFormat: 'tex',
+            template: 'template.tex',
+        };
+
+        await fs.promises.writeFile(
+            path.join(exporterDir, 'manifest.json'),
+            JSON.stringify(manifest)
+        );
+        await fs.promises.writeFile(
+            path.join(exporterDir, 'template.tex'),
+            '\\documentclass{article}\n{{body}}'
+        );
+
+        const registry = ExporterRegistry.getInstance();
+        await registry.loadFromDirectory(tempDir);
+
+        expect(registry.has('test-exporter')).toBe(true);
+        const exporter = registry.get('test-exporter');
+        expect(exporter?.name).toBe('Test Exporter');
+    });
+
+    it('should handle missing directory gracefully', async () => {
+        const registry = ExporterRegistry.getInstance();
+        await registry.loadFromDirectory('/nonexistent/path');
+        // Should not throw
+        expect(registry.getAll()).toHaveLength(0);
+    });
+
+    it('should skip invalid exporters without crashing', async () => {
+        // Create an invalid exporter (missing template)
+        const exporterDir = path.join(tempDir, 'invalid-exporter');
+        await fs.promises.mkdir(exporterDir);
+
+        await fs.promises.writeFile(
+            path.join(exporterDir, 'manifest.json'),
+            JSON.stringify({
+                id: 'invalid',
+                name: 'Invalid',
+                parent: 'latex',
+                outputFormat: 'tex',
+                template: 'missing.tex',
+            })
+        );
+
+        const registry = ExporterRegistry.getInstance();
+        await registry.loadFromDirectory(tempDir);
+
+        // Should not have loaded the invalid exporter
+        expect(registry.has('invalid')).toBe(false);
+    });
+
+    it('should clear all exporters', async () => {
+        const exporterDir = path.join(tempDir, 'test-exporter');
+        await fs.promises.mkdir(exporterDir);
+
+        await fs.promises.writeFile(
+            path.join(exporterDir, 'manifest.json'),
+            JSON.stringify({
+                id: 'test',
+                name: 'Test',
+                parent: 'latex',
+                outputFormat: 'tex',
+                template: 'template.tex',
+            })
+        );
+        await fs.promises.writeFile(
+            path.join(exporterDir, 'template.tex'),
+            '{{body}}'
+        );
+
+        const registry = ExporterRegistry.getInstance();
+        await registry.loadFromDirectory(tempDir);
+        expect(registry.getAll().length).toBeGreaterThan(0);
+
+        registry.clear();
+        expect(registry.getAll()).toHaveLength(0);
+    });
+});
+
+describe('Example Templates', () => {
+    it('should have valid CMU Memo manifest', () => {
+        expect(EXAMPLE_CMU_MEMO_MANIFEST.id).toBe('cmu-memo');
+        expect(EXAMPLE_CMU_MEMO_MANIFEST.parent).toBe('latex');
+        expect(EXAMPLE_CMU_MEMO_MANIFEST.outputFormat).toBe('pdf');
+        expect(EXAMPLE_CMU_MEMO_MANIFEST.keywords).toBeDefined();
+        expect(EXAMPLE_CMU_MEMO_MANIFEST.keywords?.to?.required).toBe(true);
+        expect(EXAMPLE_CMU_MEMO_MANIFEST.keywords?.from?.required).toBe(true);
+        expect(EXAMPLE_CMU_MEMO_MANIFEST.keywords?.department?.default).toBeDefined();
+    });
+
+    it('should have valid CMU Memo template', () => {
+        expect(EXAMPLE_CMU_MEMO_TEMPLATE).toContain('\\documentclass');
+        expect(EXAMPLE_CMU_MEMO_TEMPLATE).toContain('{{department}}');
+        expect(EXAMPLE_CMU_MEMO_TEMPLATE).toContain('{{to}}');
+        expect(EXAMPLE_CMU_MEMO_TEMPLATE).toContain('{{from}}');
+        expect(EXAMPLE_CMU_MEMO_TEMPLATE).toContain('{{{body}}}');
+        expect(EXAMPLE_CMU_MEMO_TEMPLATE).toContain('{{#if signatureLines}}');
+    });
+
+    it('should compile CMU Memo template without errors', () => {
+        const template = compileTemplate(EXAMPLE_CMU_MEMO_TEMPLATE);
+        expect(template).toBeDefined();
+
+        // Render with minimal context
+        const context: TemplateContext = {
+            title: 'Test',
+            author: 'Test Author',
+            date: '2024-01-01',
+            language: 'en',
+            body: 'Test body content',
+            department: 'Test Department',
+            to: 'Recipient',
+            from: 'Sender',
+            subject: 'Test Subject',
+            signatureLines: true,
+        };
+
+        const result = renderTemplate(template, context);
+        expect(result).toContain('\\documentclass');
+        expect(result).toContain('Test Department');
+        expect(result).toContain('Recipient');
+        expect(result).toContain('Sender');
+        expect(result).toContain('Test body content');
+        expect(result).toContain('\\signaturelines');
+    });
+});
+
+describe('Integration: Full Export Flow', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+        tempDir = path.join(os.tmpdir(), `scimax-test-${Date.now()}`);
+        await fs.promises.mkdir(tempDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        try {
+            await fs.promises.rm(tempDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+        ExporterRegistry.getInstance().clear();
+    });
+
+    it('should load and execute a custom exporter', async () => {
+        // Create a simple test exporter
+        const exporterDir = path.join(tempDir, 'simple-letter');
+        await fs.promises.mkdir(exporterDir);
+
+        const manifest: ExporterManifest = {
+            id: 'simple-letter',
+            name: 'Simple Letter',
+            parent: 'latex',
+            outputFormat: 'tex',
+            template: 'template.tex',
+            keywords: {
+                recipient: { required: true },
+                greeting: { default: 'Dear' },
+            },
+        };
+
+        const templateContent = `\\documentclass{letter}
+\\begin{document}
+{{greeting}} {{recipient}},
+
+{{{body}}}
+
+Sincerely,
+{{author}}
+\\end{document}`;
+
+        await fs.promises.writeFile(
+            path.join(exporterDir, 'manifest.json'),
+            JSON.stringify(manifest, null, 2)
+        );
+        await fs.promises.writeFile(
+            path.join(exporterDir, 'template.tex'),
+            templateContent
+        );
+
+        // Load the exporter
+        const registry = ExporterRegistry.getInstance();
+        await registry.loadFromDirectory(tempDir);
+
+        // Verify it loaded
+        expect(registry.has('simple-letter')).toBe(true);
+
+        // Get the exporter and render
+        const exporter = registry.get('simple-letter')!;
+        const context: TemplateContext = {
+            title: 'Letter',
+            author: 'John Doe',
+            date: '2024-01-01',
+            language: 'en',
+            body: 'This is the letter body.',
+            recipient: 'Jane Smith',
+            greeting: 'Hello',
+        };
+
+        const result = renderTemplate(exporter.compiledTemplate, context);
+
+        expect(result).toContain('\\documentclass{letter}');
+        expect(result).toContain('Hello Jane Smith');
+        expect(result).toContain('This is the letter body.');
+        expect(result).toContain('John Doe');
+    });
+});

--- a/src/export/commands.ts
+++ b/src/export/commands.ts
@@ -1,0 +1,367 @@
+/**
+ * VS Code Commands for Custom Exporters
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { spawn } from 'child_process';
+import {
+    ExporterRegistry,
+    executeCustomExport,
+    initializeExporterRegistry,
+    getDefaultExporterPaths,
+    EXAMPLE_CMU_MEMO_MANIFEST,
+    EXAMPLE_CMU_MEMO_TEMPLATE,
+} from './customExporter';
+
+/**
+ * Get custom exporter search paths from settings
+ */
+function getExporterSearchPaths(): string[] {
+    const config = vscode.workspace.getConfiguration('scimax.export');
+    const additionalPaths = config.get<string[]>('customExporterPaths', []);
+
+    // Expand ~ in paths
+    const homeDir = process.env.HOME || process.env.USERPROFILE || '';
+    const expandedPaths = additionalPaths.map(p =>
+        p.startsWith('~') ? p.replace('~', homeDir) : p
+    );
+
+    // Add workspace .scimax/exporters if exists
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (workspaceFolder) {
+        expandedPaths.push(path.join(workspaceFolder.uri.fsPath, '.scimax', 'exporters'));
+    }
+
+    return expandedPaths;
+}
+
+/**
+ * Reload the exporter registry
+ */
+async function reloadExporters(): Promise<void> {
+    const additionalPaths = getExporterSearchPaths();
+    await initializeExporterRegistry(additionalPaths);
+
+    const registry = ExporterRegistry.getInstance();
+    const count = registry.getAll().length;
+
+    if (count > 0) {
+        vscode.window.showInformationMessage(`Loaded ${count} custom exporter(s)`);
+    }
+}
+
+/**
+ * Show picker for custom exporters
+ */
+async function showCustomExportPicker(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'org') {
+        vscode.window.showWarningMessage('No org-mode file open');
+        return;
+    }
+
+    const registry = ExporterRegistry.getInstance();
+    const exporters = registry.getAll();
+
+    if (exporters.length === 0) {
+        const action = await vscode.window.showWarningMessage(
+            'No custom exporters found. Would you like to create one?',
+            'Create Example',
+            'Open Exporters Folder'
+        );
+
+        if (action === 'Create Example') {
+            await createExampleExporter();
+        } else if (action === 'Open Exporters Folder') {
+            await openExportersFolder();
+        }
+        return;
+    }
+
+    // Build picker items
+    const items = exporters.map(exp => ({
+        label: `$(file-text) ${exp.name}`,
+        description: exp.description || '',
+        detail: `Output: ${exp.outputFormat.toUpperCase()} via ${exp.parent}`,
+        exporter: exp,
+    }));
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Select custom exporter',
+        title: 'Custom Export',
+    });
+
+    if (!selected) return;
+
+    // Execute the export
+    await executeCustomExportCommand(selected.exporter.id);
+}
+
+/**
+ * Execute a custom export by exporter ID
+ */
+async function executeCustomExportCommand(exporterId: string): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'org') {
+        vscode.window.showWarningMessage('No org-mode file open');
+        return;
+    }
+
+    const registry = ExporterRegistry.getInstance();
+    const exporter = registry.get(exporterId);
+
+    if (!exporter) {
+        vscode.window.showErrorMessage(`Custom exporter not found: ${exporterId}`);
+        return;
+    }
+
+    const inputPath = editor.document.uri.fsPath;
+    const inputDir = path.dirname(inputPath);
+    const inputName = path.basename(inputPath, '.org');
+    const content = editor.document.getText();
+
+    // Determine output extension
+    const outputExt = exporter.outputFormat === 'pdf' ? '.tex' : `.${exporter.outputFormat}`;
+    const outputPath = path.join(inputDir, `${inputName}${outputExt}`);
+
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title: `Exporting with ${exporter.name}...`,
+            cancellable: false,
+        },
+        async () => {
+            try {
+                const result = await executeCustomExport(exporterId, content);
+
+                // Write output file
+                await fs.promises.writeFile(outputPath, result, 'utf-8');
+
+                // If PDF output, compile LaTeX
+                if (exporter.outputFormat === 'pdf') {
+                    const pdfPath = outputPath.replace(/\.tex$/, '.pdf');
+                    await compileToPdf(outputPath, pdfPath, inputDir);
+
+                    const action = await vscode.window.showInformationMessage(
+                        `Exported to ${path.basename(pdfPath)}`,
+                        'Open PDF',
+                        'Open LaTeX'
+                    );
+
+                    if (action === 'Open PDF') {
+                        await vscode.env.openExternal(vscode.Uri.file(pdfPath));
+                    } else if (action === 'Open LaTeX') {
+                        const doc = await vscode.workspace.openTextDocument(outputPath);
+                        await vscode.window.showTextDocument(doc);
+                    }
+                } else {
+                    const action = await vscode.window.showInformationMessage(
+                        `Exported to ${path.basename(outputPath)}`,
+                        'Open'
+                    );
+
+                    if (action === 'Open') {
+                        const doc = await vscode.workspace.openTextDocument(outputPath);
+                        await vscode.window.showTextDocument(doc);
+                    }
+                }
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Export failed: ${message}`);
+            }
+        }
+    );
+}
+
+/**
+ * Compile LaTeX to PDF using system LaTeX compiler
+ */
+async function compileToPdf(texPath: string, pdfPath: string, cwd: string): Promise<void> {
+    const config = vscode.workspace.getConfiguration('scimax.export.pdf');
+    const compiler = config.get<string>('compiler', 'latexmk-lualatex');
+
+    // Build command
+    let command: string;
+    let args: string[];
+
+    switch (compiler) {
+        case 'latexmk-lualatex':
+            command = 'latexmk';
+            args = ['-lualatex', '-interaction=nonstopmode', texPath];
+            break;
+        case 'latexmk-pdflatex':
+            command = 'latexmk';
+            args = ['-pdf', '-interaction=nonstopmode', texPath];
+            break;
+        case 'latexmk-xelatex':
+            command = 'latexmk';
+            args = ['-xelatex', '-interaction=nonstopmode', texPath];
+            break;
+        case 'pdflatex':
+            command = 'pdflatex';
+            args = ['-interaction=nonstopmode', texPath];
+            break;
+        case 'lualatex':
+            command = 'lualatex';
+            args = ['-interaction=nonstopmode', texPath];
+            break;
+        case 'xelatex':
+            command = 'xelatex';
+            args = ['-interaction=nonstopmode', texPath];
+            break;
+        default:
+            command = 'latexmk';
+            args = ['-lualatex', '-interaction=nonstopmode', texPath];
+    }
+
+    // Read TEXMFHOME from environment (per user's guidance)
+    const env = { ...process.env };
+
+    return new Promise((resolve, reject) => {
+        const proc = spawn(command, args, { cwd, env });
+
+        let stdout = '';
+        let stderr = '';
+
+        proc.stdout?.on('data', (data: Buffer) => {
+            stdout += data.toString();
+        });
+
+        proc.stderr?.on('data', (data: Buffer) => {
+            stderr += data.toString();
+        });
+
+        proc.on('close', (code) => {
+            if (code === 0 || fs.existsSync(pdfPath)) {
+                resolve();
+            } else {
+                reject(new Error(`LaTeX compilation failed: ${stderr || stdout}`));
+            }
+        });
+
+        proc.on('error', reject);
+    });
+}
+
+/**
+ * Open the exporters folder
+ */
+async function openExportersFolder(): Promise<void> {
+    const paths = getDefaultExporterPaths();
+    const exportersDir = paths[0]; // Use first default path
+
+    // Create directory if it doesn't exist
+    if (!fs.existsSync(exportersDir)) {
+        await fs.promises.mkdir(exportersDir, { recursive: true });
+    }
+
+    await vscode.env.openExternal(vscode.Uri.file(exportersDir));
+}
+
+/**
+ * Create an example exporter
+ */
+async function createExampleExporter(): Promise<void> {
+    const paths = getDefaultExporterPaths();
+    const exportersDir = paths[0];
+
+    // Create the example exporter directory
+    const exampleDir = path.join(exportersDir, 'cmu-memo');
+
+    if (fs.existsSync(exampleDir)) {
+        vscode.window.showInformationMessage('Example exporter already exists');
+        return;
+    }
+
+    await fs.promises.mkdir(exampleDir, { recursive: true });
+
+    // Write manifest
+    await fs.promises.writeFile(
+        path.join(exampleDir, 'manifest.json'),
+        JSON.stringify(EXAMPLE_CMU_MEMO_MANIFEST, null, 2),
+        'utf-8'
+    );
+
+    // Write template
+    await fs.promises.writeFile(
+        path.join(exampleDir, 'template.tex'),
+        EXAMPLE_CMU_MEMO_TEMPLATE,
+        'utf-8'
+    );
+
+    // Reload exporters
+    await reloadExporters();
+
+    // Open the example directory
+    const action = await vscode.window.showInformationMessage(
+        'Created example CMU Memo exporter',
+        'Open Template',
+        'Open Folder'
+    );
+
+    if (action === 'Open Template') {
+        const doc = await vscode.workspace.openTextDocument(
+            path.join(exampleDir, 'template.tex')
+        );
+        await vscode.window.showTextDocument(doc);
+    } else if (action === 'Open Folder') {
+        await vscode.env.openExternal(vscode.Uri.file(exampleDir));
+    }
+}
+
+/**
+ * Register VS Code commands for custom exporters
+ */
+export function registerCustomExportCommands(context: vscode.ExtensionContext): void {
+    // Initialize registry on extension activation
+    const additionalPaths = getExporterSearchPaths();
+    initializeExporterRegistry(additionalPaths).catch(console.error);
+
+    // Show custom export picker
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'scimax.export.custom',
+            showCustomExportPicker
+        )
+    );
+
+    // Reload exporters
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'scimax.export.reloadCustomExporters',
+            reloadExporters
+        )
+    );
+
+    // Open exporters folder
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'scimax.export.openExportersFolder',
+            openExportersFolder
+        )
+    );
+
+    // Create example exporter
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'scimax.export.createExampleExporter',
+            createExampleExporter
+        )
+    );
+
+    // Execute specific exporter by ID
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'scimax.export.customById',
+            async (exporterId: string) => {
+                if (exporterId) {
+                    await executeCustomExportCommand(exporterId);
+                } else {
+                    await showCustomExportPicker();
+                }
+            }
+        )
+    );
+}

--- a/src/export/customExporter.ts
+++ b/src/export/customExporter.ts
@@ -1,0 +1,715 @@
+/**
+ * Custom Exporter System
+ *
+ * Allows users to define custom export backends via templates and manifests.
+ * Uses the same template syntax as the existing template system for consistency:
+ * - {{variable}} for simple substitution
+ * - {{#if variable}}...{{/if}} for conditionals
+ * - {{#each items}}...{{/each}} for iteration
+ *
+ * Directory structure:
+ *   ~/.scimax/exporters/
+ *   ├── cmu-memo/
+ *   │   ├── manifest.json
+ *   │   └── template.tex
+ *   └── journal-article/
+ *       ├── manifest.json
+ *       └── template.tex
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { OrgDocumentNode } from '../parser/orgElementTypes';
+import { parseOrgFast } from '../parser/orgExportParser';
+import { exportToLatex, LatexExportOptions } from '../parser/orgExportLatex';
+import { exportToHtml, HtmlExportOptions } from '../parser/orgExportHtml';
+import { escapeString } from '../parser/orgExport';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Keyword definition in manifest
+ */
+export interface KeywordDefinition {
+    /** Default value if not specified in document */
+    default?: string;
+    /** Whether this keyword is required */
+    required?: boolean;
+    /** Type of the value */
+    type?: 'string' | 'boolean' | 'number';
+    /** Description for documentation */
+    description?: string;
+}
+
+/**
+ * Custom exporter manifest (manifest.json)
+ */
+export interface ExporterManifest {
+    /** Unique identifier (e.g., "cmu-memo") */
+    id: string;
+    /** Display name (e.g., "CMU Memo") */
+    name: string;
+    /** Description */
+    description?: string;
+    /** Parent backend to derive from */
+    parent: 'latex' | 'html' | 'markdown';
+    /** Output format */
+    outputFormat: 'tex' | 'pdf' | 'html' | 'md';
+
+    /** Custom keyword definitions */
+    keywords?: Record<string, KeywordDefinition>;
+
+    /** Path to template file (relative to manifest) */
+    template: string;
+    /** Optional path to preamble file (LaTeX only) */
+    preamble?: string;
+
+    /** LaTeX-specific options */
+    latexOptions?: {
+        documentClass?: string;
+        classOptions?: string[];
+        packages?: string[];
+    };
+}
+
+/**
+ * Loaded custom exporter with resolved paths
+ */
+export interface CustomExporter extends ExporterManifest {
+    /** Absolute path to the exporter directory */
+    basePath: string;
+    /** Raw template content */
+    templateContent: string;
+    /** Preamble content (if any) */
+    preambleContent?: string;
+}
+
+/**
+ * Template context passed to the template engine
+ */
+export interface TemplateContext {
+    // Standard org fields
+    title: string;
+    author: string;
+    date: string;
+    language: string;
+
+    // The exported body content
+    body: string;
+
+    // LaTeX-specific
+    preamble?: string;
+    documentClass?: string;
+    classOptions?: string;
+
+    // Custom keywords from document
+    [key: string]: string | boolean | number | string[] | undefined;
+}
+
+// =============================================================================
+// Template Engine (matches existing {{variable}} syntax)
+// =============================================================================
+
+/**
+ * Simple template engine matching the existing template system syntax
+ *
+ * Supported syntax:
+ * - {{variable}} - Simple substitution
+ * - {{#if variable}}...{{/if}} - Conditional (truthy check)
+ * - {{#unless variable}}...{{/unless}} - Inverse conditional
+ * - {{#each items}}{{this}}{{/each}} - Iteration over arrays
+ * - {{latex variable}} - Escape for LaTeX
+ * - {{html variable}} - Escape for HTML
+ * - {{default variable "fallback"}} - Default value
+ */
+export function renderTemplate(template: string, context: TemplateContext): string {
+    let result = template;
+
+    // Process {{#each items}}...{{/each}} blocks first
+    result = processEachBlocks(result, context);
+
+    // Process {{#if variable}}...{{/if}} blocks
+    result = processIfBlocks(result, context);
+
+    // Process {{#unless variable}}...{{/unless}} blocks
+    result = processUnlessBlocks(result, context);
+
+    // Process {{default variable "fallback"}} helpers
+    result = processDefaultHelpers(result, context);
+
+    // Process {{latex variable}} and {{html variable}} helpers
+    result = processEscapeHelpers(result, context);
+
+    // Process simple {{variable}} substitutions last
+    result = processSimpleSubstitutions(result, context);
+
+    return result;
+}
+
+/**
+ * Process {{#each items}}...{{/each}} blocks
+ */
+function processEachBlocks(template: string, context: TemplateContext): string {
+    const eachPattern = /\{\{#each\s+(\w+)\}\}([\s\S]*?)\{\{\/each\}\}/g;
+
+    return template.replace(eachPattern, (_, varName, content) => {
+        const value = context[varName];
+        if (!Array.isArray(value) || value.length === 0) {
+            return '';
+        }
+
+        return value
+            .map(item => {
+                // Replace {{this}} with the current item
+                let itemContent = content.replace(/\{\{this\}\}/g, String(item));
+                // Also support {{.}} as alias for {{this}}
+                itemContent = itemContent.replace(/\{\{\.\}\}/g, String(item));
+                return itemContent;
+            })
+            .join('');
+    });
+}
+
+/**
+ * Process {{#if variable}}...{{/if}} blocks (with optional {{else}})
+ */
+function processIfBlocks(template: string, context: TemplateContext): string {
+    // Pattern with optional else clause
+    const ifElsePattern = /\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{else\}\}([\s\S]*?)\{\{\/if\}\}/g;
+    let result = template.replace(ifElsePattern, (_, varName, ifContent, elseContent) => {
+        const value = context[varName];
+        return isTruthy(value) ? ifContent : elseContent;
+    });
+
+    // Pattern without else clause
+    const ifPattern = /\{\{#if\s+(\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g;
+    result = result.replace(ifPattern, (_, varName, content) => {
+        const value = context[varName];
+        return isTruthy(value) ? content : '';
+    });
+
+    return result;
+}
+
+/**
+ * Process {{#unless variable}}...{{/unless}} blocks
+ */
+function processUnlessBlocks(template: string, context: TemplateContext): string {
+    const unlessPattern = /\{\{#unless\s+(\w+)\}\}([\s\S]*?)\{\{\/unless\}\}/g;
+
+    return template.replace(unlessPattern, (_, varName, content) => {
+        const value = context[varName];
+        return isTruthy(value) ? '' : content;
+    });
+}
+
+/**
+ * Process {{default variable "fallback"}} helpers
+ */
+function processDefaultHelpers(template: string, context: TemplateContext): string {
+    const defaultPattern = /\{\{default\s+(\w+)\s+"([^"]*)"\}\}/g;
+
+    return template.replace(defaultPattern, (_, varName, fallback) => {
+        const value = context[varName];
+        if (value === undefined || value === null || value === '') {
+            return fallback;
+        }
+        return String(value);
+    });
+}
+
+/**
+ * Process {{latex variable}} and {{html variable}} escape helpers
+ */
+function processEscapeHelpers(template: string, context: TemplateContext): string {
+    // {{latex variable}} - escape for LaTeX
+    const latexPattern = /\{\{latex\s+(\w+)\}\}/g;
+    let result = template.replace(latexPattern, (_, varName) => {
+        const value = context[varName];
+        if (value === undefined || value === null) {
+            return '';
+        }
+        return escapeString(String(value), 'latex');
+    });
+
+    // {{html variable}} - escape for HTML
+    const htmlPattern = /\{\{html\s+(\w+)\}\}/g;
+    result = result.replace(htmlPattern, (_, varName) => {
+        const value = context[varName];
+        if (value === undefined || value === null) {
+            return '';
+        }
+        return escapeString(String(value), 'html');
+    });
+
+    return result;
+}
+
+/**
+ * Process simple {{variable}} substitutions
+ */
+function processSimpleSubstitutions(template: string, context: TemplateContext): string {
+    const simplePattern = /\{\{(\w+)\}\}/g;
+
+    return template.replace(simplePattern, (match, varName) => {
+        const value = context[varName];
+        if (value === undefined || value === null) {
+            // Return placeholder for missing values
+            return `[NOT FOUND: ${varName}]`;
+        }
+        if (typeof value === 'boolean') {
+            return value ? 'true' : 'false';
+        }
+        if (Array.isArray(value)) {
+            return value.join(', ');
+        }
+        return String(value);
+    });
+}
+
+/**
+ * Check if a value is truthy for template conditionals
+ */
+function isTruthy(value: unknown): boolean {
+    if (value === undefined || value === null) {
+        return false;
+    }
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    return true;
+}
+
+// =============================================================================
+// Keyword Extraction
+// =============================================================================
+
+/**
+ * Extract custom keywords from an org document
+ */
+export function extractCustomKeywords(
+    doc: OrgDocumentNode,
+    keywordDefs: Record<string, KeywordDefinition>
+): Record<string, string | boolean | number> {
+    const result: Record<string, string | boolean | number> = {};
+
+    for (const [key, def] of Object.entries(keywordDefs)) {
+        const upperKey = key.toUpperCase();
+        let value: string | undefined;
+
+        // Check document keywords map first
+        if (doc.keywords?.[upperKey]) {
+            value = doc.keywords[upperKey];
+        }
+
+        // Also check section keywords (preamble)
+        if (!value && doc.section?.children) {
+            for (const elem of doc.section.children) {
+                if (elem.type === 'keyword') {
+                    const kwKey = (elem as any).properties?.key?.toUpperCase();
+                    const kwValue = (elem as any).properties?.value;
+                    if (kwKey === upperKey && kwValue) {
+                        value = kwValue;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Parse value according to type
+        if (value !== undefined) {
+            result[key] = parseKeywordValue(value, def.type);
+        } else if (def.default !== undefined) {
+            result[key] = parseKeywordValue(def.default, def.type);
+        } else if (def.required) {
+            // Insert NOT FOUND placeholder for required missing fields
+            result[key] = `[NOT FOUND: ${key}]`;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Parse a keyword value to the appropriate type
+ */
+function parseKeywordValue(
+    value: string,
+    type?: 'string' | 'boolean' | 'number'
+): string | boolean | number {
+    switch (type) {
+        case 'boolean':
+            return value.toLowerCase() === 'true' ||
+                   value.toLowerCase() === 'yes' ||
+                   value.toLowerCase() === 't' ||
+                   value === '1';
+        case 'number':
+            const num = parseFloat(value);
+            return isNaN(num) ? 0 : num;
+        default:
+            return value;
+    }
+}
+
+// =============================================================================
+// Exporter Registry
+// =============================================================================
+
+/**
+ * Registry of loaded custom exporters
+ */
+class ExporterRegistry {
+    private exporters: Map<string, CustomExporter> = new Map();
+    private static instance: ExporterRegistry;
+
+    private constructor() {}
+
+    static getInstance(): ExporterRegistry {
+        if (!ExporterRegistry.instance) {
+            ExporterRegistry.instance = new ExporterRegistry();
+        }
+        return ExporterRegistry.instance;
+    }
+
+    /**
+     * Load exporters from a directory
+     */
+    async loadFromDirectory(dirPath: string): Promise<void> {
+        try {
+            const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+
+            for (const entry of entries) {
+                if (entry.isDirectory()) {
+                    const exporterPath = path.join(dirPath, entry.name);
+                    try {
+                        const exporter = await this.loadExporter(exporterPath);
+                        this.exporters.set(exporter.id, exporter);
+                    } catch (error) {
+                        console.warn(`Failed to load exporter from ${exporterPath}:`, error);
+                    }
+                }
+            }
+        } catch (error) {
+            // Directory doesn't exist or can't be read - skip silently
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                console.warn(`Failed to read exporter directory ${dirPath}:`, error);
+            }
+        }
+    }
+
+    /**
+     * Load a single exporter from a directory
+     */
+    async loadExporter(exporterPath: string): Promise<CustomExporter> {
+        const manifestPath = path.join(exporterPath, 'manifest.json');
+
+        // Read and parse manifest
+        const manifestContent = await fs.promises.readFile(manifestPath, 'utf-8');
+        const manifest: ExporterManifest = JSON.parse(manifestContent);
+
+        // Validate required fields
+        if (!manifest.id) throw new Error('Manifest missing required field: id');
+        if (!manifest.name) throw new Error('Manifest missing required field: name');
+        if (!manifest.parent) throw new Error('Manifest missing required field: parent');
+        if (!manifest.outputFormat) throw new Error('Manifest missing required field: outputFormat');
+        if (!manifest.template) throw new Error('Manifest missing required field: template');
+
+        // Load template
+        const templatePath = path.join(exporterPath, manifest.template);
+        const templateContent = await fs.promises.readFile(templatePath, 'utf-8');
+
+        // Load preamble if specified
+        let preambleContent: string | undefined;
+        if (manifest.preamble) {
+            const preamblePath = path.join(exporterPath, manifest.preamble);
+            try {
+                preambleContent = await fs.promises.readFile(preamblePath, 'utf-8');
+            } catch {
+                // Preamble file doesn't exist - ignore
+            }
+        }
+
+        return {
+            ...manifest,
+            basePath: exporterPath,
+            templateContent,
+            preambleContent,
+        };
+    }
+
+    /**
+     * Register an exporter directly
+     */
+    register(exporter: CustomExporter): void {
+        this.exporters.set(exporter.id, exporter);
+    }
+
+    /**
+     * Get an exporter by ID
+     */
+    get(id: string): CustomExporter | undefined {
+        return this.exporters.get(id);
+    }
+
+    /**
+     * Get all registered exporters
+     */
+    getAll(): CustomExporter[] {
+        return Array.from(this.exporters.values());
+    }
+
+    /**
+     * Check if an exporter exists
+     */
+    has(id: string): boolean {
+        return this.exporters.has(id);
+    }
+
+    /**
+     * Clear all exporters (useful for reloading)
+     */
+    clear(): void {
+        this.exporters.clear();
+    }
+}
+
+export { ExporterRegistry };
+
+// =============================================================================
+// Export Execution
+// =============================================================================
+
+/**
+ * Execute a custom export
+ */
+export async function executeCustomExport(
+    exporterId: string,
+    content: string,
+    options?: {
+        bodyOnly?: boolean;
+    }
+): Promise<string> {
+    const registry = ExporterRegistry.getInstance();
+    const exporter = registry.get(exporterId);
+
+    if (!exporter) {
+        throw new Error(`Custom exporter not found: ${exporterId}`);
+    }
+
+    // Parse the org document
+    const doc = parseOrgFast(content);
+
+    // Extract standard metadata
+    const title = doc.keywords?.TITLE || '';
+    const author = doc.keywords?.AUTHOR || '';
+    const date = doc.keywords?.DATE || new Date().toISOString().split('T')[0];
+    const language = doc.keywords?.LANGUAGE || 'en';
+
+    // Extract custom keywords
+    const customKeywords = exporter.keywords
+        ? extractCustomKeywords(doc, exporter.keywords)
+        : {};
+
+    // Generate the body using the parent backend
+    let body: string;
+    switch (exporter.parent) {
+        case 'latex': {
+            const latexOpts: Partial<LatexExportOptions> = {
+                title,
+                author,
+                date,
+                language,
+                bodyOnly: true, // Always get just the body for templates
+                documentClass: exporter.latexOptions?.documentClass,
+                classOptions: exporter.latexOptions?.classOptions,
+            };
+            body = exportToLatex(doc, latexOpts);
+            break;
+        }
+        case 'html': {
+            const htmlOpts: Partial<HtmlExportOptions> = {
+                title,
+                author,
+                date,
+                language,
+                bodyOnly: true,
+            };
+            body = exportToHtml(doc, htmlOpts);
+            break;
+        }
+        case 'markdown':
+            // For markdown, we'd need a markdown exporter
+            // For now, just use the raw content after removing keywords
+            body = content.replace(/^#\+[A-Z_]+:.*$/gm, '').trim();
+            break;
+        default:
+            throw new Error(`Unknown parent backend: ${exporter.parent}`);
+    }
+
+    // Build template context
+    const context: TemplateContext = {
+        title,
+        author,
+        date,
+        language,
+        body,
+        preamble: exporter.preambleContent,
+        documentClass: exporter.latexOptions?.documentClass,
+        classOptions: exporter.latexOptions?.classOptions?.join(', '),
+        ...customKeywords,
+    };
+
+    // Render the template
+    return renderTemplate(exporter.templateContent, context);
+}
+
+// =============================================================================
+// Discovery Paths
+// =============================================================================
+
+/**
+ * Get the default exporter discovery paths
+ */
+export function getDefaultExporterPaths(): string[] {
+    const paths: string[] = [];
+
+    // User home directory
+    const homeDir = process.env.HOME || process.env.USERPROFILE;
+    if (homeDir) {
+        paths.push(path.join(homeDir, '.scimax', 'exporters'));
+    }
+
+    // XDG config directory
+    const xdgConfig = process.env.XDG_CONFIG_HOME;
+    if (xdgConfig) {
+        paths.push(path.join(xdgConfig, 'scimax', 'exporters'));
+    }
+
+    return paths;
+}
+
+/**
+ * Initialize the exporter registry with default paths
+ */
+export async function initializeExporterRegistry(
+    additionalPaths?: string[]
+): Promise<ExporterRegistry> {
+    const registry = ExporterRegistry.getInstance();
+    registry.clear();
+
+    const paths = [...getDefaultExporterPaths(), ...(additionalPaths || [])];
+
+    for (const searchPath of paths) {
+        await registry.loadFromDirectory(searchPath);
+    }
+
+    return registry;
+}
+
+// =============================================================================
+// Utility: Create example exporter structure
+// =============================================================================
+
+/**
+ * Example manifest for CMU Memo exporter
+ */
+export const EXAMPLE_CMU_MEMO_MANIFEST: ExporterManifest = {
+    id: 'cmu-memo',
+    name: 'CMU Memo',
+    description: 'Carnegie Mellon University internal memo format',
+    parent: 'latex',
+    outputFormat: 'pdf',
+
+    keywords: {
+        department: {
+            default: 'Department of Chemical Engineering',
+            description: 'Originating department',
+        },
+        to: {
+            required: true,
+            description: 'Memo recipient',
+        },
+        from: {
+            required: true,
+            description: 'Memo sender',
+        },
+        subject: {
+            required: true,
+            description: 'Memo subject',
+        },
+        cc: {
+            default: '',
+            description: 'Carbon copy recipients',
+        },
+        signatureLines: {
+            type: 'boolean',
+            default: 'true',
+            description: 'Include signature lines',
+        },
+    },
+
+    template: 'template.tex',
+
+    latexOptions: {
+        documentClass: 'letter',
+        classOptions: ['12pt'],
+    },
+};
+
+/**
+ * Example template for CMU Memo
+ */
+export const EXAMPLE_CMU_MEMO_TEMPLATE = `% CMU Memo Template
+\\documentclass[{{default classOptions "12pt"}}]{letter}
+\\usepackage[utf8]{inputenc}
+\\usepackage{geometry}
+\\geometry{margin=1in}
+
+% Custom memo commands
+\\newcommand{\\memoto}[1]{\\textbf{TO:} #1\\\\}
+\\newcommand{\\memofrom}[1]{\\textbf{FROM:} #1\\\\}
+\\newcommand{\\memosubject}[1]{\\textbf{SUBJECT:} #1\\\\}
+\\newcommand{\\memodept}[1]{\\textbf{DEPARTMENT:} #1\\\\}
+\\newcommand{\\memocc}[1]{\\textbf{CC:} #1\\\\}
+\\newcommand{\\signaturelines}{%
+  \\vspace{2em}
+  \\rule{3in}{0.4pt}\\\\
+  Signature
+}
+
+\\begin{document}
+
+\\begin{letter}{ }
+
+\\memodept{{{department}}}
+\\memoto{{{to}}}
+\\memofrom{{{from}}}
+\\memosubject{{{subject}}}
+{{#if cc}}
+\\memocc{{{cc}}}
+{{/if}}
+
+\\vspace{1em}
+\\hrule
+\\vspace{1em}
+
+{{body}}
+
+{{#if signatureLines}}
+\\signaturelines
+{{/if}}
+
+\\end{letter}
+\\end{document}
+`;

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Custom Export System
+ *
+ * This module provides:
+ * - Custom exporter definitions via manifest.json + Handlebars templates
+ * - Registry for loading and managing exporters
+ * - VS Code commands for custom exports
+ */
+
+export {
+    // Types
+    KeywordDefinition,
+    ExporterManifest,
+    CustomExporter,
+    TemplateContext,
+
+    // Registry
+    ExporterRegistry,
+
+    // Functions
+    compileTemplate,
+    registerPartial,
+    renderTemplate,
+    extractCustomKeywords,
+    executeCustomExport,
+    getDefaultExporterPaths,
+    initializeExporterRegistry,
+
+    // Examples
+    EXAMPLE_CMU_MEMO_MANIFEST,
+    EXAMPLE_CMU_MEMO_TEMPLATE,
+    EXAMPLE_CMU_DISSERTATION_MANIFEST,
+} from './customExporter';
+
+export { registerCustomExportCommands } from './commands';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ import { registerLatexLivePreviewCommands } from './org/latexLivePreview';
 import { registerBabelCommands, registerBabelCodeLens } from './org/babelProvider';
 import { registerBabelAdvancedCommands } from './parser/orgBabelAdvanced';
 import { registerExportCommands } from './org/exportProvider';
+import { registerCustomExportCommands } from './export/commands';
 import { registerScimaxOrgCommands } from './org/scimaxOrg';
 import { registerScimaxObCommands } from './org/scimaxOb';
 import { registerSpeedCommands } from './org/speedCommands';
@@ -369,6 +370,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Register Export commands (for exporting to HTML, LaTeX, PDF, Markdown)
     registerExportCommands(context);
+
+    // Register Custom Export commands (user-defined export templates)
+    registerCustomExportCommands(context);
 
     // Register Manuscript commands (flatten LaTeX for journal submission)
     registerManuscriptCommands(context);

--- a/src/hydra/menus/exportMenu.ts
+++ b/src/hydra/menus/exportMenu.ts
@@ -95,6 +95,19 @@ export const exportMenu: HydraMenuDefinition = {
                 },
             ],
         },
+        {
+            title: 'Custom Exporters',
+            items: [
+                {
+                    key: 'c',
+                    label: 'Custom exports',
+                    description: 'User-defined export templates',
+                    icon: 'extensions',
+                    exit: 'exit',
+                    action: 'scimax.export.custom',
+                },
+            ],
+        },
     ],
 };
 


### PR DESCRIPTION
## Summary
Introduces a comprehensive custom exporter system that allows users to define custom export backends via templates and manifests. This enables extensibility without modifying core code, supporting LaTeX, HTML, and Markdown parent backends.

## Key Changes
- **Template Engine**: Implements a template rendering system matching existing syntax with support for:
  - Simple variable substitution (`{{variable}}`)
  - Conditionals (`{{#if}}...{{/if}}`, `{{#unless}}...{{/unless}}`)
  - Iteration (`{{#each}}...{{/each}}`)
  - Escape helpers (`{{latex variable}}`, `{{html variable}}`)
  - Default values (`{{default variable "fallback"}}`)

- **Manifest System**: Defines `ExporterManifest` interface for exporter configuration including:
  - Metadata (id, name, description)
  - Parent backend selection (latex/html/markdown)
  - Custom keyword definitions with types and defaults
  - LaTeX-specific options (document class, packages)

- **Exporter Registry**: Singleton registry for managing loaded exporters with:
  - Directory-based discovery and loading
  - Validation of manifest structure
  - Support for preamble files
  - Direct registration capability

- **Export Execution**: `executeCustomExport()` function that:
  - Parses org documents and extracts metadata
  - Generates body content using parent backend
  - Extracts custom keywords with type conversion
  - Renders final output via template engine

- **Discovery Paths**: Automatic exporter discovery from standard locations:
  - `~/.scimax/exporters/`
  - `$XDG_CONFIG_HOME/scimax/exporters/`

- **Example Implementation**: Includes complete CMU Memo exporter example with manifest and template

## Implementation Details
- Uses singleton pattern for registry to ensure single instance across application
- Keyword extraction supports both document-level and section-level keywords
- Type conversion for keywords (string, boolean, number)
- Graceful error handling for missing exporters and files
- Template processing order ensures correct precedence (each → if → unless → helpers → substitutions)