### PR TITLE
Add weekly build GitHub Action

### DIFF
--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,0 +1,41 @@
+name: Weekly Build
+
+on:
+  schedule:
+    # Run every Monday at 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+    # Allow manual triggering
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile TypeScript
+        run: npm run compile
+
+      - name: Run tests
+        run: npm test
+
+      - name: Package extension
+        run: npx vsce package
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scimax-vscode-${{ github.sha }}
+          path: '*.vsix'
+          retention-days: 30

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -33,6 +33,18 @@ jobs:
       - name: Package extension
         run: npx vsce package
 
+      - name: Install VS Code
+        run: |
+          wget -q "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64" -O code.deb
+          sudo dpkg -i code.deb
+          sudo apt-get install -f -y
+
+      - name: Install extension
+        run: code --install-extension *.vsix --force
+
+      - name: Verify installation
+        run: code --list-extensions | grep -i scimax
+
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Creates a workflow that:
- Runs every Monday at 00:00 UTC (cron schedule)
- Can be manually triggered via workflow_dispatch
- Builds and tests the extension
- Packages the VSIX and uploads it as an artifact (retained 30 days)

https://claude.ai/code/session_01VAmdMpGNyERhHX2PYFbp6N