### PR TITLE
Add link graph visualization and database extension points

### DIFF
--- a/docs/00-index.org
+++ b/docs/00-index.org
@@ -230,6 +230,7 @@ This documentation is organized into several sections:
 | [[file:34-bibtex.org][BibTeX Editing]]               | BibTeX file editing and commands |
 | [[file:35-templates.org][Document Templates]]           | Template system for documents    |
 | [[file:36-manuscript.org][Manuscript Flattening]]        | Prepare LaTeX for submission     |
+| [[file:39-link-graph.org][Link Graph]]                   | Visualize file connections       |
 
 ** Quick Start
 
@@ -411,6 +412,7 @@ Quick reference to find specific features across documentation.
 | LaTeX math            | [[file:11-latex-preview.org][LaTeX Preview]]                 | [[file:10-export.org][Export]]                                                                                             |
 | Links                 | [[file:05-links.org][Links]]                                 | [[file:19-references.org][References]], [[file:21-navigation.org][Navigation]]                                             |
 | Limitations           | [[file:29-unsupported-features.org][Unsupported Features]]   | Emacs features not available in VS Code                                                                                    |
+| Link graph            | [[file:39-link-graph.org][Link Graph]]                       | [[file:05-links.org][Links]], [[file:18-database-search.org][Database and Search]]                                         |
 | Lists (ordered)       | [[file:01.5-basic-syntax.org][Basic Syntax]]                 | [[file:02-document-structure.org][Document Structure]]                                                                     |
 | Lists (unordered)     | [[file:01.5-basic-syntax.org][Basic Syntax]]                 | [[file:02-document-structure.org][Document Structure]]                                                                     |
 | Markdown support      | [[file:30-markdown-compatibility.org][Markdown Compatibility]] | [[file:02-document-structure.org][Document Structure]], [[file:23-speed-commands.org][Speed Commands]], [[file:07-source-blocks.org][Source Blocks]] |

--- a/docs/05-links.org
+++ b/docs/05-links.org
@@ -634,6 +634,7 @@ CLOSED: [2026-01-15 Thu 19:53]
 - [[file:19-references.org][References]] - Citation links and bibliography
 - [[file:10-export.org][Export]] - How links appear in exports
 - [[file:12-image-overlays.org][Image Overlays]] - Displaying linked images
+- [[file:39-link-graph.org][Link Graph]] - Visualize file connections through links
 
 * Navigation
 

--- a/docs/24-keybindings.org
+++ b/docs/24-keybindings.org
@@ -29,6 +29,7 @@ This document provides a comprehensive reference for all keybindings in Scimax V
 | M-[         | Previous journal entry (in journal) |
 | M-]         | Next journal entry (in journal)     |
 | C-c S-/     | Context-sensitive help              |
+| C-c S-g     | Show link graph for current file    |
 
 * ✅ Help Commands
 CLOSED: [2026-01-17 Sat 13:38]

--- a/docs/25-commands.org
+++ b/docs/25-commands.org
@@ -482,6 +482,16 @@ CLOSED: [2026-01-17 Sat 12:46]
 | [[cmd:scimax.db.cancelEmbeddings]] | Cancel Embedding Generation  | -                  |
 | [[cmd:scimax.database.refresh]]    | Refresh Database             | -                  |
 
+** ⚠️ Link Graph Visualization
+
+Commands for visualizing file connections through links.
+
+| Command ID                           | Description                     | Default Keybinding |
+|--------------------------------------+---------------------------------+--------------------|
+| [[cmd:scimax.showLinkGraph]]         | Show Link Graph for Current File| C-c S-g            |
+| [[cmd:scimax.showLinkGraphForFile]]  | Show Link Graph for File        | -                  |
+| [[cmd:scimax.showLinkStats]]         | Show Link Statistics            | -                  |
+
 ** ✅ Troubleshooting and Diagnostics
 CLOSED: [2026-01-22 Thu 20:56]
 

--- a/docs/39-link-graph.org
+++ b/docs/39-link-graph.org
@@ -1,0 +1,257 @@
+#+TITLE: Link Graph Visualization
+#+AUTHOR: Scimax VS Code Team
+#+DATE: 2026-02-02
+#+STARTUP: overview
+#+OPTIONS: toc:2 num:t H:4
+#+TODO: ⚠️ 👀 | ✅
+
+*Keybinding Note:* This extension uses Emacs-style keybindings where Ctrl is used on all platforms (not Cmd on Mac), except where explicitly noted.
+
+* ⚠️ Link Graph Visualization
+
+The link graph feature provides an interactive visualization of how your files are connected through links. Files are shown as nodes, and the links between them are shown as edges, enabling you to explore your knowledge base as a network.
+
+** ⚠️ Overview
+
+The link graph visualization helps you:
+
+- *Discover connections* - See which files link to each other
+- *Navigate your knowledge base* - Click on nodes to open files
+- *Explore relationships* - Follow chains of links across multiple files
+- *Filter by context* - Filter links by tags, TODO states, and more
+
+** ⚠️ Opening the Link Graph
+
+*** Commands
+
+| Key         | Command                      | Description                      |
+|-------------+------------------------------+----------------------------------|
+| C-c S-g     | scimax.showLinkGraph         | Show link graph for current file |
+| (none)      | scimax.showLinkGraphForFile  | Show link graph for a file       |
+| (none)      | scimax.showLinkStats         | Show link statistics for file    |
+
+*** From Command Palette
+
+1. Open the Command Palette (=Ctrl+Shift+P=)
+2. Type "Link Graph" or "Scimax: Show Link Graph"
+3. Select the command
+
+*** Context Menu
+
+Right-click on a file in the explorer and select "Show Link Graph".
+
+* ⚠️ Understanding the Graph
+
+** ⚠️ Nodes
+
+Each node in the graph represents a file:
+
+- *Center node* - The starting file, highlighted in a distinct color
+- *Connected nodes* - Files that link to or from the center file
+- *Node size* - Larger nodes have more connections
+
+** ⚠️ Edges
+
+Edges (lines) represent links between files:
+
+- *Direction* - Arrows show link direction (source → target)
+- *Bidirectional* - Some file pairs may have links in both directions
+
+** ⚠️ Node Tooltips
+
+Hover over a node to see information about the file:
+
+- File name and path
+- File type (org, markdown)
+- Number of headings
+- Number of TODO items
+- Tags present in the file
+- Modification time
+
+** ⚠️ Interacting with the Graph
+
+*** Click
+
+- *Single click* - Opens the file in the editor
+
+*** Double-click
+
+- *Double-click* - Recenters the graph on that file
+
+*** Drag
+
+- *Drag nodes* - Move nodes around to arrange the layout
+- Nodes stay where you place them until you recenter
+
+* ⚠️ Graph Controls
+
+** ⚠️ Depth
+
+Controls how many hops away from the center file to include:
+
+| Depth | Description                                    |
+|-------+------------------------------------------------|
+| 1     | Only direct connections                        |
+| 2     | Connections and their connections              |
+| 3     | Up to 3 hops away (larger graphs)              |
+
+Larger depths show more of the network but can become cluttered.
+
+** ⚠️ Direction
+
+Controls which types of links to follow:
+
+| Direction | Description                            |
+|-----------+----------------------------------------|
+| Both      | Show incoming and outgoing links       |
+| Outgoing  | Only show files this file links to     |
+| Incoming  | Only show files that link to this file |
+
+** ⚠️ Filters
+
+The filter panel allows you to narrow down which links appear in the graph based on various criteria.
+
+*** File Type Filter
+
+Filter by file extension:
+- =org= - Org-mode files only
+- =md= - Markdown files only
+
+*** Tag Filter
+
+Filter to show only links within headings that have specific tags:
+- Enter comma-separated tags (e.g., =project,important=)
+- A link appears if its containing heading has ANY of the specified tags
+
+*** TODO State Filter
+
+Filter links by the TODO state of their containing heading:
+- =TODO= - Links in headings with TODO state
+- =DONE= - Links in completed headings
+- =WAITING=, =NEXT=, etc. - Other states
+
+*** Exclude Done Filter
+
+When checked, links in headings with DONE or CANCELLED states are hidden.
+
+*** Modified After Filter
+
+Show only links in files modified after a certain date:
+- Enter a date in YYYY-MM-DD format
+- Useful for finding recently updated connections
+
+* ⚠️ Link Statistics
+
+The =scimax.showLinkStats= command shows a summary of links for the current file:
+
+#+BEGIN_EXAMPLE
+Link Statistics for notes.org
+
+Outgoing links: 15
+By type:
+  file: 8
+  http: 5
+  cite: 2
+Incoming links (backlinks): 3
+#+END_EXAMPLE
+
+After viewing statistics, you can click "Show Graph" to open the full visualization.
+
+* ⚠️ How Links Are Indexed
+
+Links are extracted from your org and markdown files and stored in the database:
+
+** ⚠️ Link Types
+
+| Type  | Description                       | Example                  |
+|-------+-----------------------------------+--------------------------|
+| file  | Links to other files              | [[file:other.org]]       |
+| http  | Web links                         | [[https://example.com]]  |
+| https | Secure web links                  | [[https://example.com]]  |
+| cite  | Citation links                    | cite:author-2024         |
+| id    | Links to headings by ID           | [[id:abc-123]]           |
+| nb    | Notebook project links            | [[nb:project::file.org]] |
+
+** ⚠️ Heading Association
+
+Each link is associated with its containing heading. This enables filtering:
+
+- Links under a heading inherit that heading's tags
+- Filter by TODO state to see links in active vs completed tasks
+- Filter by priority to focus on important connections
+
+* ⚠️ Use Cases
+
+** ⚠️ Exploring Backlinks
+
+Want to see what references a particular file?
+
+1. Open the file
+2. Run =scimax.showLinkGraph=
+3. Set direction to "Incoming"
+4. Explore which files cite this one
+
+** ⚠️ Tracing Topic Chains
+
+Want to follow a chain of related topics?
+
+1. Open a starting file
+2. Set depth to 2 or 3
+3. Double-click interesting nodes to recenter
+4. Follow the chain of connections
+
+** ⚠️ Finding Active Project Connections
+
+Want to see links only in active tasks?
+
+1. Open a project file
+2. Apply filter: TODO state = "TODO" or "NEXT"
+3. Or check "Exclude done" to hide completed items
+4. See which files are referenced by active work
+
+** ⚠️ Recent Modifications Review
+
+Want to see recently updated connections?
+
+1. Apply "Modified after" filter with a recent date
+2. See which connected files have been recently changed
+3. Useful for reviewing changes in a connected set of notes
+
+* ⚠️ Technical Details
+
+** ⚠️ Database Tables
+
+The link graph uses the =links= table in the Scimax database:
+
+| Column      | Description                            |
+|-------------+----------------------------------------|
+| file_path   | Source file containing the link        |
+| target      | Link target (path, URL, etc.)          |
+| link_type   | Type of link (file, http, cite, etc.)  |
+| line_number | Line where link appears                |
+| heading_id  | ID of containing heading (for filters) |
+
+** ⚠️ Visualization Technology
+
+The graph is rendered using vis.js Network in a VS Code webview:
+
+- Force-directed layout automatically arranges nodes
+- Physics simulation enables smooth dragging
+- SVG rendering for crisp display at any zoom level
+
+** ⚠️ Performance
+
+- Default maximum of 100 nodes to prevent overwhelming graphs
+- Truncation indicator shows when limit is reached
+- Use filters to narrow down large graphs
+
+* ⚠️ Related Topics
+
+- [[file:05-links.org][Hyperlinks]] - Creating and following links
+- [[file:18-database-search.org][Database and Search]] - Database structure and search
+- [[file:16-notebook.org][Notebooks]] - Project organization with nb: links
+
+* Navigation
+
+- Previous: [[file:38-find-file.org][Find File]]
+- Index: [[file:00-index.org][Documentation Index]]

--- a/docs/extension-points.org
+++ b/docs/extension-points.org
@@ -576,6 +576,286 @@ context.subscriptions.push(registerExportHook(hook));
 Hooks that throw errors are caught and logged. The export continues with the
 unmodified content, so a failing hook won't break the entire export.
 
+** Database Extension Points
+
+Extension points for extracting custom data during indexing, running custom
+queries, and enriching graph visualizations. These enable building knowledge
+graphs, custom search algorithms, and entity extraction systems.
+
+*** IndexerAdapter - Custom Content Extraction
+
+Hook into the file indexing pipeline to extract entities, relationships, or
+custom metadata from files as they are indexed.
+
+Location: =src/adapters/indexerAdapter.ts=
+
+**** IndexerAdapter Interface
+
+#+BEGIN_SRC typescript
+interface IndexerAdapter {
+  /** Unique identifier */
+  id: string;
+
+  /** Human-readable description */
+  description?: string;
+
+  /** Priority for ordering (higher first) */
+  priority?: number;
+
+  /** File types to process (['org', 'md']). Empty = all. */
+  fileTypes?: string[];
+
+  /** Extract custom data during indexing */
+  extract(
+    content: string,
+    ast: OrgDocumentNode | undefined,
+    context: IndexContext
+  ): Promise<ExtractedData[]>;
+
+  /** Called when file is removed (cleanup) */
+  onFileRemoved?(filePath: string, fileId: number, db: unknown): Promise<void>;
+}
+
+interface IndexContext {
+  filePath: string;
+  fileId: number;
+  fileType: string;
+  mtime: number;
+  db: unknown;  // Database client for custom queries
+}
+#+END_SRC
+
+**** Extracted Data Types
+
+#+BEGIN_SRC typescript
+// Entity - a named concept, person, project, etc.
+interface ExtractedEntity {
+  type: 'entity';
+  category: string;  // 'person', 'concept', 'project'
+  name: string;
+  properties?: Record<string, unknown>;
+  lineNumber?: number;
+}
+
+// Relationship between entities or files
+interface ExtractedRelationship {
+  type: 'relationship';
+  source: string;
+  target: string;
+  relation: string;  // 'references', 'is_part_of', 'related_to'
+  weight?: number;
+  properties?: Record<string, unknown>;
+}
+
+// Custom metadata about a file
+interface ExtractedMetadata {
+  type: 'metadata';
+  key: string;
+  value: unknown;
+}
+#+END_SRC
+
+**** Example: Entity Extractor
+
+#+BEGIN_SRC typescript
+import { registerIndexer, IndexerAdapter } from './adapters/indexerAdapter';
+
+const entityExtractor: IndexerAdapter = {
+  id: 'knowledge-graph-entities',
+  description: 'Extract named entities for knowledge graph',
+  fileTypes: ['org', 'md'],
+
+  async extract(content, ast, context) {
+    const entities: ExtractedEntity[] = [];
+
+    // Example: Extract #+CONCEPT: definitions
+    const conceptMatches = content.matchAll(/^#\+CONCEPT:\s*(.+)$/gm);
+    for (const match of conceptMatches) {
+      entities.push({
+        type: 'entity',
+        category: 'concept',
+        name: match[1].trim()
+      });
+    }
+
+    return entities;
+  }
+};
+
+context.subscriptions.push(registerIndexer(entityExtractor));
+#+END_SRC
+
+*** QueryProviderAdapter - Custom Search Types
+
+Register custom query providers for specialized searches like graph traversal,
+path finding, or semantic similarity queries.
+
+Location: =src/adapters/queryProviderAdapter.ts=
+
+**** QueryProvider Interface
+
+#+BEGIN_SRC typescript
+interface QueryProvider {
+  /** Query type identifier */
+  queryType: string;
+
+  /** Human-readable name */
+  name: string;
+
+  /** Description */
+  description?: string;
+
+  /** Capabilities (pagination, filtering, ranking) */
+  capabilities?: QueryCapabilities;
+
+  /** Validate parameters (return true or error message) */
+  validate?(params: QueryParams): true | string;
+
+  /** Execute the query */
+  execute(params: QueryParams, db: unknown): Promise<QueryResponse>;
+}
+
+interface QueryResponse {
+  results: QueryResult[];
+  totalCount?: number;
+  executionTimeMs?: number;
+  metadata?: Record<string, unknown>;
+}
+#+END_SRC
+
+**** Built-in Query Providers
+
+| Query Type    | Description                          | Parameters          |
+|---------------+--------------------------------------+---------------------|
+| graph-path    | Find shortest path between files     | from, to, maxHops   |
+| related-files | Find files related by links and tags | filePath, limit     |
+
+**** Example: Custom Similarity Query
+
+#+BEGIN_SRC typescript
+import { registerQueryProvider, QueryProvider } from './adapters/queryProviderAdapter';
+
+const similarityProvider: QueryProvider = {
+  queryType: 'semantic-similarity',
+  name: 'Semantic Similarity Search',
+  description: 'Find semantically similar files using embeddings',
+
+  validate(params) {
+    if (!params.filePath) return 'Missing filePath';
+    return true;
+  },
+
+  async execute(params, db) {
+    const filePath = params.filePath as string;
+    const limit = (params.limit as number) || 10;
+
+    // Query embedding vectors and compute similarity
+    // ...
+
+    return {
+      results: similarFiles.map(f => ({
+        type: 'file',
+        id: f.path,
+        label: f.name,
+        score: f.similarity
+      }))
+    };
+  }
+};
+
+context.subscriptions.push(registerQueryProvider(similarityProvider));
+#+END_SRC
+
+*** GraphDataProviderAdapter - Graph Enrichment
+
+Add custom data to link graph nodes and edges, or inject additional edges
+beyond the standard file links (e.g., semantic relationships).
+
+Location: =src/adapters/graphDataAdapter.ts=
+
+**** GraphDataProvider Interface
+
+#+BEGIN_SRC typescript
+interface GraphDataProvider {
+  id: string;
+  name: string;
+  description?: string;
+  priority?: number;
+
+  /** Enrich node with custom properties */
+  enrichNode?(node: GraphNode, context: GraphDataContext): Promise<NodeEnrichment | undefined>;
+
+  /** Enrich edge with custom properties */
+  enrichEdge?(edge: GraphEdge, context: GraphDataContext): Promise<EdgeEnrichment | undefined>;
+
+  /** Add custom edges (e.g., semantic relationships) */
+  getCustomEdges?(filePath: string, context: GraphDataContext): Promise<CustomEdge[]>;
+
+  /** Filter out nodes */
+  filterNode?(node: GraphNode, context: GraphDataContext): boolean;
+
+  /** Filter out edges */
+  filterEdge?(edge: GraphEdge, context: GraphDataContext): boolean;
+}
+
+interface NodeEnrichment {
+  color?: string;
+  size?: number;
+  shape?: string;
+  label?: string;
+  tooltip?: string;
+  group?: string;
+  importance?: number;
+  properties?: Record<string, unknown>;
+}
+#+END_SRC
+
+**** Built-in Providers
+
+| Provider ID          | Description                              |
+|----------------------+------------------------------------------|
+| link-count-importance | Sizes nodes based on link count         |
+| recency-coloring     | Colors nodes by modification recency     |
+
+**** Example: Cluster Provider
+
+#+BEGIN_SRC typescript
+import { registerGraphDataProvider, GraphDataProvider } from './adapters/graphDataAdapter';
+
+const clusterProvider: GraphDataProvider = {
+  id: 'topic-clusters',
+  name: 'Topic Clustering',
+  description: 'Group files by topic similarity',
+
+  async enrichNode(node, context) {
+    // Compute cluster membership
+    const cluster = await getFileCluster(node.id, context.db);
+
+    return {
+      group: cluster.name,
+      color: cluster.color,
+      properties: { clusterId: cluster.id }
+    };
+  },
+
+  async getCustomEdges(filePath, context) {
+    // Add edges to semantically similar files
+    const similar = await getSimilarFiles(filePath, context.db);
+
+    return similar.map(s => ({
+      from: filePath,
+      to: s.path,
+      type: 'semantic-similarity',
+      label: 'Similar',
+      style: 'dashed',
+      color: '#999'
+    }));
+  }
+};
+
+context.subscriptions.push(registerGraphDataProvider(clusterProvider));
+#+END_SRC
+
 ** Potential Future Extension Points
 
 These patterns could be extended for additional plugin types:

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,7 +234,6 @@
       "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.7.21.tgz",
       "integrity": "sha512-Vobv2/Yfnn6C6BVO/pvj7madQ7Mfzl83/jAWwixbemGF6ZThhGMz8++FD9hWHyHXDMYuLGa6fK68c2VsolZmTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
@@ -1850,7 +1849,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2383,7 +2381,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3574,7 +3571,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4564,7 +4560,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6759,7 +6755,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -7429,7 +7425,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7564,7 +7559,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7684,7 +7678,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7778,7 +7771,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -1128,6 +1128,19 @@
         "title": "Scimax: Configure Embedding Service"
       },
       {
+        "command": "scimax.showLinkGraph",
+        "title": "Scimax: Show Link Graph",
+        "icon": "$(type-hierarchy)"
+      },
+      {
+        "command": "scimax.showLinkGraphForFile",
+        "title": "Scimax: Show Link Graph for File"
+      },
+      {
+        "command": "scimax.showLinkStats",
+        "title": "Scimax: Show Link Statistics"
+      },
+      {
         "command": "scimax.journal.refresh",
         "title": "Scimax: Refresh Journal View",
         "icon": "$(refresh)"
@@ -5131,6 +5144,12 @@
         "command": "scimax.insertOcrScreenshot",
         "key": "shift+f10",
         "mac": "shift+f10",
+        "when": "editorTextFocus && editorLangId =~ /org|markdown/"
+      },
+      {
+        "command": "scimax.showLinkGraph",
+        "key": "ctrl+c shift+g",
+        "mac": "ctrl+c shift+g",
         "when": "editorTextFocus && editorLangId =~ /org|markdown/"
       }
     ],

--- a/src/adapters/__tests__/graphDataAdapter.test.ts
+++ b/src/adapters/__tests__/graphDataAdapter.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tests for GraphDataProviderAdapter
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    graphDataRegistry,
+    GraphDataProvider,
+    GraphDataContext,
+    NodeEnrichment,
+    EdgeEnrichment
+} from '../graphDataAdapter';
+
+// Mock vscode
+vi.mock('vscode', () => ({
+    Disposable: class {
+        constructor(private callback: () => void) {}
+        dispose() { this.callback(); }
+    }
+}));
+
+// Mock GraphNode and GraphEdge types
+interface MockGraphNode {
+    id: string;
+    label: string;
+    title: string;
+    level: number;
+    isCenter: boolean;
+    fileType: 'org' | 'md';
+    mtime: number;
+    headingCount: number;
+    todoCount: number;
+    linkCount: number;
+    hasUpcomingDeadline: boolean;
+    topTags: string[];
+    metadata?: Record<string, unknown>;
+}
+
+interface MockGraphEdge {
+    id: string;
+    from: string;
+    to: string;
+    linkType: string;
+    count: number;
+    title: string;
+    arrows: 'to';
+    metadata?: Record<string, unknown>;
+}
+
+describe('GraphDataProviderRegistry', () => {
+    beforeEach(() => {
+        graphDataRegistry.clear();
+    });
+
+    const createMockNode = (id: string): MockGraphNode => ({
+        id,
+        label: id.split('/').pop() || id,
+        title: id,
+        level: 0,
+        isCenter: false,
+        fileType: 'org',
+        mtime: Date.now(),
+        headingCount: 5,
+        todoCount: 2,
+        linkCount: 3,
+        hasUpcomingDeadline: false,
+        topTags: ['project']
+    });
+
+    const createMockEdge = (from: string, to: string): MockGraphEdge => ({
+        id: `${from}->${to}`,
+        from,
+        to,
+        linkType: 'file',
+        count: 1,
+        title: 'Link',
+        arrows: 'to'
+    });
+
+    const createMockContext = (): GraphDataContext => ({
+        centerFile: '/test/center.org',
+        depth: 1,
+        maxDepth: 2,
+        direction: 'both',
+        db: {}
+    });
+
+    describe('register', () => {
+        it('should register a provider', () => {
+            const provider: GraphDataProvider = {
+                id: 'test-provider',
+                name: 'Test Provider'
+            };
+
+            const disposable = graphDataRegistry.register(provider);
+
+            expect(graphDataRegistry.hasProvider('test-provider')).toBe(true);
+            expect(graphDataRegistry.getProviderIds()).toContain('test-provider');
+
+            disposable.dispose();
+            expect(graphDataRegistry.hasProvider('test-provider')).toBe(false);
+        });
+
+        it('should throw on duplicate id', () => {
+            const provider: GraphDataProvider = {
+                id: 'test-provider',
+                name: 'Test Provider'
+            };
+
+            graphDataRegistry.register(provider);
+
+            expect(() => graphDataRegistry.register(provider)).toThrow(/already registered/);
+        });
+    });
+
+    describe('applyProviders', () => {
+        it('should apply node enrichments', async () => {
+            graphDataRegistry.register({
+                id: 'color-provider',
+                name: 'Color Provider',
+                async enrichNode(node) {
+                    return { color: '#ff0000' };
+                }
+            });
+
+            const nodes = [createMockNode('/test/file1.org')];
+            const edges: MockGraphEdge[] = [];
+            const context = createMockContext();
+
+            const result = await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            expect(result.nodeEnrichments.get('/test/file1.org')).toEqual({
+                color: '#ff0000',
+                properties: {}
+            });
+        });
+
+        it('should apply edge enrichments', async () => {
+            graphDataRegistry.register({
+                id: 'edge-styler',
+                name: 'Edge Styler',
+                async enrichEdge(edge) {
+                    return { style: 'dashed', width: 2 };
+                }
+            });
+
+            const nodes = [createMockNode('/test/file1.org'), createMockNode('/test/file2.org')];
+            const edges = [createMockEdge('/test/file1.org', '/test/file2.org')];
+            const context = createMockContext();
+
+            const result = await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            expect(result.edgeEnrichments.get('/test/file1.org:/test/file2.org')).toEqual({
+                style: 'dashed',
+                width: 2,
+                properties: {}
+            });
+        });
+
+        it('should collect custom edges', async () => {
+            graphDataRegistry.register({
+                id: 'semantic-edges',
+                name: 'Semantic Edges',
+                async getCustomEdges(filePath) {
+                    if (filePath === '/test/file1.org') {
+                        return [{
+                            from: '/test/file1.org',
+                            to: '/test/file3.org',
+                            type: 'semantic-similarity',
+                            label: 'Similar content'
+                        }];
+                    }
+                    return [];
+                }
+            });
+
+            const nodes = [createMockNode('/test/file1.org'), createMockNode('/test/file2.org')];
+            const edges: MockGraphEdge[] = [];
+            const context = createMockContext();
+
+            const result = await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            expect(result.customEdges).toHaveLength(1);
+            expect(result.customEdges[0].type).toBe('semantic-similarity');
+        });
+
+        it('should filter nodes', async () => {
+            graphDataRegistry.register({
+                id: 'node-filter',
+                name: 'Node Filter',
+                filterNode(node) {
+                    return !node.id.includes('excluded');
+                }
+            });
+
+            const nodes = [
+                createMockNode('/test/file1.org'),
+                createMockNode('/test/excluded.org')
+            ];
+            const edges: MockGraphEdge[] = [];
+            const context = createMockContext();
+
+            const result = await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            expect(result.filteredNodes.has('/test/excluded.org')).toBe(true);
+            expect(result.filteredNodes.has('/test/file1.org')).toBe(false);
+        });
+
+        it('should filter edges', async () => {
+            graphDataRegistry.register({
+                id: 'edge-filter',
+                name: 'Edge Filter',
+                filterEdge(edge) {
+                    return edge.linkType !== 'http';
+                }
+            });
+
+            const nodes = [createMockNode('/test/file1.org'), createMockNode('/test/file2.org')];
+            const edges = [
+                createMockEdge('/test/file1.org', '/test/file2.org'),
+                { ...createMockEdge('/test/file1.org', '/test/file3.org'), linkType: 'http' }
+            ];
+            const context = createMockContext();
+
+            const result = await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            expect(result.filteredEdges.has('/test/file1.org:/test/file3.org')).toBe(true);
+            expect(result.filteredEdges.has('/test/file1.org:/test/file2.org')).toBe(false);
+        });
+
+        it('should collect errors without stopping', async () => {
+            graphDataRegistry.register({
+                id: 'failing-provider',
+                name: 'Failing Provider',
+                async enrichNode() {
+                    throw new Error('Test error');
+                }
+            });
+
+            graphDataRegistry.register({
+                id: 'working-provider',
+                name: 'Working Provider',
+                async enrichNode() {
+                    return { color: '#00ff00' };
+                }
+            });
+
+            const nodes = [createMockNode('/test/file1.org')];
+            const edges: MockGraphEdge[] = [];
+            const context = createMockContext();
+
+            const result = await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            // Working provider should still have run
+            expect(result.nodeEnrichments.get('/test/file1.org')?.color).toBe('#00ff00');
+
+            // Error should be collected
+            expect(result.errors).toHaveLength(1);
+            expect(result.errors[0].providerId).toBe('failing-provider');
+        });
+
+        it('should respect priority ordering', async () => {
+            const order: string[] = [];
+
+            graphDataRegistry.register({
+                id: 'low-priority',
+                name: 'Low Priority',
+                priority: 0,
+                async enrichNode() {
+                    order.push('low');
+                    return { color: '#000000' };
+                }
+            });
+
+            graphDataRegistry.register({
+                id: 'high-priority',
+                name: 'High Priority',
+                priority: 10,
+                async enrichNode() {
+                    order.push('high');
+                    return { color: '#ffffff' };
+                }
+            });
+
+            const nodes = [createMockNode('/test/file1.org')];
+            const edges: MockGraphEdge[] = [];
+            const context = createMockContext();
+
+            await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            expect(order).toEqual(['high', 'low']);
+        });
+
+        it('should merge enrichments from multiple providers', async () => {
+            graphDataRegistry.register({
+                id: 'color-provider',
+                name: 'Color Provider',
+                async enrichNode() {
+                    return { color: '#ff0000', properties: { colored: true } };
+                }
+            });
+
+            graphDataRegistry.register({
+                id: 'size-provider',
+                name: 'Size Provider',
+                async enrichNode() {
+                    return { size: 20, properties: { sized: true } };
+                }
+            });
+
+            const nodes = [createMockNode('/test/file1.org')];
+            const edges: MockGraphEdge[] = [];
+            const context = createMockContext();
+
+            const result = await graphDataRegistry.applyProviders(
+                nodes as any,
+                edges as any,
+                context
+            );
+
+            const enrichment = result.nodeEnrichments.get('/test/file1.org');
+            expect(enrichment?.color).toBe('#ff0000');
+            expect(enrichment?.size).toBe(20);
+            expect(enrichment?.properties?.colored).toBe(true);
+            expect(enrichment?.properties?.sized).toBe(true);
+        });
+    });
+
+    describe('built-in providers', () => {
+        it('should export linkCountImportanceProvider', async () => {
+            const { linkCountImportanceProvider } = await import('../graphDataAdapter');
+            expect(linkCountImportanceProvider.id).toBe('link-count-importance');
+            expect(linkCountImportanceProvider.enrichNode).toBeDefined();
+        });
+
+        it('should export recencyColoringProvider', async () => {
+            const { recencyColoringProvider } = await import('../graphDataAdapter');
+            expect(recencyColoringProvider.id).toBe('recency-coloring');
+            expect(recencyColoringProvider.enrichNode).toBeDefined();
+        });
+    });
+});

--- a/src/adapters/__tests__/indexerAdapter.test.ts
+++ b/src/adapters/__tests__/indexerAdapter.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for IndexerAdapter
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    indexerRegistry,
+    IndexerAdapter,
+    IndexContext,
+    ExtractedEntity,
+    ExtractedRelationship,
+    ExtractedMetadata
+} from '../indexerAdapter';
+
+// Mock vscode
+vi.mock('vscode', () => ({
+    Disposable: class {
+        constructor(private callback: () => void) {}
+        dispose() { this.callback(); }
+    }
+}));
+
+describe('IndexerAdapterRegistry', () => {
+    beforeEach(() => {
+        indexerRegistry.clear();
+    });
+
+    describe('register', () => {
+        it('should register an adapter', () => {
+            const adapter: IndexerAdapter = {
+                id: 'test-adapter',
+                extract: async () => []
+            };
+
+            const disposable = indexerRegistry.register(adapter);
+
+            expect(indexerRegistry.hasAdapter('test-adapter')).toBe(true);
+            expect(indexerRegistry.getAdapterIds()).toContain('test-adapter');
+
+            disposable.dispose();
+            expect(indexerRegistry.hasAdapter('test-adapter')).toBe(false);
+        });
+
+        it('should throw on duplicate id', () => {
+            const adapter: IndexerAdapter = {
+                id: 'test-adapter',
+                extract: async () => []
+            };
+
+            indexerRegistry.register(adapter);
+
+            expect(() => indexerRegistry.register(adapter)).toThrow(/already registered/);
+        });
+
+        it('should throw on missing id', () => {
+            const adapter = {
+                extract: async () => []
+            } as any;
+
+            expect(() => indexerRegistry.register(adapter)).toThrow(/must have an id/);
+        });
+    });
+
+    describe('getAdaptersForFileType', () => {
+        it('should filter adapters by file type', () => {
+            indexerRegistry.register({
+                id: 'org-only',
+                fileTypes: ['org'],
+                extract: async () => []
+            });
+
+            indexerRegistry.register({
+                id: 'md-only',
+                fileTypes: ['md'],
+                extract: async () => []
+            });
+
+            indexerRegistry.register({
+                id: 'all-files',
+                extract: async () => []
+            });
+
+            const orgAdapters = indexerRegistry.getAdaptersForFileType('org');
+            expect(orgAdapters.map(a => a.id)).toContain('org-only');
+            expect(orgAdapters.map(a => a.id)).toContain('all-files');
+            expect(orgAdapters.map(a => a.id)).not.toContain('md-only');
+
+            const mdAdapters = indexerRegistry.getAdaptersForFileType('md');
+            expect(mdAdapters.map(a => a.id)).toContain('md-only');
+            expect(mdAdapters.map(a => a.id)).toContain('all-files');
+            expect(mdAdapters.map(a => a.id)).not.toContain('org-only');
+        });
+    });
+
+    describe('runAdapters', () => {
+        it('should run adapters and collect results', async () => {
+            indexerRegistry.register({
+                id: 'entity-extractor',
+                extract: async () => [
+                    {
+                        type: 'entity' as const,
+                        category: 'concept',
+                        name: 'Machine Learning'
+                    }
+                ]
+            });
+
+            indexerRegistry.register({
+                id: 'relationship-extractor',
+                extract: async () => [
+                    {
+                        type: 'relationship' as const,
+                        source: 'file1.org',
+                        target: 'file2.org',
+                        relation: 'references'
+                    }
+                ]
+            });
+
+            const context: IndexContext = {
+                filePath: '/test/file.org',
+                fileId: 1,
+                fileType: 'org',
+                mtime: Date.now(),
+                db: {}
+            };
+
+            const result = await indexerRegistry.runAdapters('content', undefined, context);
+
+            expect(result.entities).toHaveLength(1);
+            expect(result.entities[0].name).toBe('Machine Learning');
+
+            expect(result.relationships).toHaveLength(1);
+            expect(result.relationships[0].relation).toBe('references');
+
+            expect(result.errors).toHaveLength(0);
+        });
+
+        it('should collect errors without stopping', async () => {
+            indexerRegistry.register({
+                id: 'failing-adapter',
+                extract: async () => { throw new Error('Test error'); }
+            });
+
+            indexerRegistry.register({
+                id: 'working-adapter',
+                extract: async () => [
+                    { type: 'entity' as const, category: 'test', name: 'Test' }
+                ]
+            });
+
+            const context: IndexContext = {
+                filePath: '/test/file.org',
+                fileId: 1,
+                fileType: 'org',
+                mtime: Date.now(),
+                db: {}
+            };
+
+            const result = await indexerRegistry.runAdapters('content', undefined, context);
+
+            expect(result.entities).toHaveLength(1);
+            expect(result.errors).toHaveLength(1);
+            expect(result.errors[0].adapterId).toBe('failing-adapter');
+        });
+
+        it('should respect priority ordering', async () => {
+            const order: string[] = [];
+
+            indexerRegistry.register({
+                id: 'low-priority',
+                priority: 0,
+                extract: async () => { order.push('low'); return []; }
+            });
+
+            indexerRegistry.register({
+                id: 'high-priority',
+                priority: 10,
+                extract: async () => { order.push('high'); return []; }
+            });
+
+            const context: IndexContext = {
+                filePath: '/test/file.org',
+                fileId: 1,
+                fileType: 'org',
+                mtime: Date.now(),
+                db: {}
+            };
+
+            await indexerRegistry.runAdapters('content', undefined, context);
+
+            expect(order).toEqual(['high', 'low']);
+        });
+    });
+
+    describe('notifyFileRemoved', () => {
+        it('should call onFileRemoved for adapters that implement it', async () => {
+            const removedFiles: string[] = [];
+
+            indexerRegistry.register({
+                id: 'cleanup-adapter',
+                extract: async () => [],
+                onFileRemoved: async (filePath) => {
+                    removedFiles.push(filePath);
+                }
+            });
+
+            indexerRegistry.register({
+                id: 'no-cleanup-adapter',
+                extract: async () => []
+            });
+
+            await indexerRegistry.notifyFileRemoved('/test/removed.org', 1, {});
+
+            expect(removedFiles).toEqual(['/test/removed.org']);
+        });
+    });
+});

--- a/src/adapters/__tests__/queryProviderAdapter.test.ts
+++ b/src/adapters/__tests__/queryProviderAdapter.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for QueryProviderAdapter
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    queryProviderRegistry,
+    QueryProvider,
+    QueryParams,
+    QueryResponse
+} from '../queryProviderAdapter';
+
+// Mock vscode
+vi.mock('vscode', () => ({
+    Disposable: class {
+        constructor(private callback: () => void) {}
+        dispose() { this.callback(); }
+    }
+}));
+
+describe('QueryProviderRegistry', () => {
+    beforeEach(() => {
+        queryProviderRegistry.clear();
+    });
+
+    describe('register', () => {
+        it('should register a provider', () => {
+            const provider: QueryProvider = {
+                queryType: 'test-query',
+                name: 'Test Query',
+                execute: async () => ({ results: [] })
+            };
+
+            const disposable = queryProviderRegistry.register(provider);
+
+            expect(queryProviderRegistry.hasProvider('test-query')).toBe(true);
+            expect(queryProviderRegistry.getQueryTypes()).toContain('test-query');
+
+            disposable.dispose();
+            expect(queryProviderRegistry.hasProvider('test-query')).toBe(false);
+        });
+
+        it('should throw on duplicate queryType', () => {
+            const provider: QueryProvider = {
+                queryType: 'test-query',
+                name: 'Test Query',
+                execute: async () => ({ results: [] })
+            };
+
+            queryProviderRegistry.register(provider);
+
+            expect(() => queryProviderRegistry.register(provider)).toThrow(/already registered/);
+        });
+
+        it('should throw on missing queryType', () => {
+            const provider = {
+                name: 'Test Query',
+                execute: async () => ({ results: [] })
+            } as any;
+
+            expect(() => queryProviderRegistry.register(provider)).toThrow(/must have a queryType/);
+        });
+    });
+
+    describe('getAllProviders', () => {
+        it('should return all registered providers', () => {
+            queryProviderRegistry.register({
+                queryType: 'query-1',
+                name: 'Query 1',
+                execute: async () => ({ results: [] })
+            });
+
+            queryProviderRegistry.register({
+                queryType: 'query-2',
+                name: 'Query 2',
+                execute: async () => ({ results: [] })
+            });
+
+            const providers = queryProviderRegistry.getAllProviders();
+            expect(providers).toHaveLength(2);
+            expect(providers.map(p => p.queryType)).toContain('query-1');
+            expect(providers.map(p => p.queryType)).toContain('query-2');
+        });
+    });
+
+    describe('executeQuery', () => {
+        it('should execute a registered query', async () => {
+            queryProviderRegistry.register({
+                queryType: 'test-query',
+                name: 'Test Query',
+                execute: async (params) => ({
+                    results: [
+                        { type: 'test', id: '1', label: `Result for ${params.search}` }
+                    ]
+                })
+            });
+
+            const response = await queryProviderRegistry.executeQuery(
+                'test-query',
+                { search: 'hello' },
+                {}
+            );
+
+            expect(response.results).toHaveLength(1);
+            expect(response.results[0].label).toBe('Result for hello');
+            expect(response.executionTimeMs).toBeDefined();
+        });
+
+        it('should throw for unknown query type', async () => {
+            await expect(
+                queryProviderRegistry.executeQuery('unknown-query', {}, {})
+            ).rejects.toThrow(/Unknown query type/);
+        });
+
+        it('should validate parameters if validator exists', async () => {
+            queryProviderRegistry.register({
+                queryType: 'validated-query',
+                name: 'Validated Query',
+                validate: (params) => {
+                    if (!params.required) {
+                        return 'Missing required parameter';
+                    }
+                    return true;
+                },
+                execute: async () => ({ results: [] })
+            });
+
+            await expect(
+                queryProviderRegistry.executeQuery('validated-query', {}, {})
+            ).rejects.toThrow(/Missing required parameter/);
+
+            const response = await queryProviderRegistry.executeQuery(
+                'validated-query',
+                { required: true },
+                {}
+            );
+            expect(response.results).toEqual([]);
+        });
+
+        it('should add execution time if not provided', async () => {
+            queryProviderRegistry.register({
+                queryType: 'slow-query',
+                name: 'Slow Query',
+                execute: async () => {
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                    return { results: [] };
+                }
+            });
+
+            const response = await queryProviderRegistry.executeQuery('slow-query', {}, {});
+            expect(response.executionTimeMs).toBeGreaterThanOrEqual(10);
+        });
+
+        it('should preserve execution time if provided', async () => {
+            queryProviderRegistry.register({
+                queryType: 'timed-query',
+                name: 'Timed Query',
+                execute: async () => ({
+                    results: [],
+                    executionTimeMs: 42
+                })
+            });
+
+            const response = await queryProviderRegistry.executeQuery('timed-query', {}, {});
+            expect(response.executionTimeMs).toBe(42);
+        });
+    });
+
+    describe('built-in providers', () => {
+        // These tests would require a mock database
+        // For now, just test that the providers are importable
+        it('should export graphPathProvider', async () => {
+            const { graphPathProvider } = await import('../queryProviderAdapter');
+            expect(graphPathProvider.queryType).toBe('graph-path');
+            expect(graphPathProvider.validate).toBeDefined();
+        });
+
+        it('should export relatedFilesProvider', async () => {
+            const { relatedFilesProvider } = await import('../queryProviderAdapter');
+            expect(relatedFilesProvider.queryType).toBe('related-files');
+            expect(relatedFilesProvider.validate).toBeDefined();
+        });
+
+        it('should validate graphPathProvider params', async () => {
+            const { graphPathProvider } = await import('../queryProviderAdapter');
+
+            expect(graphPathProvider.validate!({})).toMatch(/from/);
+            expect(graphPathProvider.validate!({ from: '/a.org' })).toMatch(/to/);
+            expect(graphPathProvider.validate!({ from: '/a.org', to: '/b.org' })).toBe(true);
+            expect(graphPathProvider.validate!({ from: '/a.org', to: '/b.org', maxHops: 3 })).toBe(true);
+            expect(graphPathProvider.validate!({ from: '/a.org', to: '/b.org', maxHops: -1 })).toMatch(/maxHops/);
+        });
+
+        it('should validate relatedFilesProvider params', async () => {
+            const { relatedFilesProvider } = await import('../queryProviderAdapter');
+
+            expect(relatedFilesProvider.validate!({})).toMatch(/filePath/);
+            expect(relatedFilesProvider.validate!({ filePath: '/test.org' })).toBe(true);
+        });
+    });
+});

--- a/src/adapters/graphDataAdapter.ts
+++ b/src/adapters/graphDataAdapter.ts
@@ -1,0 +1,440 @@
+/**
+ * Graph Data Provider Adapter
+ *
+ * Provides extension points for enriching graph visualizations with custom data.
+ * Plugins can register adapters to add custom node properties, edge properties,
+ * or entirely new edges beyond the standard file links.
+ *
+ * This enables building knowledge graphs with computed properties, importance
+ * scores, clusters, or semantic relationships derived from content analysis.
+ */
+
+import * as vscode from 'vscode';
+import type { GraphNode, GraphEdge } from '../linkGraph/linkGraphQueries';
+
+/**
+ * Context for graph data operations
+ */
+export interface GraphDataContext {
+    /** Center file of the graph */
+    centerFile: string;
+    /** Current traversal depth */
+    depth: number;
+    /** Maximum depth */
+    maxDepth: number;
+    /** Direction of traversal */
+    direction: 'incoming' | 'outgoing' | 'both';
+    /** Database client */
+    db: unknown;
+}
+
+/**
+ * Additional properties that can be added to nodes
+ */
+export interface NodeEnrichment {
+    /** Custom properties to merge with node */
+    properties?: Record<string, unknown>;
+    /** Override node label */
+    label?: string;
+    /** Override node color */
+    color?: string;
+    /** Override node size */
+    size?: number;
+    /** Node shape (dot, square, triangle, star, etc.) */
+    shape?: string;
+    /** Custom tooltip content */
+    tooltip?: string;
+    /** Group/cluster identifier */
+    group?: string;
+    /** Importance score (affects layout) */
+    importance?: number;
+}
+
+/**
+ * Additional properties that can be added to edges
+ */
+export interface EdgeEnrichment {
+    /** Custom properties to merge with edge */
+    properties?: Record<string, unknown>;
+    /** Override edge label */
+    label?: string;
+    /** Override edge color */
+    color?: string;
+    /** Edge width */
+    width?: number;
+    /** Edge style (solid, dashed, dotted) */
+    style?: 'solid' | 'dashed' | 'dotted';
+    /** Weight for layout algorithms */
+    weight?: number;
+}
+
+/**
+ * A custom edge to add to the graph
+ */
+export interface CustomEdge {
+    /** Source node ID (file path) */
+    from: string;
+    /** Target node ID (file path) */
+    to: string;
+    /** Relationship type */
+    type: string;
+    /** Edge label */
+    label?: string;
+    /** Edge color */
+    color?: string;
+    /** Edge width */
+    width?: number;
+    /** Edge style */
+    style?: 'solid' | 'dashed' | 'dotted';
+    /** Custom properties */
+    properties?: Record<string, unknown>;
+}
+
+/**
+ * Graph data provider interface
+ */
+export interface GraphDataProvider {
+    /** Unique identifier for this provider */
+    id: string;
+
+    /** Human-readable name */
+    name: string;
+
+    /** Description of what this provider adds */
+    description?: string;
+
+    /** Priority for ordering (higher runs first, default 0) */
+    priority?: number;
+
+    /**
+     * Enrich a node with additional data
+     * @param node The graph node to enrich
+     * @param context Graph context
+     * @returns Enrichment data or undefined to skip
+     */
+    enrichNode?(node: GraphNode, context: GraphDataContext): Promise<NodeEnrichment | undefined>;
+
+    /**
+     * Enrich an edge with additional data
+     * @param edge The graph edge to enrich
+     * @param context Graph context
+     * @returns Enrichment data or undefined to skip
+     */
+    enrichEdge?(edge: GraphEdge, context: GraphDataContext): Promise<EdgeEnrichment | undefined>;
+
+    /**
+     * Get custom edges to add to the graph
+     * These are edges beyond the standard file links (e.g., semantic relationships)
+     * @param filePath File to get custom edges for
+     * @param context Graph context
+     * @returns Array of custom edges
+     */
+    getCustomEdges?(filePath: string, context: GraphDataContext): Promise<CustomEdge[]>;
+
+    /**
+     * Filter nodes from the graph
+     * @param node Node to check
+     * @param context Graph context
+     * @returns true to include, false to exclude
+     */
+    filterNode?(node: GraphNode, context: GraphDataContext): boolean;
+
+    /**
+     * Filter edges from the graph
+     * @param edge Edge to check
+     * @param context Graph context
+     * @returns true to include, false to exclude
+     */
+    filterEdge?(edge: GraphEdge, context: GraphDataContext): boolean;
+}
+
+/**
+ * Result of applying all graph data providers
+ */
+export interface GraphEnrichmentResult {
+    /** Node enrichments by node ID */
+    nodeEnrichments: Map<string, NodeEnrichment>;
+    /** Edge enrichments by edge key (from:to) */
+    edgeEnrichments: Map<string, EdgeEnrichment>;
+    /** Custom edges to add */
+    customEdges: CustomEdge[];
+    /** Nodes to filter out */
+    filteredNodes: Set<string>;
+    /** Edges to filter out (key: from:to) */
+    filteredEdges: Set<string>;
+    /** Any errors that occurred */
+    errors: Array<{ providerId: string; error: Error }>;
+}
+
+/**
+ * Registry for graph data providers
+ */
+class GraphDataProviderRegistry {
+    /** @internal */
+    readonly providers: Map<string, GraphDataProvider> = new Map();
+
+    /**
+     * Register a new graph data provider
+     */
+    register(provider: GraphDataProvider): vscode.Disposable {
+        if (!provider.id) {
+            throw new Error('Graph data provider must have an id');
+        }
+        if (this.providers.has(provider.id)) {
+            throw new Error(`Graph data provider with id '${provider.id}' is already registered`);
+        }
+
+        this.providers.set(provider.id, provider);
+
+        return new vscode.Disposable(() => {
+            this.providers.delete(provider.id);
+        });
+    }
+
+    /**
+     * Unregister a provider by id
+     */
+    unregister(id: string): boolean {
+        return this.providers.delete(id);
+    }
+
+    /**
+     * Get all registered providers sorted by priority (higher first)
+     */
+    getProviders(): GraphDataProvider[] {
+        return Array.from(this.providers.values())
+            .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    }
+
+    /**
+     * Get a specific provider by id
+     */
+    getProvider(id: string): GraphDataProvider | undefined {
+        return this.providers.get(id);
+    }
+
+    /**
+     * Check if a provider is registered
+     */
+    hasProvider(id: string): boolean {
+        return this.providers.has(id);
+    }
+
+    /**
+     * Get all provider ids
+     */
+    getProviderIds(): string[] {
+        return Array.from(this.providers.keys());
+    }
+
+    /**
+     * Apply all providers to enrich graph data
+     */
+    async applyProviders(
+        nodes: GraphNode[],
+        edges: GraphEdge[],
+        context: GraphDataContext
+    ): Promise<GraphEnrichmentResult> {
+        const result: GraphEnrichmentResult = {
+            nodeEnrichments: new Map(),
+            edgeEnrichments: new Map(),
+            customEdges: [],
+            filteredNodes: new Set(),
+            filteredEdges: new Set(),
+            errors: []
+        };
+
+        const providers = this.getProviders();
+
+        for (const provider of providers) {
+            try {
+                // Enrich nodes
+                if (provider.enrichNode) {
+                    for (const node of nodes) {
+                        try {
+                            const enrichment = await provider.enrichNode(node, context);
+                            if (enrichment) {
+                                const existing = result.nodeEnrichments.get(node.id) || {};
+                                result.nodeEnrichments.set(node.id, {
+                                    ...existing,
+                                    ...enrichment,
+                                    properties: {
+                                        ...existing.properties,
+                                        ...enrichment.properties
+                                    }
+                                });
+                            }
+                        } catch (error) {
+                            result.errors.push({
+                                providerId: provider.id,
+                                error: error as Error
+                            });
+                        }
+                    }
+                }
+
+                // Filter nodes
+                if (provider.filterNode) {
+                    for (const node of nodes) {
+                        if (!provider.filterNode(node, context)) {
+                            result.filteredNodes.add(node.id);
+                        }
+                    }
+                }
+
+                // Enrich edges
+                if (provider.enrichEdge) {
+                    for (const edge of edges) {
+                        try {
+                            const enrichment = await provider.enrichEdge(edge, context);
+                            if (enrichment) {
+                                const key = `${edge.from}:${edge.to}`;
+                                const existing = result.edgeEnrichments.get(key) || {};
+                                result.edgeEnrichments.set(key, {
+                                    ...existing,
+                                    ...enrichment,
+                                    properties: {
+                                        ...existing.properties,
+                                        ...enrichment.properties
+                                    }
+                                });
+                            }
+                        } catch (error) {
+                            result.errors.push({
+                                providerId: provider.id,
+                                error: error as Error
+                            });
+                        }
+                    }
+                }
+
+                // Filter edges
+                if (provider.filterEdge) {
+                    for (const edge of edges) {
+                        if (!provider.filterEdge(edge, context)) {
+                            result.filteredEdges.add(`${edge.from}:${edge.to}`);
+                        }
+                    }
+                }
+
+                // Get custom edges
+                if (provider.getCustomEdges) {
+                    for (const node of nodes) {
+                        try {
+                            const customEdges = await provider.getCustomEdges(node.id, context);
+                            result.customEdges.push(...customEdges);
+                        } catch (error) {
+                            result.errors.push({
+                                providerId: provider.id,
+                                error: error as Error
+                            });
+                        }
+                    }
+                }
+            } catch (error) {
+                result.errors.push({
+                    providerId: provider.id,
+                    error: error as Error
+                });
+                console.error(`Graph data provider '${provider.id}' failed:`, error);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Clear all providers (for testing)
+     */
+    clear(): void {
+        this.providers.clear();
+    }
+}
+
+/**
+ * Global graph data provider registry instance
+ */
+export const graphDataRegistry = new GraphDataProviderRegistry();
+
+/**
+ * Register a graph data provider
+ * @returns Disposable that unregisters the provider when disposed
+ */
+export function registerGraphDataProvider(provider: GraphDataProvider): vscode.Disposable {
+    return graphDataRegistry.register(provider);
+}
+
+// ============================================================================
+// Built-in Providers
+// ============================================================================
+
+/**
+ * Link count importance provider - sizes nodes by their link count
+ */
+export const linkCountImportanceProvider: GraphDataProvider = {
+    id: 'link-count-importance',
+    name: 'Link Count Importance',
+    description: 'Sizes nodes based on their incoming and outgoing link count',
+    priority: -10, // Run last so other providers can override
+
+    async enrichNode(node, context) {
+        // Use existing metadata if available
+        const incomingLinks = node.metadata?.incomingLinks ?? 0;
+        const outgoingLinks = node.metadata?.outgoingLinks ?? 0;
+        const totalLinks = (incomingLinks as number) + (outgoingLinks as number);
+
+        // Scale size based on link count (10-50 range)
+        const size = Math.min(50, Math.max(10, 10 + Math.log2(totalLinks + 1) * 10));
+
+        return {
+            size,
+            importance: totalLinks,
+            properties: {
+                linkCount: totalLinks,
+                incomingLinks,
+                outgoingLinks
+            }
+        };
+    }
+};
+
+/**
+ * Recency coloring provider - colors nodes by modification time
+ */
+export const recencyColoringProvider: GraphDataProvider = {
+    id: 'recency-coloring',
+    name: 'Recency Coloring',
+    description: 'Colors nodes based on how recently they were modified',
+    priority: -10,
+
+    async enrichNode(node, context) {
+        const mtime = node.metadata?.mtime as number | undefined;
+        if (!mtime) {
+            return undefined;
+        }
+
+        const now = Date.now();
+        const age = now - mtime;
+        const dayMs = 24 * 60 * 60 * 1000;
+
+        // Color based on age
+        let color: string;
+        if (age < dayMs) {
+            color = '#4caf50'; // Green - modified today
+        } else if (age < 7 * dayMs) {
+            color = '#2196f3'; // Blue - modified this week
+        } else if (age < 30 * dayMs) {
+            color = '#ff9800'; // Orange - modified this month
+        } else {
+            color = '#9e9e9e'; // Gray - older
+        }
+
+        return {
+            color,
+            properties: {
+                ageInDays: Math.floor(age / dayMs),
+                lastModified: new Date(mtime).toISOString()
+            }
+        };
+    }
+};

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -122,3 +122,47 @@ export {
     createWrapperHook,
     createElementReplacerHook,
 } from './exportHooksAdapter';
+
+// Indexer Adapter (for knowledge graph extraction)
+export {
+    IndexerAdapter,
+    IndexContext,
+    ExtractedData,
+    ExtractedDataType,
+    ExtractedEntity,
+    ExtractedRelationship,
+    ExtractedMetadata,
+    ExtractedCustom,
+    IndexerResult,
+    indexerRegistry,
+    registerIndexer,
+} from './indexerAdapter';
+
+// Query Provider Adapter (for custom search types)
+export {
+    QueryProvider,
+    QueryParams,
+    QueryResult,
+    QueryResponse,
+    QueryCapabilities,
+    queryProviderRegistry,
+    registerQueryProvider,
+    // Built-in providers
+    graphPathProvider,
+    relatedFilesProvider,
+} from './queryProviderAdapter';
+
+// Graph Data Provider Adapter (for graph enrichment)
+export {
+    GraphDataProvider,
+    GraphDataContext,
+    NodeEnrichment,
+    EdgeEnrichment,
+    CustomEdge,
+    GraphEnrichmentResult,
+    graphDataRegistry,
+    registerGraphDataProvider,
+    // Built-in providers
+    linkCountImportanceProvider,
+    recencyColoringProvider,
+} from './graphDataAdapter';

--- a/src/adapters/indexerAdapter.ts
+++ b/src/adapters/indexerAdapter.ts
@@ -1,0 +1,318 @@
+/**
+ * Indexer Adapter
+ *
+ * Provides extension points for extracting custom data during file indexing.
+ * Plugins can register adapters to extract entities, relationships, or other
+ * metadata from files as they are indexed into the database.
+ *
+ * This enables building knowledge graphs, entity extraction systems, or
+ * custom metadata tracking without modifying the core indexing logic.
+ */
+
+import * as vscode from 'vscode';
+import type { OrgDocumentNode } from '../parser/orgElementTypes';
+
+/**
+ * Context passed to indexer adapters during file indexing
+ */
+export interface IndexContext {
+    /** Absolute path to the file being indexed */
+    filePath: string;
+    /** File ID in the database */
+    fileId: number;
+    /** File type (org, md) */
+    fileType: string;
+    /** File modification time */
+    mtime: number;
+    /** Database client for custom queries/inserts */
+    db: unknown;
+}
+
+/**
+ * Types of extracted data
+ */
+export type ExtractedDataType = 'entity' | 'relationship' | 'metadata' | 'custom';
+
+/**
+ * Base interface for extracted data
+ */
+export interface ExtractedDataBase {
+    /** Type of extracted data */
+    type: ExtractedDataType;
+}
+
+/**
+ * An entity extracted from a file (e.g., person, concept, term)
+ */
+export interface ExtractedEntity extends ExtractedDataBase {
+    type: 'entity';
+    /** Entity category (e.g., 'person', 'concept', 'project') */
+    category: string;
+    /** Entity name/identifier */
+    name: string;
+    /** Optional properties */
+    properties?: Record<string, unknown>;
+    /** Line number where entity was found */
+    lineNumber?: number;
+}
+
+/**
+ * A relationship between entities or files
+ */
+export interface ExtractedRelationship extends ExtractedDataBase {
+    type: 'relationship';
+    /** Source entity or file path */
+    source: string;
+    /** Target entity or file path */
+    target: string;
+    /** Relationship type (e.g., 'references', 'is_part_of', 'related_to') */
+    relation: string;
+    /** Optional weight/strength */
+    weight?: number;
+    /** Optional properties */
+    properties?: Record<string, unknown>;
+}
+
+/**
+ * Custom metadata about a file
+ */
+export interface ExtractedMetadata extends ExtractedDataBase {
+    type: 'metadata';
+    /** Metadata key */
+    key: string;
+    /** Metadata value (will be JSON serialized) */
+    value: unknown;
+}
+
+/**
+ * Custom data type for plugin-specific needs
+ */
+export interface ExtractedCustom extends ExtractedDataBase {
+    type: 'custom';
+    /** Custom data category */
+    category: string;
+    /** Custom data payload */
+    data: unknown;
+}
+
+/**
+ * Union type for all extracted data
+ */
+export type ExtractedData = ExtractedEntity | ExtractedRelationship | ExtractedMetadata | ExtractedCustom;
+
+/**
+ * Indexer adapter interface
+ */
+export interface IndexerAdapter {
+    /** Unique identifier for this adapter */
+    id: string;
+
+    /** Human-readable description */
+    description?: string;
+
+    /** Priority for ordering (higher runs first, default 0) */
+    priority?: number;
+
+    /** File types to process (e.g., ['org', 'md']). Empty means all. */
+    fileTypes?: string[];
+
+    /**
+     * Extract custom data from a file during indexing
+     * @param content Raw file content
+     * @param ast Parsed AST (may be undefined for non-org/md files)
+     * @param context Indexing context
+     * @returns Array of extracted data items
+     */
+    extract(
+        content: string,
+        ast: OrgDocumentNode | undefined,
+        context: IndexContext
+    ): Promise<ExtractedData[]>;
+
+    /**
+     * Optional: Called when a file is removed from the index
+     * Use this to clean up any custom data associated with the file
+     * @param filePath Path of the file being removed
+     * @param fileId Database ID of the file
+     * @param db Database client
+     */
+    onFileRemoved?(filePath: string, fileId: number, db: unknown): Promise<void>;
+}
+
+/**
+ * Result of running indexer adapters
+ */
+export interface IndexerResult {
+    /** All extracted entities */
+    entities: ExtractedEntity[];
+    /** All extracted relationships */
+    relationships: ExtractedRelationship[];
+    /** All extracted metadata */
+    metadata: ExtractedMetadata[];
+    /** All custom data by category */
+    custom: Map<string, ExtractedCustom[]>;
+    /** Any errors that occurred */
+    errors: Array<{ adapterId: string; error: Error }>;
+}
+
+/**
+ * Registry for indexer adapters
+ */
+class IndexerAdapterRegistry {
+    /** @internal */
+    readonly adapters: Map<string, IndexerAdapter> = new Map();
+
+    /**
+     * Register a new indexer adapter
+     */
+    register(adapter: IndexerAdapter): vscode.Disposable {
+        if (!adapter.id) {
+            throw new Error('Indexer adapter must have an id');
+        }
+        if (this.adapters.has(adapter.id)) {
+            throw new Error(`Indexer adapter with id '${adapter.id}' is already registered`);
+        }
+
+        this.adapters.set(adapter.id, adapter);
+
+        return new vscode.Disposable(() => {
+            this.adapters.delete(adapter.id);
+        });
+    }
+
+    /**
+     * Unregister an adapter by id
+     */
+    unregister(id: string): boolean {
+        return this.adapters.delete(id);
+    }
+
+    /**
+     * Get all registered adapters sorted by priority (higher first)
+     */
+    getAdapters(): IndexerAdapter[] {
+        return Array.from(this.adapters.values())
+            .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    }
+
+    /**
+     * Get adapters that handle a specific file type
+     */
+    getAdaptersForFileType(fileType: string): IndexerAdapter[] {
+        return this.getAdapters().filter(adapter => {
+            if (!adapter.fileTypes || adapter.fileTypes.length === 0) {
+                return true; // Handle all file types
+            }
+            return adapter.fileTypes.includes(fileType);
+        });
+    }
+
+    /**
+     * Get a specific adapter by id
+     */
+    getAdapter(id: string): IndexerAdapter | undefined {
+        return this.adapters.get(id);
+    }
+
+    /**
+     * Check if an adapter is registered
+     */
+    hasAdapter(id: string): boolean {
+        return this.adapters.has(id);
+    }
+
+    /**
+     * Get all adapter ids
+     */
+    getAdapterIds(): string[] {
+        return Array.from(this.adapters.keys());
+    }
+
+    /**
+     * Run all applicable adapters for a file
+     */
+    async runAdapters(
+        content: string,
+        ast: OrgDocumentNode | undefined,
+        context: IndexContext
+    ): Promise<IndexerResult> {
+        const result: IndexerResult = {
+            entities: [],
+            relationships: [],
+            metadata: [],
+            custom: new Map(),
+            errors: []
+        };
+
+        const adapters = this.getAdaptersForFileType(context.fileType);
+
+        for (const adapter of adapters) {
+            try {
+                const extracted = await adapter.extract(content, ast, context);
+
+                for (const item of extracted) {
+                    switch (item.type) {
+                        case 'entity':
+                            result.entities.push(item);
+                            break;
+                        case 'relationship':
+                            result.relationships.push(item);
+                            break;
+                        case 'metadata':
+                            result.metadata.push(item);
+                            break;
+                        case 'custom':
+                            if (!result.custom.has(item.category)) {
+                                result.custom.set(item.category, []);
+                            }
+                            result.custom.get(item.category)!.push(item);
+                            break;
+                    }
+                }
+            } catch (error) {
+                result.errors.push({
+                    adapterId: adapter.id,
+                    error: error as Error
+                });
+                console.error(`Indexer adapter '${adapter.id}' failed:`, error);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Notify adapters of file removal
+     */
+    async notifyFileRemoved(filePath: string, fileId: number, db: unknown): Promise<void> {
+        for (const adapter of this.getAdapters()) {
+            if (adapter.onFileRemoved) {
+                try {
+                    await adapter.onFileRemoved(filePath, fileId, db);
+                } catch (error) {
+                    console.error(`Indexer adapter '${adapter.id}' onFileRemoved failed:`, error);
+                }
+            }
+        }
+    }
+
+    /**
+     * Clear all adapters (for testing)
+     */
+    clear(): void {
+        this.adapters.clear();
+    }
+}
+
+/**
+ * Global indexer adapter registry instance
+ */
+export const indexerRegistry = new IndexerAdapterRegistry();
+
+/**
+ * Register an indexer adapter
+ * @returns Disposable that unregisters the adapter when disposed
+ */
+export function registerIndexer(adapter: IndexerAdapter): vscode.Disposable {
+    return indexerRegistry.register(adapter);
+}

--- a/src/adapters/queryProviderAdapter.ts
+++ b/src/adapters/queryProviderAdapter.ts
@@ -1,0 +1,465 @@
+/**
+ * Query Provider Adapter
+ *
+ * Provides extension points for custom database query types.
+ * Plugins can register query providers to add specialized search
+ * capabilities like graph traversal, path finding, or semantic queries.
+ *
+ * This enables building knowledge graph queries, recommendation systems,
+ * or custom search algorithms without modifying the core search logic.
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * Parameters for a query
+ */
+export interface QueryParams {
+    /** Query-specific parameters */
+    [key: string]: unknown;
+}
+
+/**
+ * A single query result
+ */
+export interface QueryResult {
+    /** Result type (file, heading, entity, path, etc.) */
+    type: string;
+    /** Primary identifier (usually file path) */
+    id: string;
+    /** Display label */
+    label: string;
+    /** Optional description */
+    description?: string;
+    /** Relevance score (higher is better) */
+    score?: number;
+    /** Result-specific data */
+    data?: Record<string, unknown>;
+}
+
+/**
+ * Query execution result
+ */
+export interface QueryResponse {
+    /** Query results */
+    results: QueryResult[];
+    /** Total count (may be greater than results.length if paginated) */
+    totalCount?: number;
+    /** Execution time in milliseconds */
+    executionTimeMs?: number;
+    /** Additional metadata about the query */
+    metadata?: Record<string, unknown>;
+}
+
+/**
+ * Query provider capabilities
+ */
+export interface QueryCapabilities {
+    /** Whether this provider supports pagination */
+    supportsPagination?: boolean;
+    /** Whether this provider supports filtering */
+    supportsFiltering?: boolean;
+    /** Whether results are ranked by relevance */
+    supportsRanking?: boolean;
+    /** Maximum results this provider can return */
+    maxResults?: number;
+}
+
+/**
+ * Query provider interface
+ */
+export interface QueryProvider {
+    /** Unique query type identifier (e.g., 'graph-path', 'semantic', 'related') */
+    queryType: string;
+
+    /** Human-readable name */
+    name: string;
+
+    /** Description of what this query does */
+    description?: string;
+
+    /** Provider capabilities */
+    capabilities?: QueryCapabilities;
+
+    /**
+     * Validate query parameters
+     * @returns true if valid, or error message if invalid
+     */
+    validate?(params: QueryParams): true | string;
+
+    /**
+     * Execute the query
+     * @param params Query parameters
+     * @param db Database client
+     * @returns Query response
+     */
+    execute(params: QueryParams, db: unknown): Promise<QueryResponse>;
+
+    /**
+     * Optional: Get parameter schema for documentation/UI
+     * Returns JSON Schema for the params object
+     */
+    getParamSchema?(): Record<string, unknown>;
+}
+
+/**
+ * Registry for query providers
+ */
+class QueryProviderRegistry {
+    /** @internal */
+    readonly providers: Map<string, QueryProvider> = new Map();
+
+    /**
+     * Register a new query provider
+     */
+    register(provider: QueryProvider): vscode.Disposable {
+        if (!provider.queryType) {
+            throw new Error('Query provider must have a queryType');
+        }
+        if (this.providers.has(provider.queryType)) {
+            throw new Error(`Query provider for type '${provider.queryType}' is already registered`);
+        }
+
+        this.providers.set(provider.queryType, provider);
+
+        return new vscode.Disposable(() => {
+            this.providers.delete(provider.queryType);
+        });
+    }
+
+    /**
+     * Unregister a provider by query type
+     */
+    unregister(queryType: string): boolean {
+        return this.providers.delete(queryType);
+    }
+
+    /**
+     * Get a provider by query type
+     */
+    getProvider(queryType: string): QueryProvider | undefined {
+        return this.providers.get(queryType);
+    }
+
+    /**
+     * Get all registered providers
+     */
+    getAllProviders(): QueryProvider[] {
+        return Array.from(this.providers.values());
+    }
+
+    /**
+     * Get all query types
+     */
+    getQueryTypes(): string[] {
+        return Array.from(this.providers.keys());
+    }
+
+    /**
+     * Check if a query type is registered
+     */
+    hasProvider(queryType: string): boolean {
+        return this.providers.has(queryType);
+    }
+
+    /**
+     * Execute a query
+     * @throws Error if query type is not registered or validation fails
+     */
+    async executeQuery(queryType: string, params: QueryParams, db: unknown): Promise<QueryResponse> {
+        const provider = this.providers.get(queryType);
+        if (!provider) {
+            throw new Error(`Unknown query type: ${queryType}`);
+        }
+
+        // Validate parameters if validator exists
+        if (provider.validate) {
+            const validation = provider.validate(params);
+            if (validation !== true) {
+                throw new Error(`Invalid query parameters: ${validation}`);
+            }
+        }
+
+        const startTime = Date.now();
+        const response = await provider.execute(params, db);
+
+        // Add execution time if not already set
+        if (response.executionTimeMs === undefined) {
+            response.executionTimeMs = Date.now() - startTime;
+        }
+
+        return response;
+    }
+
+    /**
+     * Clear all providers (for testing)
+     */
+    clear(): void {
+        this.providers.clear();
+    }
+}
+
+/**
+ * Global query provider registry instance
+ */
+export const queryProviderRegistry = new QueryProviderRegistry();
+
+/**
+ * Register a query provider
+ * @returns Disposable that unregisters the provider when disposed
+ */
+export function registerQueryProvider(provider: QueryProvider): vscode.Disposable {
+    return queryProviderRegistry.register(provider);
+}
+
+// ============================================================================
+// Built-in Query Providers
+// ============================================================================
+
+/**
+ * Graph path query provider - finds paths between files through links
+ */
+export const graphPathProvider: QueryProvider = {
+    queryType: 'graph-path',
+    name: 'Graph Path Finder',
+    description: 'Find shortest path between two files through link connections',
+    capabilities: {
+        supportsRanking: true,
+        maxResults: 100
+    },
+
+    validate(params) {
+        if (!params.from || typeof params.from !== 'string') {
+            return 'Missing or invalid "from" parameter (file path)';
+        }
+        if (!params.to || typeof params.to !== 'string') {
+            return 'Missing or invalid "to" parameter (file path)';
+        }
+        if (params.maxHops !== undefined && (typeof params.maxHops !== 'number' || params.maxHops < 1)) {
+            return 'Invalid "maxHops" parameter (must be positive number)';
+        }
+        return true;
+    },
+
+    async execute(params, db): Promise<QueryResponse> {
+        const from = params.from as string;
+        const to = params.to as string;
+        const maxHops = (params.maxHops as number) || 5;
+
+        // BFS to find shortest path
+        const paths = await findPaths(from, to, maxHops, db as any);
+
+        return {
+            results: paths.map((path, index) => ({
+                type: 'path',
+                id: `path-${index}`,
+                label: `Path (${path.length - 1} hops)`,
+                description: path.join(' → '),
+                score: 1 / path.length, // Shorter paths score higher
+                data: { path, hops: path.length - 1 }
+            })),
+            totalCount: paths.length,
+            metadata: { from, to, maxHops }
+        };
+    },
+
+    getParamSchema() {
+        return {
+            type: 'object',
+            properties: {
+                from: { type: 'string', description: 'Source file path' },
+                to: { type: 'string', description: 'Target file path' },
+                maxHops: { type: 'number', description: 'Maximum path length', default: 5 }
+            },
+            required: ['from', 'to']
+        };
+    }
+};
+
+/**
+ * Related files query provider - finds files related to a given file
+ */
+export const relatedFilesProvider: QueryProvider = {
+    queryType: 'related-files',
+    name: 'Related Files Finder',
+    description: 'Find files related to a given file based on shared links, tags, or content',
+    capabilities: {
+        supportsPagination: true,
+        supportsRanking: true,
+        maxResults: 50
+    },
+
+    validate(params) {
+        if (!params.filePath || typeof params.filePath !== 'string') {
+            return 'Missing or invalid "filePath" parameter';
+        }
+        return true;
+    },
+
+    async execute(params, db): Promise<QueryResponse> {
+        const filePath = params.filePath as string;
+        const limit = (params.limit as number) || 20;
+
+        const related = await findRelatedFiles(filePath, limit, db as any);
+
+        return {
+            results: related,
+            totalCount: related.length,
+            metadata: { filePath }
+        };
+    }
+};
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * BFS to find paths between files
+ */
+async function findPaths(
+    from: string,
+    to: string,
+    maxHops: number,
+    db: { execute: (opts: { sql: string; args: unknown[] }) => Promise<{ rows: any[] }> }
+): Promise<string[][]> {
+    const visited = new Set<string>();
+    const queue: Array<{ path: string[]; depth: number }> = [{ path: [from], depth: 0 }];
+    const paths: string[][] = [];
+
+    while (queue.length > 0 && paths.length < 10) {
+        const { path, depth } = queue.shift()!;
+        const current = path[path.length - 1];
+
+        if (current === to) {
+            paths.push(path);
+            continue;
+        }
+
+        if (depth >= maxHops) {
+            continue;
+        }
+
+        if (visited.has(current)) {
+            continue;
+        }
+        visited.add(current);
+
+        // Get neighbors (files this file links to)
+        try {
+            const result = await db.execute({
+                sql: `SELECT DISTINCT target FROM links
+                      WHERE file_path = ? AND link_type = 'file'
+                      AND target IN (SELECT path FROM files)`,
+                args: [current]
+            });
+
+            for (const row of result.rows) {
+                const target = row.target as string;
+                if (!path.includes(target)) {
+                    queue.push({ path: [...path, target], depth: depth + 1 });
+                }
+            }
+        } catch {
+            // Ignore errors, just skip this node
+        }
+    }
+
+    return paths;
+}
+
+/**
+ * Find files related to a given file
+ */
+async function findRelatedFiles(
+    filePath: string,
+    limit: number,
+    db: { execute: (opts: { sql: string; args: unknown[] }) => Promise<{ rows: any[] }> }
+): Promise<QueryResult[]> {
+    const results: QueryResult[] = [];
+    const scores = new Map<string, number>();
+
+    try {
+        // Files that this file links to (outgoing)
+        const outgoing = await db.execute({
+            sql: `SELECT target, COUNT(*) as count FROM links
+                  WHERE file_path = ? AND link_type = 'file'
+                  AND target IN (SELECT path FROM files)
+                  GROUP BY target`,
+            args: [filePath]
+        });
+
+        for (const row of outgoing.rows) {
+            const target = row.target as string;
+            const count = row.count as number;
+            scores.set(target, (scores.get(target) || 0) + count * 2);
+        }
+
+        // Files that link to this file (incoming/backlinks)
+        const incoming = await db.execute({
+            sql: `SELECT file_path, COUNT(*) as count FROM links
+                  WHERE target LIKE ? AND link_type = 'file'
+                  GROUP BY file_path`,
+            args: [`%${filePath.split('/').pop()}`]
+        });
+
+        for (const row of incoming.rows) {
+            const source = row.file_path as string;
+            const count = row.count as number;
+            if (source !== filePath) {
+                scores.set(source, (scores.get(source) || 0) + count * 2);
+            }
+        }
+
+        // Files with shared tags
+        const tagsResult = await db.execute({
+            sql: `SELECT tags FROM headings WHERE file_path = ? AND tags != '[]'`,
+            args: [filePath]
+        });
+
+        const fileTags = new Set<string>();
+        for (const row of tagsResult.rows) {
+            try {
+                const tags = JSON.parse(row.tags as string) as string[];
+                tags.forEach(t => fileTags.add(t));
+            } catch { /* ignore */ }
+        }
+
+        if (fileTags.size > 0) {
+            const tagArray = Array.from(fileTags);
+            for (const tag of tagArray) {
+                const taggedFiles = await db.execute({
+                    sql: `SELECT DISTINCT file_path FROM headings
+                          WHERE tags LIKE ? AND file_path != ?`,
+                    args: [`%"${tag}"%`, filePath]
+                });
+
+                for (const row of taggedFiles.rows) {
+                    const fp = row.file_path as string;
+                    scores.set(fp, (scores.get(fp) || 0) + 1);
+                }
+            }
+        }
+
+        // Sort by score and convert to results
+        const sorted = Array.from(scores.entries())
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, limit);
+
+        for (const [fp, score] of sorted) {
+            const fileName = fp.split('/').pop() || fp;
+            results.push({
+                type: 'file',
+                id: fp,
+                label: fileName,
+                description: fp,
+                score: score / 10, // Normalize
+                data: { filePath: fp, relationScore: score }
+            });
+        }
+    } catch (error) {
+        console.error('Error finding related files:', error);
+    }
+
+    return results;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,7 @@ import { registerManuscriptCommands } from './manuscript';
 import { initializeLogging, extensionLogger } from './utils/logger';
 import { registerDiredCommands } from './dired';
 import { registerFindFileCommands } from './findFile';
+import { registerLinkGraphCommands } from './linkGraph';
 
 let journalManager: JournalManager;
 let hydraManager: HydraManager;
@@ -190,6 +191,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Register Database Commands (uses lazy loading - db initializes on first command use)
     registerDbCommands(context);
+
+    // Register Link Graph Commands (uses lazy loading)
+    context.subscriptions.push(...registerLinkGraphCommands(context));
 
     // Register Database View
     registerDatabaseView(context);

--- a/src/help/docIndex.json
+++ b/src/help/docIndex.json
@@ -1,6 +1,6 @@
 {
-  "buildDate": "2026-02-01T17:59:06.897Z",
-  "count": 3300,
+  "buildDate": "2026-02-02T18:18:08.871Z",
+  "count": 3352,
   "entries": [
     {
       "heading": "Scimax VS Code",
@@ -748,7 +748,7 @@
       "heading": "Quick Start",
       "level": 2,
       "file": "00-index.org",
-      "line": 234,
+      "line": 235,
       "content": "1. *Install the extension* from the VS Code marketplace or from a VSIX file 2. *Open or create an org file* with the `.org' extension 3. *Create a heading* by typing `* My First Heading' 4. *Add a source block* and execute it: #+BEGIN_SRC org ,#+BEGIN_SRC python :results output print(\"Hello, Scimax VS Code!\") ,#+END_SRC #+END_SRC Press `C-<return>' or `C-c C-c' to execute. 5. *Explore the menus* with `C-c m' (main menu) or `C-c C-m' (context menu) See [[file:01-getting-started.org][Getting Start",
       "path": [
         "Scimax VS Code"
@@ -786,7 +786,7 @@
       "heading": "Getting Help",
       "level": 2,
       "file": "00-index.org",
-      "line": 254,
+      "line": 255,
       "content": "",
       "path": [
         "Scimax VS Code"
@@ -802,7 +802,7 @@
       "heading": "Within VS Code",
       "level": 3,
       "file": "00-index.org",
-      "line": 256,
+      "line": 257,
       "content": "- Press `C-c m' to open the main Hydra menu - Press `C-c C-m' for context-sensitive menus - Use `C-S-P' and search for \"Scimax\" commands - Hover over elements for tooltips and information",
       "path": [
         "Scimax VS Code",
@@ -841,7 +841,7 @@
       "heading": "Online Resources",
       "level": 3,
       "file": "00-index.org",
-      "line": 263,
+      "line": 264,
       "content": "- GitHub Issues: Report bugs and request features - Documentation: This documentation set",
       "path": [
         "Scimax VS Code",
@@ -866,7 +866,7 @@
       "heading": "Keybinding Help",
       "level": 3,
       "file": "00-index.org",
-      "line": 268,
+      "line": 269,
       "content": "Press `? ' at the beginning of a heading (with speed commands enabled) to see available speed commands. See [[file:24-keybindings.org][Keybindings]] for the complete reference.",
       "path": [
         "Scimax VS Code",
@@ -894,7 +894,7 @@
       "heading": "Acknowledgments",
       "level": 2,
       "file": "00-index.org",
-      "line": 275,
+      "line": 276,
       "content": "Scimax VS Code is inspired by: - [[https://github.com/jkitchin/scimax][Scimax]] - The original Emacs package by John Kitchin - [[https://orgmode.org][Org-mode]] - The powerful Emacs major mode for notes and planning - [[https://orgmode.org/worg/org-contrib/babel/][Org Babel]] - Literate programming in Org-mode",
       "path": [
         "Scimax VS Code"
@@ -928,7 +928,7 @@
       "heading": "License",
       "level": 2,
       "file": "00-index.org",
-      "line": 283,
+      "line": 284,
       "content": "Scimax VS Code is open source software. See the LICENSE file for details.",
       "path": [
         "Scimax VS Code"
@@ -949,7 +949,7 @@
       "heading": "Complete Documentation Index",
       "level": 1,
       "file": "00-index.org",
-      "line": 287,
+      "line": 288,
       "content": "This section provides a comprehensive index of all documentation topics with links for quick navigation.",
       "path": [],
       "commands": [],
@@ -971,7 +971,7 @@
       "heading": "Navigation Guides",
       "level": 2,
       "file": "00-index.org",
-      "line": 291,
+      "line": 292,
       "content": "| Document                                         | Topics Covered                                   | |--------------------------------------------------+--------------------------------------------------| | [[file:01-getting-started.org][Getting Started]] | Installation, first steps, basic usage           | | [[file:01.5-basic-syntax.org][Basic Syntax]]    | Text markup, lists, equations, blocks            | | [[file:21-navigation.org][Navigation]]           | Fuzzy search, avy-style jump, ou",
       "path": [
         "Complete Documentation Index"
@@ -1005,7 +1005,7 @@
       "heading": "Document Editing",
       "level": 2,
       "file": "00-index.org",
-      "line": 303,
+      "line": 304,
       "content": "| Document                                                       | Topics Covered                             | |----------------------------------------------------------------+--------------------------------------------| | [[file:02-document-structure.org][Document Structure]]         | Headings, folding, properties, drawers     | | [[file:30-markdown-compatibility.org][Markdown Compatibility]] | Markdown structural editing, navigation    | | [[file:03-todo-items.org][TODO Items]]            ",
       "path": [
         "Complete Documentation Index"
@@ -1038,7 +1038,7 @@
       "heading": "Code Execution",
       "level": 2,
       "file": "00-index.org",
-      "line": 315,
+      "line": 316,
       "content": "| Document                                                 | Topics Covered                               | |----------------------------------------------------------+----------------------------------------------| | [[file:07-source-blocks.org][Source Code Blocks]]        | Babel execution, header arguments            | | [[file:08-supported-languages.org][Supported Languages]] | Python, R, Julia, Shell, and more            | | [[file:09-jupyter.org][Jupyter Integration]]             | Kernel ",
       "path": [
         "Complete Documentation Index"
@@ -1072,7 +1072,7 @@
       "heading": "Export and Preview",
       "level": 2,
       "file": "00-index.org",
-      "line": 324,
+      "line": 325,
       "content": "| Document                                       | Topics Covered                    | |------------------------------------------------+-----------------------------------| | [[file:10-export.org][Export]]                 | HTML, LaTeX, PDF, Markdown export | | [[file:11-latex-preview.org][LaTeX Preview]]   | Math rendering, equation preview  | | [[file:12-image-overlays.org][Image Overlays]] | Inline image display              | | [[file:32-excalidraw.org][Excalidraw]]         | Diagram creati",
       "path": [
         "Complete Documentation Index"
@@ -1106,7 +1106,7 @@
       "heading": "Organization and Planning",
       "level": 2,
       "file": "00-index.org",
-      "line": 333,
+      "line": 334,
       "content": "| Document                               | Topics Covered                        | |----------------------------------------+---------------------------------------| | [[file:13-agenda.org][Agenda]]         | Agenda views, task filtering          | | [[file:14-journal.org][Journal]]       | Daily journaling, calendar navigation | | [[file:15-capture.org][Capture]]       | Quick note capture, templates         | | [[file:16-notebook.org][Notebook]]     | Project-based organization            | | ",
       "path": [
         "Complete Documentation Index"
@@ -1140,7 +1140,7 @@
       "heading": "Search and Database",
       "level": 2,
       "file": "00-index.org",
-      "line": 343,
+      "line": 344,
       "content": "| Document                                             | Topics Covered                                | |------------------------------------------------------+-----------------------------------------------| | [[file:18-database-search.org][Database and Search]] | Full-text search, semantic search, embeddings | | [[file:19-references.org][References]]               | Citations, bibliography, DOI lookup           |",
       "path": [
         "Complete Documentation Index"
@@ -1170,7 +1170,7 @@
       "heading": "Specialized File Editing",
       "level": 2,
       "file": "00-index.org",
-      "line": 350,
+      "line": 351,
       "content": "| Document                                             | Topics Covered                                         | |------------------------------------------------------+--------------------------------------------------------| | [[file:33-latex-navigation.org][LaTeX Navigation]]   | LaTeX speed commands, structure navigation             | | [[file:34-bibtex.org][BibTeX Editing]]               | BibTeX speed commands, entry/file operations, sorting  |",
       "path": [
         "Complete Documentation Index"
@@ -1201,7 +1201,7 @@
       "heading": "Configuration",
       "level": 2,
       "file": "00-index.org",
-      "line": 357,
+      "line": 358,
       "content": "| Document                                     | Topics Covered                      | |----------------------------------------------+-------------------------------------| | [[file:26-configuration.org][Configuration]] | All settings, customization options |",
       "path": [
         "Complete Documentation Index"
@@ -1224,7 +1224,7 @@
       "heading": "Topic Index",
       "level": 1,
       "file": "00-index.org",
-      "line": 363,
+      "line": 364,
       "content": "Quick reference to find specific features across documentation. | Topic                 | Primary Documentation                                        | Related Documentation                                                                                                      | |-----------------------+--------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------| | Agenda",
       "path": [],
       "commands": [],
@@ -1249,7 +1249,7 @@
       "heading": "Quick Start by Use Case",
       "level": 1,
       "file": "00-index.org",
-      "line": 444,
+      "line": 446,
       "content": "",
       "path": [],
       "commands": [],
@@ -1264,7 +1264,7 @@
       "heading": "I want to...",
       "level": 2,
       "file": "00-index.org",
-      "line": 446,
+      "line": 448,
       "content": "",
       "path": [
         "Quick Start by Use Case"
@@ -1279,7 +1279,7 @@
       "heading": "Take notes and organize information",
       "level": 3,
       "file": "00-index.org",
-      "line": 448,
+      "line": 450,
       "content": "- Start with [[file:01-getting-started.org][Getting Started]] - Learn [[file:01.5-basic-syntax.org][Basic Syntax]] for formatting text - Learn [[file:02-document-structure.org][Document Structure]] for headings and organization - Use [[file:15-capture.org][Capture]] for quick note-taking - Search with [[file:18-database-search.org][Database and Search]]",
       "path": [
         "Quick Start by Use Case",
@@ -1314,7 +1314,7 @@
       "heading": "Manage tasks and projects",
       "level": 3,
       "file": "00-index.org",
-      "line": 455,
+      "line": 457,
       "content": "- Set up tasks with [[file:03-todo-items.org][TODO Items]] - Add dates with [[file:06-timestamps.org][Timestamps]] - View agenda with [[file:13-agenda.org][Agenda]] - Organize projects with [[file:17-projectile.org][Projectile]] or [[file:16-notebook.org][Notebook]]",
       "path": [
         "Quick Start by Use Case",
@@ -1348,7 +1348,7 @@
       "heading": "Write scientific documents",
       "level": 3,
       "file": "00-index.org",
-      "line": 461,
+      "line": 463,
       "content": "- Execute code with [[file:07-source-blocks.org][Source Code Blocks]] - Preview math with [[file:11-latex-preview.org][LaTeX Preview]] - Manage citations with [[file:19-references.org][References]] - Export with [[file:10-export.org][Export]]",
       "path": [
         "Quick Start by Use Case",
@@ -1381,7 +1381,7 @@
       "heading": "Keep a journal",
       "level": 3,
       "file": "00-index.org",
-      "line": 467,
+      "line": 469,
       "content": "- Set up with [[file:14-journal.org][Journal]] - Use templates from [[file:15-capture.org][Capture]] - Navigate entries with [[file:21-navigation.org][Navigation]]",
       "path": [
         "Quick Start by Use Case",
@@ -1407,7 +1407,7 @@
       "heading": "Navigate efficiently",
       "level": 3,
       "file": "00-index.org",
-      "line": 472,
+      "line": 474,
       "content": "- Learn [[file:21-navigation.org][Navigation]] techniques - Master [[file:23-speed-commands.org][Speed Commands]] - Use [[file:22-hydra-menus.org][Hydra Menus]] for discovery - Reference [[file:24-keybindings.org][Keybindings]]",
       "path": [
         "Quick Start by Use Case",
@@ -1439,7 +1439,7 @@
       "heading": "Programmatically modify org files",
       "level": 3,
       "file": "00-index.org",
-      "line": 478,
+      "line": 480,
       "content": "CLOSED: [2026-01-16 Fri 20:04] - Use the [[file:27-org-api.org][Org API]] in TypeScript source blocks - Bulk update TODO states, properties, and tags - Extract and transform table data - Automate repetitive org file operations",
       "path": [
         "Quick Start by Use Case",
@@ -1474,7 +1474,7 @@
       "heading": "Configure the extension",
       "level": 3,
       "file": "00-index.org",
-      "line": 485,
+      "line": 487,
       "content": "CLOSED: [2026-01-16 Fri 20:04] - See all options in [[file:26-configuration.org][Configuration]] - Set up keybindings with [[file:24-keybindings.org][Keybindings]] - Customize menus with [[file:22-hydra-menus.org][Hydra Menus]]",
       "path": [
         "Quick Start by Use Case",
@@ -1505,7 +1505,7 @@
       "heading": "Navigation",
       "level": 1,
       "file": "00-index.org",
-      "line": 491,
+      "line": 493,
       "content": "- Index: [[file:00-index.org][Documentation Index]] - Next: [[file:01-getting-started.org][Getting Started]]",
       "path": [],
       "commands": [],
@@ -12015,7 +12015,7 @@
       "level": 1,
       "file": "05-links.org",
       "line": 632,
-      "content": "- [[file:19-references.org][References]] - Citation links and bibliography - [[file:10-export.org][Export]] - How links appear in exports - [[file:12-image-overlays.org][Image Overlays]] - Displaying linked images",
+      "content": "- [[file:19-references.org][References]] - Citation links and bibliography - [[file:10-export.org][Export]] - How links appear in exports - [[file:12-image-overlays.org][Image Overlays]] - Displaying linked images - [[file:39-link-graph.org][Link Graph]] - Visualize file connections through links",
       "path": [],
       "commands": [],
       "keybindings": [],
@@ -12036,14 +12036,17 @@
         "overlays",
         "displaying",
         "linked",
-        "images"
+        "images",
+        "file39-link-graphorg",
+        "link",
+        "graph"
       ]
     },
     {
       "heading": "Navigation",
       "level": 1,
       "file": "05-links.org",
-      "line": 638,
+      "line": 639,
       "content": "- Previous: [[file:04-tables.org][Tables]] - Index: [[file:00-index.org][Documentation Index]] - Next: [[file:06-timestamps.org][Timestamps]]",
       "path": [],
       "commands": [],
@@ -70251,7 +70254,7 @@
       "heading": "Help Commands",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 33,
+      "line": 34,
       "content": "CLOSED: [2026-01-17 Sat 13:38] Emacs-style help commands for discovering keybindings and commands. | Key   | Action                                                | |-------+-------------------------------------------------------| | C-h k | Describe key - type a key sequence to see its command | | C-h b | List keybindings - browse all keybindings             | | C-h f | Describe command - select a command to see its keys   | | C-h v | Describe variable - view setting details              | | C-h",
       "path": [],
       "commands": [],
@@ -70285,7 +70288,7 @@
       "heading": "C-h k (Describe Key)",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 46,
+      "line": 47,
       "content": "Type a key sequence using either Emacs notation (`C-c C-c', `M-x') or VS Code notation (`ctrl+c ctrl+c', `alt+x') to see what command it is bound to. Shows the command ID, title, and any context conditions (`when' clause).",
       "path": [
         "Help Commands"
@@ -70323,7 +70326,7 @@
       "heading": "C-h b (List Keybindings)",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 50,
+      "line": 51,
       "content": "Browse all scimax keybindings in a searchable list. Filter by typing to find keybindings. Select an entry to see full details or execute the command.",
       "path": [
         "Help Commands"
@@ -70354,7 +70357,7 @@
       "heading": "C-h f (Describe Command)",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 54,
+      "line": 55,
       "content": "Search for a command by name and see its keybindings. Useful when you know what you want to do but not the keybinding.",
       "path": [
         "Help Commands"
@@ -70380,7 +70383,7 @@
       "heading": "C-h v (Describe Variable/Setting)",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 58,
+      "line": 59,
       "content": "Browse all scimax settings with completion. Shows the setting type, default value, current value, and description. Actions include opening VS Code Settings to modify the value.",
       "path": [
         "Help Commands"
@@ -70415,7 +70418,7 @@
       "heading": "C-h a (Apropos)",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 62,
+      "line": 63,
       "content": "Search the documentation for keywords. Enter one or more search terms to find relevant documentation sections. Results are ranked by relevance: - Heading matches score highest - Command and keybinding mentions score high - Keyword and content matches score lower Select a result to see details or open the documentation file at that location.",
       "path": [
         "Help Commands"
@@ -70451,7 +70454,7 @@
       "heading": "Emacs-Style Editor Keybindings",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 71,
+      "line": 72,
       "content": "| Key             | Action                         | |-----------------+--------------------------------| | M-x             | Show command palette           | | C-x C-f         | Quick open file                | | C-x d           | Open Dired (directory editor)  | | C-x C-s         | Save file                      | | C-x s           | Save all files                 | | C-x k           | Close active editor            | | C-x b           | Switch to recent editor        | | C-x 3           | Spl",
       "path": [],
       "commands": [],
@@ -70488,7 +70491,7 @@
       "heading": "Navigation",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 112,
+      "line": 113,
       "content": "| Key         | Action                   | |-------------+--------------------------| | <tab>       | Toggle fold (on heading) | | S-<tab>     | Cycle global fold        | | C-c C-j     | Jump to heading          | | C-c C-n     | Next heading             | | C-c C-p     | Previous heading         | | C-c C-f     | Next sibling heading     | | C-c C-b     | Previous sibling heading | | C-c u       | Go to parent heading     | | C-<up>      | Previous source block    | | C-<down>    | Next source",
       "path": [],
       "commands": [],
@@ -70527,7 +70530,7 @@
       "heading": "Headings",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 132,
+      "line": 133,
       "content": "| Key           | Action                         | |---------------+--------------------------------| | M-<left>      | Promote heading/subtree        | | M-<right>     | Demote heading/subtree         | | M-S-<left>    | Promote subtree (not in table) | | M-S-<right>   | Demote subtree (not in table)  | | M-<up>        | Move heading/subtree up        | | M-<down>      | Move heading/subtree down      | | C-<return>    | Insert new heading             | | s-<return>    | (Mac) Insert new headin",
       "path": [],
       "commands": [],
@@ -70561,7 +70564,7 @@
       "heading": "Items",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 150,
+      "line": 151,
       "content": "| Key     | Action                             | |---------+------------------------------------| | C-c C-t | Cycle TODO state                   | | C-c C-c | Toggle checkbox (not in src block) | | C-c C-d | Insert due date (DEADLINE)         | | C-c C-s | Insert scheduled date (SCHEDULED)  |",
       "path": [],
       "commands": [],
@@ -70598,7 +70601,7 @@
       "heading": "Timestamps",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 159,
+      "line": 160,
       "content": "| Key        | Action                               | |------------+--------------------------------------| | C-c .      | Insert timestamp                     | | C-c ,      | Insert inactive timestamp            | | C-c C-r    | Add repeater to timestamp            | | S-<up>     | Shift timestamp up                   | | S-<down>   | Shift timestamp down                 | | S-<left>   | Shift timestamp left (no selection)  | | S-<right>  | Shift timestamp right (no selection) | *Note:* S-<arr",
       "path": [],
       "commands": [],
@@ -70633,7 +70636,7 @@
       "heading": "Tables",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 173,
+      "line": 174,
       "content": "| Key               | Action                            | |-------------------+-----------------------------------| | C-c \\vert         | Create table                      | | C-c S-\\           | Create table (alternative)        | | C-c -             | Insert table separator row        | | C-c ^             | Sort table by column              | | C-c S-6           | Sort table by column (alt)        | | C-c C-c           | Recalculate table (on TBLFM line) | | C-c *             | Recalculate ta",
       "path": [],
       "commands": [],
@@ -70667,7 +70670,7 @@
       "heading": "Source Blocks (Babel)",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 194,
+      "line": 195,
       "content": "",
       "path": [],
       "commands": [],
@@ -70682,7 +70685,7 @@
       "heading": "Execution",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 196,
+      "line": 197,
       "content": "| Key          | Action                              | |--------------+-------------------------------------| | C-<return>   | Execute source block                | | s-<return>   | (Mac) Execute source block          | | C-c C-c      | Execute source block (in src block) | | S-<return>   | Execute and move to next block      |",
       "path": [
         "Source Blocks (Babel)"
@@ -70712,7 +70715,7 @@
       "heading": "Navigation & Manipulation",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 205,
+      "line": 206,
       "content": "| Key           | Action                          | |---------------+---------------------------------| | C-<up>        | Previous source block           | | C-<down>      | Next source block               | | C-c C-b       | Jump to source block            | | C-c C-v g     | Jump to source block (alt)      | | C-c C-v n     | Next source block (alt)         | | C-c n         | Next source block               | | C-c C-,       | Insert source block below       | | C-c -         | Split source b",
       "path": [
         "Source Blocks (Babel)"
@@ -70749,7 +70752,7 @@
       "heading": "Advanced Babel Operations",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 223,
+      "line": 224,
       "content": "| Key       | Action                      | |-----------+-----------------------------| | C-c C-v t | Tangle source blocks        | | C-c C-v p | Execute all blocks to point | | C-c C-v i | Execute inline code         | | C-c C-v q | Queue block for execution   |",
       "path": [
         "Source Blocks (Babel)"
@@ -70783,7 +70786,7 @@
       "heading": "Export",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 232,
+      "line": 233,
       "content": "| Key           | Action                        | |---------------+-------------------------------| | C-c C-e       | Export dispatcher (show menu) | | C-c C-e h h   | Export to HTML                | | C-c C-e h o   | Export to HTML and open       | | C-c C-e l l   | Export to LaTeX               | | C-c C-e l o   | Export to LaTeX and open      | | C-c C-e l p   | Export to PDF                 | | C-c C-e l v   | Open LaTeX preview            | | C-c C-e l s   | LaTeX forward sync            | ",
       "path": [],
       "commands": [],
@@ -70813,7 +70816,7 @@
       "heading": "Links",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 246,
+      "line": 247,
       "content": "| Key        | Action                   | |------------+--------------------------| | C-c C-l    | Insert link              | | C-c C-o    | Open link                | | <return>   | Open link (when on link) | | F10        | Insert screenshot        | *Note:* On macOS, =F10= requires screen recording permission. See [[file:12-image-overlays.org::*Inserting Screenshots][Inserting Screenshots]].",
       "path": [],
       "commands": [],
@@ -70848,7 +70851,7 @@
       "heading": "Citations & References",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 257,
+      "line": 258,
       "content": "| Key        | Action                                 | |------------+----------------------------------------| | C-c ]      | Insert citation                        | | C-c z      | Insert citation from Zotero            | | C-u C-c ]  | Insert cross-reference                 | | S-<left>   | Transpose citation left (on citation)  | | S-<right>  | Transpose citation right (on citation) | | S-<up>     | Sort citations (on citation)           | | S-<down>   | Sort citations by year (on citation) ",
       "path": [],
       "commands": [],
@@ -70883,7 +70886,7 @@
       "heading": "Text Markup",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 271,
+      "line": 272,
       "content": "| Key   | Alt Key (Mac: C-M) | Action                              | |-------+--------------------+-------------------------------------| | C-c b | M-b (C-M-b)        | Bold                                | | C-c i | M-i (C-M-i)        | Italic                              | | C-c _ | M-u (C-M-u)        | Underline                           | | C-c ` | M-c (C-M-c)        | Code (inline)                       | | C-c = | M-v (C-M-v)        | Verbatim                            | | C-c + | M-x (C-",
       "path": [],
       "commands": [],
@@ -70929,7 +70932,7 @@
       "heading": "Search & Navigation",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 287,
+      "line": 288,
       "content": "",
       "path": [],
       "commands": [],
@@ -70943,7 +70946,7 @@
       "heading": "Fuzzy Search (Swiper-style)",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 289,
+      "line": 290,
       "content": "| Key     | Action                         | |---------+--------------------------------| | C-c s   | Fuzzy search in current buffer | | C-c S-s | Fuzzy search in open files     | | C-c M-s | Fuzzy search outline/headings  |",
       "path": [
         "Search & Navigation"
@@ -70973,7 +70976,7 @@
       "heading": "Jump (Avy-style)",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 297,
+      "line": 298,
       "content": "| Key     | Action                 | |---------+------------------------| | C-c j c | Jump to character      | | C-c j j | Jump to 2 characters   | | C-c j w | Jump to word           | | C-c j l | Jump to line           | | C-c j o | Jump to symbol/outline | | C-c j s | Jump to subword        |",
       "path": [
         "Search & Navigation"
@@ -71001,7 +71004,7 @@
       "heading": "Projectile",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 308,
+      "line": 309,
       "content": "| Key       | Action                          | |-----------+---------------------------------| | C-c p p   | Switch project                  | | C-c p f   | Find file in project            | | C-c p s   | Search in project               | | C-c p d   | Open project root directory     | | C-c p a   | Add project                     | | C-c p S-f | Find file in all known projects |",
       "path": [
         "Search & Navigation"
@@ -71033,7 +71036,7 @@
       "heading": "Database and Agenda",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 319,
+      "line": 320,
       "content": "CLOSED: [2026-01-24 Sat 17:38] | Key     | Action               | |---------+----------------------| | C-c a a | Agenda menu          | | C-c a w | Week agenda          | | C-c a m | Month agenda         | | C-c a t | TODO list            | | C-c a d | Deadlines            | | C-c d   | Database hydra menu  | | C-c d f | Browse indexed files | | C-c d s | Search database      | | C-c d h | Search headings      | | C-c d t | Show TODOs           | | C-c d a | Show agenda          |",
       "path": [
         "Search & Navigation"
@@ -71069,7 +71072,7 @@
       "heading": "Templates",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 336,
+      "line": 337,
       "content": "CLOSED: [2026-01-24 Sat 17:38] | Key       | Action                         | |-----------+--------------------------------| | C-c C-t i | Quick insert template          | | C-c C-t n | New file from template         | | C-c C-t l | List templates                 | | C-c C-t s | Create template from selection |",
       "path": [
         "Search & Navigation"
@@ -71102,7 +71105,7 @@
       "heading": "Spelling",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 346,
+      "line": 347,
       "content": "CLOSED: [2026-01-24 Sat 17:38] | Key     | Action                        | |---------+-------------------------------| | C-c ;   | Go to previous spelling error | | C-c S-; | Go to next spelling error     |",
       "path": [
         "Search & Navigation"
@@ -71130,7 +71133,7 @@
       "heading": "Edit Marks (Track Changes)",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 354,
+      "line": 355,
       "content": "| Key     | Action                  | |---------+-------------------------| | C-c e i | Mark insertion          | | C-c e d | Mark deletion           | | C-c e c | Add comment             | | C-c e t | Mark typo               | | C-c e a | Accept edit mark        | | C-c e r | Reject edit mark        | | C-c e ] | Next edit mark          | | C-c e [ | Previous edit mark      | | C-c e s | Show edit marks summary |",
       "path": [],
       "commands": [],
@@ -71164,7 +71167,7 @@
       "heading": "Mark Ring (Emacs-style)",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 368,
+      "line": 369,
       "content": "CLOSED: [2026-01-24 Sat 17:38] Emacs-style mark and region commands. | Key               | Action                     | |-------------------+----------------------------| | C-Space           | Set mark at point          | | C-g               | Cancel selection           | | C-c Space         | Push mark to ring          | | C-u C-Space       | Pop mark from local ring   | | Ctrl+U Ctrl+Space | Pop from local ring (alt)  | | C-x C-Space       | Pop mark from global ring  | | Ctrl+X Ctrl+Space | P",
       "path": [],
       "commands": [],
@@ -71205,7 +71208,7 @@
       "heading": "Speed Commands",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 385,
+      "line": 386,
       "content": "Speed commands are single-key shortcuts available when the cursor is at the *beginning* of a heading (the first character of the heading line). They must be enabled in settings (scimax.speedCommands.enabled).",
       "path": [],
       "commands": [
@@ -71233,7 +71236,7 @@
       "heading": "Navigation Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 389,
+      "line": 390,
       "content": "| Key | Action                            | |-----+-----------------------------------| | n   | Next heading (same level)         | | p   | Previous heading (same level)     | | f   | Next sibling heading              | | b   | Previous sibling heading          | | u   | Parent heading (up one level)     | | j   | Jump to heading (quick picker)    | | g   | Goto menu (additional navigation) |",
       "path": [
         "Speed Commands"
@@ -71266,7 +71269,7 @@
       "heading": "Visibility Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 401,
+      "line": 402,
       "content": "| Key   | Action                            | |-------+-----------------------------------| | <tab> | Toggle fold (same as regular tab) | | c     | Cycle global fold                 | | C     | Show children only                | | o     | Overview (collapse all)           | | 1     | Show level 1 headings             | | 2     | Show level 2 headings             | | 3     | Show level 3 headings             | | 0     | Show all headings                 | | N     | Narrow to subtree             ",
       "path": [
         "Speed Commands"
@@ -71300,7 +71303,7 @@
       "heading": "Structure Editing Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 415,
+      "line": 416,
       "content": "| Key | Action               | |-----+----------------------| | l   | Promote heading only | | r   | Demote heading only  | | L   | Promote subtree      | | R   | Demote subtree       | | U   | Move subtree up      | | D   | Move subtree down    |",
       "path": [
         "Speed Commands"
@@ -71327,7 +71330,7 @@
       "heading": "\"TODO\" & Content Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 426,
+      "line": 427,
       "content": "| Key | Action                 | |-----+------------------------| | t   | Cycle TODO state       | | d   | Insert DEADLINE        | | s   | Insert SCHEDULED       | | e   | Set effort estimate    | | :   | Set tags               | | P   | Set property           | | I   | Clock in               | | O   | Clock out              |",
       "path": [
         "Speed Commands"
@@ -71360,7 +71363,7 @@
       "heading": "Editing Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 439,
+      "line": 440,
       "content": "| Key | Action                  | |-----+-------------------------| | k   | Kill (cut) subtree      | | y   | Yank (paste) subtree    | | w   | Refile subtree          | | W   | Clone subtree           | | m   | Mark (select) subtree   | | @   | Mark subtree (alt)      | | ^   | Sort entries            | | a   | Archive subtree         | | A   | Toggle archive tag      | | $   | Archive to sibling      |",
       "path": [
         "Speed Commands"
@@ -71394,7 +71397,7 @@
       "heading": "Other Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 454,
+      "line": 455,
       "content": "| Key | Action                   | |-----+--------------------------| | ?   | Show speed commands help | | /   | Show speed commands help |",
       "path": [
         "Speed Commands"
@@ -71415,7 +71418,7 @@
       "heading": "BibTeX Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 461,
+      "line": 462,
       "content": "CLOSED: [2026-01-19 Mon 18:18] Speed commands for BibTeX files, active at column 0 of @entry lines (e.g., =@article{=, =@book{=).",
       "path": [
         "Speed Commands"
@@ -71442,7 +71445,7 @@
       "heading": "Navigation",
       "level": 3,
       "file": "24-keybindings.org",
-      "line": 466,
+      "line": 467,
       "content": "CLOSED: [2026-01-19 Mon 18:18] | Key | Action         | |-----+----------------| | n   | Next entry     | | p   | Previous entry | | j   | Jump to entry  |",
       "path": [
         "Speed Commands",
@@ -71469,7 +71472,7 @@
       "heading": "Formatting",
       "level": 3,
       "file": "24-keybindings.org",
-      "line": 475,
+      "line": 476,
       "content": "CLOSED: [2026-01-19 Mon 18:18] | Key | Action              | |-----+---------------------| | s   | Sort fields         | | d   | Downcase entry      | | t   | Title case title    | | S   | Sentence case title | | c   | Clean/format entry  |",
       "path": [
         "Speed Commands",
@@ -71500,7 +71503,7 @@
       "heading": "Wrap/Strip Braces (Case Protection)",
       "level": 4,
       "file": "24-keybindings.org",
-      "line": 486,
+      "line": 487,
       "content": "CLOSED: [2026-01-21 Wed 08:02] | Key         | Action                                      | |-------------+---------------------------------------------| | C-S-]       | Wrap selection or word at cursor in braces  | | C-S-[       | Strip braces from selection or word         | Wraps text in ={}= for case protection in BibTeX titles (e.g., ={NASA}=, ={Python}=). Works anywhere in the file, not just at entry start.",
       "path": [
         "Speed Commands",
@@ -71538,7 +71541,7 @@
       "heading": "Access",
       "level": 3,
       "file": "24-keybindings.org",
-      "line": 496,
+      "line": 497,
       "content": "CLOSED: [2026-01-19 Mon 18:18] | Key | Action               | |-----+----------------------| | o   | Open PDF             | | u   | Open URL/DOI         | | N   | Open notes           | | g   | Google Scholar       | | x   | CrossRef             | | w   | Web of Science       |",
       "path": [
         "Speed Commands",
@@ -71570,7 +71573,7 @@
       "heading": "OpenAlex Integration",
       "level": 3,
       "file": "24-keybindings.org",
-      "line": 508,
+      "line": 509,
       "content": "CLOSED: [2026-01-19 Mon 18:18] | Key | Action                        | |-----+-------------------------------| | C   | Show citing works (OpenAlex)  | | R   | Show related works (OpenAlex) | | r   | Show references (OpenAlex)    |",
       "path": [
         "Speed Commands",
@@ -71599,7 +71602,7 @@
       "heading": "Actions",
       "level": 3,
       "file": "24-keybindings.org",
-      "line": 517,
+      "line": 518,
       "content": "CLOSED: [2026-01-19 Mon 18:18] | Key | Action                    | |-----+---------------------------| | y   | Copy citation key         | | b   | Copy BibTeX entry         | | B   | Strip braces from entry   | | k   | Delete entry              | | K   | Generate citation key     | | U   | Update from web           | | N   | Open notes for entry      | | A   | Toggle journal abbreviation | | ?   | Show help                 |",
       "path": [
         "Speed Commands",
@@ -71634,7 +71637,7 @@
       "heading": "Toggle Speed Commands",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 532,
+      "line": 533,
       "content": "CLOSED: [2026-01-19 Mon 18:19] | Key       | Action                       | |-----------+------------------------------| | C-c C-x s | Toggle speed commands on/off |",
       "path": [],
       "commands": [],
@@ -71661,7 +71664,7 @@
       "heading": "Additional Notes",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 539,
+      "line": 540,
       "content": "CLOSED: [2026-01-19 Mon 18:19]",
       "path": [],
       "commands": [],
@@ -71679,7 +71682,7 @@
       "heading": "Context-Dependent Keybindings",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 542,
+      "line": 543,
       "content": "CLOSED: [2026-01-19 Mon 18:19] Many keybindings are context-aware and behave differently depending on cursor position: - C-c C-c toggles checkboxes normally, executes source blocks inside code blocks, and recalculates tables on TBLFM lines - S-<arrow> keys modify timestamps normally, but transpose/sort citations when on a citation - M-S-<left>/M-S-<right> promote/demote subtrees normally, but delete/insert columns when in a table - <return> opens links when cursor is on a link",
       "path": [
         "Additional Notes"
@@ -71716,7 +71719,7 @@
       "heading": "When Conditions",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 552,
+      "line": 553,
       "content": "CLOSED: [2026-01-19 Mon 18:19] Some keybindings only work in specific contexts: - Org-mode/Markdown files: Most document structure commands - On headings: Folding, promotion, demotion - In tables: Table-specific commands - In source blocks: Block execution - At heading start: Speed commands",
       "path": [
         "Additional Notes"
@@ -71750,7 +71753,7 @@
       "heading": "Mac vs Windows/Linux",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 562,
+      "line": 563,
       "content": "CLOSED: [2026-01-19 Mon 18:19] Most keybindings use C- (Ctrl) on all platforms to match Emacs conventions. Exceptions where Mac uses s- (Cmd): - s-S-j (journal) - s-<return> (execute/insert heading) - s-S-k (delete citation) - s-S-r (reload window) - C-s-v (database menu)",
       "path": [
         "Additional Notes"
@@ -71786,7 +71789,7 @@
       "heading": "LaTeX Navigation",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 572,
+      "line": 573,
       "content": "CLOSED: [2026-01-19 Mon 18:20] These keybindings are active in LaTeX files (=.tex=):",
       "path": [],
       "commands": [],
@@ -71807,7 +71810,7 @@
       "heading": "Section Navigation",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 577,
+      "line": 578,
       "content": "CLOSED: [2026-01-19 Mon 18:19] | Key         | Action                       | |-------------+------------------------------| | C-c C-n     | Next section                 | | C-c C-p     | Previous section             | | C-c C-u     | Parent section               | | C-c C-f     | Next sibling section         | | C-c C-b     | Previous sibling section     | | C-c C-j     | Jump to any section          | | C-c j       | Jump to any section (alt)    |",
       "path": [
         "LaTeX Navigation"
@@ -71849,7 +71852,7 @@
       "heading": "Structure Editing",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 590,
+      "line": 591,
       "content": "CLOSED: [2026-01-19 Mon 18:20] | Key              | Action                     | |------------------+----------------------------| | Alt+Left         | Promote section            | | Alt+Right        | Demote section             | | Alt+Shift+Left   | Promote subtree            | | Alt+Shift+Right  | Demote subtree             | | Alt+Up           | Move section up            | | Alt+Down         | Move section down          | | C-c @            | Mark (select) section      |",
       "path": [
         "LaTeX Navigation"
@@ -71891,7 +71894,7 @@
       "heading": "Environment Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 603,
+      "line": 604,
       "content": "CLOSED: [2026-01-19 Mon 18:20] | Key       | Action                          | |-----------+---------------------------------| | C-c C-e   | Select environment              | | C-c e     | Change environment type         | | C-c w     | Wrap selection in environment   | | C-c *     | Toggle starred variant          | | C-c %     | Jump to matching begin/end      | | C-c l     | Jump to label                   | | C-c C-l   | Add label to environment        |",
       "path": [
         "LaTeX Navigation"
@@ -71929,7 +71932,7 @@
       "heading": "Folding",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 616,
+      "line": 617,
       "content": "CLOSED: [2026-01-19 Mon 18:20] | Key       | Action            | |-----------+-------------------| | Tab       | Toggle fold       | | Shift+Tab | Cycle global fold |",
       "path": [
         "LaTeX Navigation"
@@ -71959,7 +71962,7 @@
       "heading": "Compile and Preview",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 624,
+      "line": 625,
       "content": "CLOSED: [2026-01-19 Mon 18:20] | Key       | Action                      | |-----------+-----------------------------| | C-c C-c   | Compile document            | | C-c v     | View PDF (built-in panel)   | | C-c C-v   | View PDF (external viewer)  | | C-c C-a   | Compile and view PDF        | | C-c g     | SyncTeX forward search      | | C-c C-k   | Clean auxiliary files       | See [[file:33-latex-navigation.org][LaTeX Navigation and Structure]] for complete documentation.",
       "path": [
         "LaTeX Navigation"
@@ -71999,7 +72002,7 @@
       "heading": "LaTeX Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 638,
+      "line": 639,
       "content": "CLOSED: [2026-01-24 Sat 17:39] Speed commands active at the start of =\\section=, =\\subsection=, or =\\begin{}= lines:",
       "path": [
         "LaTeX Navigation"
@@ -72026,7 +72029,7 @@
       "heading": "Section Speed Commands",
       "level": 3,
       "file": "24-keybindings.org",
-      "line": 643,
+      "line": 644,
       "content": "| Key | Action             | |-----+--------------------| | n   | Next section       | | p   | Previous section   | | f   | Forward sibling    | | b   | Backward sibling   | | u   | Up to parent       | | j   | Jump to section    | | U   | Move section up    | | D   | Move section down  | | <   | Promote section    | | >   | Demote section     | | I   | Insert section     | | N   | Narrow to section  | | W   | Widen (show all)   | | /   | Show help          |",
       "path": [
         "LaTeX Navigation",
@@ -72061,7 +72064,7 @@
       "heading": "Environment Speed Commands",
       "level": 3,
       "file": "24-keybindings.org",
-      "line": 662,
+      "line": 663,
       "content": "| Key | Action                  | |-----+-------------------------| | n   | Next environment        | | p   | Previous environment    | | j   | Jump to environment     | | s   | Select environment      | | c   | Change environment      | | k   | Kill environment        | | w   | Wrap in environment     | | u   | Unwrap environment      | | *   | Toggle starred variant  | | l   | Add label               | | C   | Add caption             | | i   | Environment info        | | /   | Show help       ",
       "path": [
         "LaTeX Navigation",
@@ -72096,7 +72099,7 @@
       "heading": "Quick Reference Card",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 680,
+      "line": 681,
       "content": "CLOSED: [2026-01-19 Mon 18:20]",
       "path": [],
       "commands": [],
@@ -72115,7 +72118,7 @@
       "heading": "Most Common Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 683,
+      "line": 684,
       "content": "CLOSED: [2026-01-19 Mon 18:20] | Command            | Keybinding   | |--------------------+--------------| | Open journal       | C-S-j        | | Execute code block | C-<return>   | | Cycle TODO         | C-c C-t      | | Insert timestamp   | C-c .        | | Insert link        | C-c C-l      | | Insert citation    | C-c ]        | | Export dispatcher  | C-c C-e      | | Jump to heading    | C-c C-j      | | Fuzzy search       | C-c s        | | Hydra menu         | C-c m        |",
       "path": [
         "Quick Reference Card"
@@ -72156,7 +72159,7 @@
       "heading": "Most Common Speed Commands",
       "level": 2,
       "file": "24-keybindings.org",
-      "line": 699,
+      "line": 700,
       "content": "CLOSED: [2026-01-19 Mon 18:20] | Speed Key | Action                 | |-----------+------------------------| | n/p       | Next/Previous heading  | | f/b       | Forward/Back sibling   | | u         | Up to parent           | | j         | Jump to heading        | | t         | Cycle TODO             | | l/r       | Promote/Demote subtree |",
       "path": [
         "Quick Reference Card"
@@ -72190,7 +72193,7 @@
       "heading": "Further Help",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 711,
+      "line": 712,
       "content": "CLOSED: [2026-01-19 Mon 18:20] - Use C-c m to open the Hydra menu for guided command discovery - Use M-x to search all commands by name - Enable speed commands help with ? when at heading start - See [[file:00-index.org][Documentation Index]] for comprehensive guides",
       "path": [],
       "commands": [],
@@ -72225,7 +72228,7 @@
       "heading": "Navigation",
       "level": 1,
       "file": "24-keybindings.org",
-      "line": 719,
+      "line": 720,
       "content": "CLOSED: [2026-01-19 Mon 18:20] - Previous: [[file:23-speed-commands.org][Speed Commands]] - Index: [[file:00-index.org][Documentation Index]] - Next: [[file:25-commands.org][Commands]]",
       "path": [],
       "commands": [],
@@ -73690,10 +73693,49 @@
       ]
     },
     {
-      "heading": "Troubleshooting and Diagnostics",
+      "heading": "Link Graph Visualization",
       "level": 2,
       "file": "25-commands.org",
       "line": 485,
+      "content": "Commands for visualizing file connections through links. | Command ID                           | Description                     | Default Keybinding | |--------------------------------------+---------------------------------+--------------------| | [[cmd:scimax.showLinkGraph]]         | Show Link Graph for Current File| C-c S-g            | | [[cmd:scimax.showLinkGraphForFile]]  | Show Link Graph for File        | -                  | | [[cmd:scimax.showLinkStats]]         | Show Link Statisti",
+      "path": [
+        "Database and Search"
+      ],
+      "commands": [
+        "scimax.showLinkGraph",
+        "scimax.showLinkGraphForFile",
+        "scimax.showLinkStats"
+      ],
+      "keybindings": [
+        "C-c"
+      ],
+      "keywords": [
+        "link",
+        "graph",
+        "visualization",
+        "commands",
+        "visualizing",
+        "connections",
+        "through",
+        "links",
+        "command",
+        "description",
+        "default",
+        "keybinding",
+        "-------------------------------------------------------------------------------------------",
+        "cmd",
+        "show",
+        "current",
+        "c-c",
+        "s-g",
+        "statisti"
+      ]
+    },
+    {
+      "heading": "Troubleshooting and Diagnostics",
+      "level": 2,
+      "file": "25-commands.org",
+      "line": 495,
       "content": "CLOSED: [2026-01-22 Thu 20:56] Commands for debugging issues and reporting problems. | Command ID                    | Description                | Default Keybinding | |-------------------------------+----------------------------+--------------------| | [[cmd:scimax.showErrorLog]]    | Show Error Log             | -                  | | [[cmd:scimax.clearErrors]]     | Clear Error Log            | -                  | | [[cmd:scimax.showDiagnostics]] | Show Diagnostic Report     | -            ",
       "path": [
         "Database and Search"
@@ -73731,7 +73773,7 @@
       "heading": "References (org-ref)",
       "level": 1,
       "file": "25-commands.org",
-      "line": 501,
+      "line": 511,
       "content": "CLOSED: [2026-01-17 Sat 12:46]",
       "path": [],
       "commands": [],
@@ -73749,7 +73791,7 @@
       "heading": "Citation Management",
       "level": 2,
       "file": "25-commands.org",
-      "line": 504,
+      "line": 514,
       "content": "CLOSED: [2026-01-17 Sat 12:46] | Command ID                             | Description                 | Default Keybinding   | |----------------------------------------+-----------------------------+----------------------| | [[cmd:scimax.ref.insertCitation]]      | Insert Citation             | C-c ] (org/md/latex) | | [[cmd:scimax.zotero.insertCitation]]   | Insert Citation from Zotero | C-c z (org/md/latex) | | [[cmd:scimax.ref.insertRef]]           | Insert Reference Link       | C-u C-c ]   ",
       "path": [
         "References (org-ref)"
@@ -73789,7 +73831,7 @@
       "heading": "Citation Editing",
       "level": 2,
       "file": "25-commands.org",
-      "line": 516,
+      "line": 526,
       "content": "CLOSED: [2026-01-17 Sat 12:46] | Command ID                                     | Description                   | Default Keybinding    | |------------------------------------------------+-------------------------------+-----------------------| | [[cmd:scimax.ref.transposeCitationLeft]]       | Transpose Citation Left       | S-LEFT (on citation)  | | [[cmd:scimax.ref.transposeCitationRight]]      | Transpose Citation Right      | S-RIGHT (on citation) | | [[cmd:scimax.ref.sortCitations]]       ",
       "path": [
         "References (org-ref)"
@@ -73824,7 +73866,7 @@
       "heading": "Bibliography Management",
       "level": 2,
       "file": "25-commands.org",
-      "line": 528,
+      "line": 538,
       "content": "CLOSED: [2026-01-17 Sat 12:46] | Command ID                             | Description                    | Default Keybinding | |----------------------------------------+--------------------------------+--------------------| | [[cmd:scimax.ref.openBibliography]]    | Open Bibliography              | -                  | | [[cmd:scimax.ref.fetchFromDOI]]        | Fetch BibTeX from DOI          | -                  | | [[cmd:scimax.ref.searchReferences]]    | Search References              | -    ",
       "path": [
         "References (org-ref)"
@@ -73860,7 +73902,7 @@
       "heading": "OpenAlex Integration",
       "level": 2,
       "file": "25-commands.org",
-      "line": 540,
+      "line": 550,
       "content": "CLOSED: [2026-01-17 Sat 12:46] | Command ID                          | Description                   | Default Keybinding | |-------------------------------------+-------------------------------+--------------------| | [[cmd:scimax.ref.showCitingWorks]]  | Show Citing Works (OpenAlex)  | -                  | | [[cmd:scimax.ref.showRelatedWorks]] | Show Related Works (OpenAlex) | -                  | | [[cmd:scimax.ref.searchOpenAlex]]   | Search OpenAlex               | -                  | | [[",
       "path": [
         "References (org-ref)"
@@ -73895,7 +73937,7 @@
       "heading": "BibTeX Speed Commands",
       "level": 2,
       "file": "25-commands.org",
-      "line": 551,
+      "line": 561,
       "content": "CLOSED: [2026-01-21 Wed 08:03] :PROPERTIES: :CUSTOM_ID: bibtex-speed-commands :END: Speed commands for BibTeX files, active at column 0 of @entry lines.",
       "path": [
         "References (org-ref)"
@@ -73924,7 +73966,7 @@
       "heading": "Navigation",
       "level": 3,
       "file": "25-commands.org",
-      "line": 559,
+      "line": 569,
       "content": "CLOSED: [2026-01-21 Wed 08:03] | Command ID                         | Description      | Speed Key | |------------------------------------+------------------+-----------| | [[cmd:scimax.bibtex.nextEntry]]    | Next Entry       | n         | | [[cmd:scimax.bibtex.previousEntry]]| Previous Entry   | p         | | [[cmd:scimax.bibtex.jumpToEntry]]  | Jump to Entry    | j         |",
       "path": [
         "References (org-ref)",
@@ -73958,7 +74000,7 @@
       "heading": "Formatting",
       "level": 3,
       "file": "25-commands.org",
-      "line": 568,
+      "line": 578,
       "content": "CLOSED: [2026-01-21 Wed 08:03] | Command ID                          | Description         | Speed Key   | |-------------------------------------+---------------------+-------------| | [[cmd:scimax.bibtex.sortFields]]    | Sort Fields         | s           | | [[cmd:scimax.bibtex.downcaseEntry]] | Downcase Entry      | d           | | [[cmd:scimax.bibtex.titleCase]]     | Title Case Title    | t           | | [[cmd:scimax.bibtex.sentenceCase]]  | Sentence Case Title | S           | | [[cmd:scima",
       "path": [
         "References (org-ref)",
@@ -73997,7 +74039,7 @@
       "heading": "Access",
       "level": 3,
       "file": "25-commands.org",
-      "line": 583,
+      "line": 593,
       "content": "CLOSED: [2026-01-21 Wed 11:31] | Command ID                          | Description            | Speed Key | |-------------------------------------+------------------------+-----------| | [[cmd:scimax.bibtex.openPdf]]       | Open PDF               | o         | | [[cmd:scimax.bibtex.openUrl]]       | Open URL/DOI           | u         | | [[cmd:scimax.bibtex.openNotes]]     | Open Notes             | N         | | [[cmd:scimax.bibtex.googleScholar]] | Google Scholar         | g         | | [[cmd",
       "path": [
         "References (org-ref)",
@@ -74034,7 +74076,7 @@
       "heading": "OpenAlex Integration",
       "level": 3,
       "file": "25-commands.org",
-      "line": 595,
+      "line": 605,
       "content": "CLOSED: [2026-01-21 Wed 11:31] | Command ID                             | Description           | Speed Key | |----------------------------------------+-----------------------+-----------| | [[cmd:scimax.bibtex.showCitingWorks]]  | Show Citing Works     | C         | | [[cmd:scimax.bibtex.showRelatedWorks]] | Show Related Works    | R         | | [[cmd:scimax.bibtex.showReferences]]   | Show References       | r         |",
       "path": [
         "References (org-ref)",
@@ -74070,7 +74112,7 @@
       "heading": "Actions",
       "level": 3,
       "file": "25-commands.org",
-      "line": 604,
+      "line": 614,
       "content": "CLOSED: [2026-01-21 Wed 11:31] | Command ID                         | Description          | Speed Key | |------------------------------------+----------------------+-----------| | [[cmd:scimax.bibtex.copyKey]]      | Copy Citation Key    | y         | | [[cmd:scimax.bibtex.copyBibtex]]   | Copy BibTeX Entry    | b         | | [[cmd:scimax.bibtex.killEntry]]    | Delete Entry         | k         | | [[cmd:scimax.bibtex.generateKey]]  | Generate Citation Key| K         | | [[cmd:scimax.bibtex.upd",
       "path": [
         "References (org-ref)",
@@ -74108,7 +74150,7 @@
       "heading": "File-Wide Commands",
       "level": 3,
       "file": "25-commands.org",
-      "line": 616,
+      "line": 626,
       "content": "CLOSED: [2026-01-21 Wed 11:31] These commands operate on the entire file. They appear as code lens buttons at the top of .bib files. | Command ID                              | Description          | Code Lens   | |-----------------------------------------+----------------------+-------------| | [[cmd:scimax.bibtex.validateFile]]      | Validate File        | ✓ Validate | | [[cmd:scimax.bibtex.showStatistics]]    | Show File Statistics | N entries   | | [[cmd:scimax.bibtex.sortEntries]]       | ",
       "path": [
         "References (org-ref)",
@@ -74147,7 +74189,7 @@
       "heading": "Journal Abbreviations",
       "level": 3,
       "file": "25-commands.org",
-      "line": 628,
+      "line": 638,
       "content": "CLOSED: [2026-01-21 Wed 11:32] Commands for managing journal name abbreviations in BibTeX entries. | Command ID                                      | Description                          | Default Keybinding | |-------------------------------------------------+--------------------------------------+--------------------| | [[cmd:scimax.bibtex.toggleJournalAbbreviation]] | Toggle Journal Abbreviation          | -                  | | [[cmd:scimax.bibtex.abbreviateAllJournals]]     | Abbreviate Al",
       "path": [
         "References (org-ref)",
@@ -74185,7 +74227,7 @@
       "heading": "Notebook",
       "level": 1,
       "file": "25-commands.org",
-      "line": 644,
+      "line": 654,
       "content": "CLOSED: [2026-01-17 Sat 12:46] | Command ID                              | Description                   | Default Keybinding | |-----------------------------------------+-------------------------------+--------------------| | [[cmd:scimax.notebook.new]]             | New Notebook                  | -                  | | [[cmd:scimax.notebook.open]]            | Open Notebook                 | -                  | | [[cmd:scimax.notebook.openMasterFile]]  | Open Notebook Master File     | -    ",
       "path": [],
       "commands": [
@@ -74215,7 +74257,7 @@
       "heading": "Navigation",
       "level": 1,
       "file": "25-commands.org",
-      "line": 662,
+      "line": 672,
       "content": "CLOSED: [2026-01-17 Sat 12:47]",
       "path": [],
       "commands": [],
@@ -74232,7 +74274,7 @@
       "heading": "Fuzzy Search (Swiper)",
       "level": 2,
       "file": "25-commands.org",
-      "line": 665,
+      "line": 675,
       "content": "CLOSED: [2026-01-17 Sat 12:47] | Command ID                          | Description                 | Default Keybinding | |-------------------------------------+-----------------------------+--------------------| | [[cmd:scimax.fuzzySearch]]          | Fuzzy Search (Current File) | C-c s              | | [[cmd:scimax.fuzzySearchOpenFiles]] | Fuzzy Search (Open Files)   | C-c S-s            | | [[cmd:scimax.fuzzySearchOutline]]   | Fuzzy Search (Outline)      | C-c M-s            |",
       "path": [
         "Navigation"
@@ -74272,7 +74314,7 @@
       "heading": "Jump (Avy)",
       "level": 2,
       "file": "25-commands.org",
-      "line": 674,
+      "line": 684,
       "content": "CLOSED: [2026-01-17 Sat 12:47] | Command ID                      | Description                  | Default Keybinding | |---------------------------------+------------------------------+--------------------| | [[cmd:scimax.jump.gotoChar]]    | Jump to Character            | C-c j c            | | [[cmd:scimax.jump.gotoChar2]]   | Jump to 2-Character Sequence | C-c j j            | | [[cmd:scimax.jump.gotoWord]]    | Jump to Word                 | C-c j w            | | [[cmd:scimax.jump.gotoLine]",
       "path": [
         "Navigation"
@@ -74310,7 +74352,7 @@
       "heading": "Projectile",
       "level": 1,
       "file": "25-commands.org",
-      "line": 688,
+      "line": 698,
       "content": "CLOSED: [2026-01-17 Sat 12:47] | Command ID                            | Description                   | Default Keybinding | |---------------------------------------+-------------------------------+--------------------| | [[cmd:scimax.projectile.switch]]      | Switch Project                | C-c p p            | | [[cmd:scimax.projectile.findFile]]    | Find File in Project          | C-c p f            | | [[cmd:scimax.projectile.findFileInKnownProjects]] | Find File in Known Projects | -    ",
       "path": [],
       "commands": [
@@ -74345,7 +74387,7 @@
       "heading": "Editmarks",
       "level": 1,
       "file": "25-commands.org",
-      "line": 710,
+      "line": 720,
       "content": "CLOSED: [2026-01-17 Sat 12:47]",
       "path": [],
       "commands": [],
@@ -74362,7 +74404,7 @@
       "heading": "Mark Edits",
       "level": 2,
       "file": "25-commands.org",
-      "line": 713,
+      "line": 723,
       "content": "CLOSED: [2026-01-17 Sat 12:47] | Command ID                         | Description          | Default Keybinding | |------------------------------------+----------------------+--------------------| | [[cmd:scimax.editmarks.insertion]] | Mark Insertion       | C-c e i            | | [[cmd:scimax.editmarks.deletion]]  | Mark Deletion        | C-c e d            | | [[cmd:scimax.editmarks.comment]]   | Insert Edit Comment  | C-c e c            | | [[cmd:scimax.editmarks.typo]]      | Mark Typo Corre",
       "path": [
         "Editmarks"
@@ -74403,7 +74445,7 @@
       "heading": "Review Edits",
       "level": 2,
       "file": "25-commands.org",
-      "line": 723,
+      "line": 733,
       "content": "CLOSED: [2026-01-17 Sat 12:47] | Command ID                         | Description             | Default Keybinding | |------------------------------------+-------------------------+--------------------| | [[cmd:scimax.editmarks.accept]]    | Accept Edit Mark        | C-c e a            | | [[cmd:scimax.editmarks.reject]]    | Reject Edit Mark        | C-c e r            | | [[cmd:scimax.editmarks.acceptAll]] | Accept All Edit Marks   | -                  | | [[cmd:scimax.editmarks.rejectAll]] | ",
       "path": [
         "Editmarks"
@@ -74442,7 +74484,7 @@
       "heading": "Hydra",
       "level": 1,
       "file": "25-commands.org",
-      "line": 736,
+      "line": 746,
       "content": "CLOSED: [2026-01-17 Sat 12:47] | Command ID                      | Description      | Default Keybinding | |---------------------------------+------------------+--------------------| | [[cmd:scimax.hydra.show]]       | Show Hydra Menu  | -                  | | [[cmd:scimax.hydra.hide]]       | Hide Hydra Menu  | -                  | | [[cmd:scimax.hydra.back]]       | Hydra Menu Back  | -                  | | [[cmd:scimax.hydra.main]]       | Main Menu        | C-c m              | | [[cmd:scima",
       "path": [],
       "commands": [
@@ -74479,7 +74521,7 @@
       "heading": "Markup",
       "level": 1,
       "file": "25-commands.org",
-      "line": 748,
+      "line": 758,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                             | Description                 | Default Keybinding | |----------------------------------------+-----------------------------+--------------------| | [[cmd:scimax.markup.bold]]             | Bold (Markup)               | C-c b              | | [[cmd:scimax.markup.italic]]           | Italic (Markup)             | C-c i              | | [[cmd:scimax.markup.underline]]        | Underline (Markup)          | C-c _              |",
       "path": [],
       "commands": [
@@ -74512,7 +74554,7 @@
       "heading": "Word Case & Navigation",
       "level": 1,
       "file": "25-commands.org",
-      "line": 765,
+      "line": 775,
       "content": "| Command ID                        | Description                   | Default Keybinding | |-----------------------------------+-------------------------------+--------------------| | [[cmd:scimax.capitalizeWord]]     | Capitalize Word and Move Next | M-c                | | [[cmd:scimax.lowercaseWord]]      | Lowercase Word and Move Next  | M-l                | | [[cmd:scimax.uppercaseWord]]      | Uppercase Word and Move Next  | M-u                | | [[cmd:scimax.beginningOfBuffer]]  | Beginni",
       "path": [],
       "commands": [
@@ -74551,7 +74593,7 @@
       "heading": "Speed Commands",
       "level": 1,
       "file": "25-commands.org",
-      "line": 777,
+      "line": 787,
       "content": "CLOSED: [2026-01-17 Sat 12:48] Speed commands are single-key commands available when cursor is at the beginning of a heading line (with scimax.speedCommandsEnabled).",
       "path": [],
       "commands": [
@@ -74577,7 +74619,7 @@
       "heading": "Navigation",
       "level": 2,
       "file": "25-commands.org",
-      "line": 782,
+      "line": 792,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                           | Description          | Speed Key | |--------------------------------------+----------------------+-----------| | [[cmd:scimax.speed.nextSibling]]     | Next Sibling Heading | f         | | [[cmd:scimax.speed.previousSibling]] | Previous Sibling     | b         | | [[cmd:scimax.org.nextHeading]]       | Next Heading         | n         | | [[cmd:scimax.org.previousHeading]]   | Previous Heading     | p         | | [[cmd:scima",
       "path": [
         "Speed Commands"
@@ -74612,7 +74654,7 @@
       "heading": "Visibility",
       "level": 2,
       "file": "25-commands.org",
-      "line": 797,
+      "line": 807,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                         | Description         | Speed Key | |------------------------------------+---------------------+-----------| | [[cmd:scimax.org.cycleGlobalFold]] | Cycle Global Fold   | c         | | [[cmd:scimax.speed.showChildren]]  | Show All Children   | C (S-c)   | | [[cmd:scimax.speed.overview]]      | Overview (Fold All) | o         |",
       "path": [
         "Speed Commands"
@@ -74648,7 +74690,7 @@
       "heading": "Structure Editing",
       "level": 2,
       "file": "25-commands.org",
-      "line": 806,
+      "line": 816,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                            | Description          | Speed Key | |---------------------------------------+----------------------+-----------| | [[cmd:scimax.heading.moveUp]]         | Move Heading Up      | U (S-u)   | | [[cmd:scimax.heading.moveDown]]       | Move Heading Down    | D (S-d)   | | [[cmd:scimax.heading.demote]]         | Demote Heading       | r         | | [[cmd:scimax.heading.promote]]        | Promote Heading      | l         | | [[cmd",
       "path": [
         "Speed Commands"
@@ -74686,7 +74728,7 @@
       "heading": "TODO and Tags",
       "level": 2,
       "file": "25-commands.org",
-      "line": 824,
+      "line": 834,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                        | Description      | Speed Key | |-----------------------------------+------------------+-----------| | [[cmd:scimax.org.cycleTodo]]      | Cycle TODO State | t         | | [[cmd:scimax.speed.setTags]]      | Set Tags         | : (S-;)   | | [[cmd:scimax.speed.priorityA]]    | Set Priority A   | 1         | | [[cmd:scimax.speed.priorityB]]    | Set Priority B   | 2         | | [[cmd:scimax.speed.priorityC]]    | Set Priority C   ",
       "path": [
         "Speed Commands"
@@ -74722,7 +74764,7 @@
       "heading": "Scheduling and Timestamps",
       "level": 2,
       "file": "25-commands.org",
-      "line": 836,
+      "line": 846,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                          | Description        | Speed Key | |-------------------------------------+--------------------+-----------| | [[cmd:scimax.speed.schedule]]       | Add/Edit SCHEDULED | s         | | [[cmd:scimax.speed.deadline]]       | Add/Edit DEADLINE  | d         | | [[cmd:scimax.org.insertTimestamp]]  | Insert Timestamp   | .         | | [[cmd:scimax.org.shiftTimestampUp]] | Shift Timestamp Up | ,         |",
       "path": [
         "Speed Commands"
@@ -74759,7 +74801,7 @@
       "heading": "Properties and Clocking",
       "level": 2,
       "file": "25-commands.org",
-      "line": 846,
+      "line": 856,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                       | Description  | Speed Key | |----------------------------------+--------------+-----------| | [[cmd:scimax.speed.setProperty]] | Set Property | P (S-p)   | | [[cmd:scimax.speed.setEffort]]   | Set Effort   | e         | | [[cmd:scimax.speed.clockIn]]     | Clock In     | I (S-i)   | | [[cmd:scimax.speed.clockOut]]    | Clock Out    | O (S-o)   |",
       "path": [
         "Speed Commands"
@@ -74798,7 +74840,7 @@
       "heading": "Archiving",
       "level": 2,
       "file": "25-commands.org",
-      "line": 856,
+      "line": 866,
       "content": "CLOSED: [2026-01-17 Sat 12:48] | Command ID                            | Description        | Speed Key | |---------------------------------------+--------------------+-----------| | [[cmd:scimax.speed.archiveSubtree]]   | Archive Subtree    | a         | | [[cmd:scimax.speed.toggleArchiveTag]] | Toggle Archive Tag | A (S-a)   | | [[cmd:scimax.speed.archiveToSibling]] | Archive to Sibling | $ (S-4)   |",
       "path": [
         "Speed Commands"
@@ -74834,7 +74876,7 @@
       "heading": "Narrowing",
       "level": 2,
       "file": "25-commands.org",
-      "line": 865,
+      "line": 875,
       "content": "CLOSED: [2026-01-17 Sat 12:50] Note this is not the same as narrowing in Emacs which restricts the visible portion of the window. | Command ID                           | Description       | Speed Key | |--------------------------------------+-------------------+-----------| | [[cmd:scimax.speed.narrowToSubtree]] | Narrow to Subtree | N (S-n)   | | [[cmd:scimax.speed.widen]]           | Widen             | S (S-s)   |",
       "path": [
         "Speed Commands"
@@ -74871,7 +74913,7 @@
       "heading": "Help",
       "level": 2,
       "file": "25-commands.org",
-      "line": 875,
+      "line": 885,
       "content": "CLOSED: [2026-01-17 Sat 12:49] | Command ID                  | Description           | Speed Key | |-----------------------------+-----------------------+-----------| | [[cmd:scimax.speed.help]]   | Speed Commands Help   | ? (S-/)   | | [[cmd:scimax.speed.toggle]] | Toggle Speed Commands | C-c C-x s |",
       "path": [
         "Speed Commands"
@@ -74905,7 +74947,7 @@
       "heading": "LaTeX",
       "level": 1,
       "file": "25-commands.org",
-      "line": 883,
+      "line": 893,
       "content": "CLOSED: [2026-01-21 Wed 11:33] Comprehensive LaTeX editing support with structural navigation, environment manipulation, and compilation.",
       "path": [],
       "commands": [],
@@ -74930,7 +74972,7 @@
       "heading": "Section Navigation",
       "level": 2,
       "file": "25-commands.org",
-      "line": 888,
+      "line": 898,
       "content": "CLOSED: [2026-01-21 Wed 11:33] | Command ID                                  | Description              | Default Keybinding | |---------------------------------------------+--------------------------+--------------------| | [[cmd:scimax.latex.nextSection]]            | Next Section             | C-c C-n            | | [[cmd:scimax.latex.previousSection]]        | Previous Section         | C-c C-p            | | [[cmd:scimax.latex.parentSection]]          | Parent Section           | C-c C-u   ",
       "path": [
         "LaTeX"
@@ -74971,7 +75013,7 @@
       "heading": "Environment Navigation",
       "level": 2,
       "file": "25-commands.org",
-      "line": 902,
+      "line": 912,
       "content": "CLOSED: [2026-01-21 Wed 11:33] | Command ID                                     | Description                | Default Keybinding | |------------------------------------------------+----------------------------+--------------------| | [[cmd:scimax.latex.nextEnvironment]]           | Next Environment           | -                  | | [[cmd:scimax.latex.previousEnvironment]]       | Previous Environment       | -                  | | [[cmd:scimax.latex.jumpToEnvironment]]         | Jump to Enviro",
       "path": [
         "LaTeX"
@@ -75005,7 +75047,7 @@
       "heading": "Structure Editing",
       "level": 2,
       "file": "25-commands.org",
-      "line": 913,
+      "line": 923,
       "content": "CLOSED: [2026-01-21 Wed 11:33] | Command ID                              | Description        | Default Keybinding | |-----------------------------------------+--------------------+--------------------| | [[cmd:scimax.latex.promoteSection]]     | Promote Section    | M-LEFT             | | [[cmd:scimax.latex.demoteSection]]      | Demote Section     | M-RIGHT            | | [[cmd:scimax.latex.promoteSubtree]]     | Promote Subtree    | M-S-LEFT           | | [[cmd:scimax.latex.demoteSubtree]]   ",
       "path": [
         "LaTeX"
@@ -75047,7 +75089,7 @@
       "heading": "Environment Manipulation",
       "level": 2,
       "file": "25-commands.org",
-      "line": 932,
+      "line": 942,
       "content": "CLOSED: [2026-01-21 Wed 11:33] | Command ID                                    | Description                | Default Keybinding | |-----------------------------------------------+----------------------------+--------------------| | [[cmd:scimax.latex.selectEnvironment]]        | Select Environment         | C-c C-e            | | [[cmd:scimax.latex.selectEnvironmentContent]] | Select Environment Content | -                  | | [[cmd:scimax.latex.changeEnvironment]]        | Change Environment ",
       "path": [
         "LaTeX"
@@ -75084,7 +75126,7 @@
       "heading": "Compilation and PDF Viewing",
       "level": 2,
       "file": "25-commands.org",
-      "line": 948,
+      "line": 958,
       "content": "CLOSED: [2026-01-21 Wed 11:33] | Command ID                               | Description                        | Default Keybinding | |------------------------------------------+------------------------------------+--------------------| | [[cmd:scimax.latex.compile]]             | Compile Document                   | C-c C-c            | | [[cmd:scimax.latex.viewPdf]]             | View PDF (External)                | C-c C-v            | | [[cmd:scimax.latex.viewPdfPanel]]        | View PDF (Bu",
       "path": [
         "LaTeX"
@@ -75124,7 +75166,7 @@
       "heading": "Error Navigation",
       "level": 2,
       "file": "25-commands.org",
-      "line": 967,
+      "line": 977,
       "content": "CLOSED: [2026-01-21 Wed 11:33] | Command ID                         | Description          | Default Keybinding | |------------------------------------+----------------------+--------------------| | [[cmd:scimax.latex.nextError]]     | Go to Next Error     | C-c `              | | [[cmd:scimax.latex.previousError]] | Go to Previous Error | C-c S-`            | | [[cmd:scimax.latex.showErrors]]    | Show All Errors      | C-c !              |",
       "path": [
         "LaTeX"
@@ -75161,7 +75203,7 @@
       "heading": "Insertion Commands",
       "level": 2,
       "file": "25-commands.org",
-      "line": 976,
+      "line": 986,
       "content": "CLOSED: [2026-01-21 Wed 11:34] | Command ID                          | Description     | Default Keybinding | |-------------------------------------+-----------------+--------------------| | [[cmd:scimax.latex.insertFigure]]   | Insert Figure   | -                  | | [[cmd:scimax.latex.insertTable]]    | Insert Table    | -                  | | [[cmd:scimax.latex.insertEquation]] | Insert Equation | -                  |",
       "path": [
         "LaTeX"
@@ -75195,7 +75237,7 @@
       "heading": "Utilities",
       "level": 2,
       "file": "25-commands.org",
-      "line": 985,
+      "line": 995,
       "content": "CLOSED: [2026-01-21 Wed 11:34] | Command ID                                     | Description                  | Default Keybinding | |------------------------------------------------+------------------------------+--------------------| | [[cmd:scimax.latex.format]]                    | Format Document              | C-c C-q            | | [[cmd:scimax.latex.wordCount]]                 | Word Count                   | -                  | | [[cmd:scimax.latex.addToDictionary]]           | Add Wo",
       "path": [
         "LaTeX"
@@ -75233,7 +75275,7 @@
       "heading": "Speed Commands",
       "level": 2,
       "file": "25-commands.org",
-      "line": 995,
+      "line": 1005,
       "content": "CLOSED: [2026-01-21 Wed 11:34] Speed commands are available when cursor is at the beginning of a section line. | Command ID                            | Description        | Speed Key | |---------------------------------------+--------------------+-----------| | [[cmd:scimax.latex.speedCommandHelp]] | Speed Command Help | ?         | Section speed commands (at \\section, \\subsection, etc.): - n :: Next section - p :: Previous section - f :: Next sibling - b :: Previous sibling - u :: Parent secti",
       "path": [
         "LaTeX"
@@ -75269,7 +75311,7 @@
       "heading": "Environment Speed Commands",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1021,
+      "line": 1031,
       "content": "CLOSED: [2026-01-21 Wed 11:36] Environment speed commands available at \\begin{...} lines. | Command ID                               | Description               | Speed Key | |------------------------------------------+---------------------------+-----------| | [[cmd:scimax.latex.envSpeedCommand]]     | Environment Speed Command | -         | | [[cmd:scimax.latex.envSpeedCommandHelp]] | Environment Speed Help    | ?         | Environment speed command keys: - n :: Next environment - p :: Previou",
       "path": [
         "LaTeX"
@@ -75305,7 +75347,7 @@
       "heading": "LaTeX Cache Management",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1045,
+      "line": 1055,
       "content": "CLOSED: [2026-01-21 Wed 11:36] | Command ID                     | Description                     | Default Keybinding | |--------------------------------+---------------------------------+--------------------| | [[cmd:scimax.clearLatexCache]] | Clear LaTeX Preview Cache       | -                  | | [[cmd:scimax.checkLatexTools]] | Check LaTeX Tools Availability  | -                  | | [[cmd:scimax.latexCacheStats]] | Show LaTeX Cache Statistics     | -                  |",
       "path": [
         "LaTeX"
@@ -75343,7 +75385,7 @@
       "heading": "Capture",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1054,
+      "line": 1064,
       "content": "CLOSED: [2026-01-17 Sat 12:50] | Command ID                            | Description                 | Default Keybinding | |---------------------------------------+-----------------------------+--------------------| | [[cmd:scimax.capture]]                | Capture                     | C-c c              | | [[cmd:scimax.captureByKey]]           | Capture by Key              | -                  | | [[cmd:scimax.capture.todo]]           | Quick Capture TODO          | C-c t              | | [[",
       "path": [],
       "commands": [
@@ -75376,7 +75418,7 @@
       "heading": "Templates",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1067,
+      "line": 1077,
       "content": "CLOSED: [2026-01-21 Wed 11:36] :PROPERTIES: :CUSTOM_ID: templates :END: Insert and manage file templates for org, markdown, and LaTeX files.",
       "path": [],
       "commands": [],
@@ -75401,7 +75443,7 @@
       "heading": "Insert Templates",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1075,
+      "line": 1085,
       "content": "CLOSED: [2026-01-21 Wed 11:36] | Command ID                               | Description               | Default Keybinding | |------------------------------------------+---------------------------+--------------------| | [[cmd:scimax.templates.insert]]          | Insert Template           | -                  | | [[cmd:scimax.templates.insertOrg]]       | Insert Org Template       | -                  | | [[cmd:scimax.templates.insertMarkdown]]  | Insert Markdown Template  | -                  |",
       "path": [
         "Templates"
@@ -75434,7 +75476,7 @@
       "heading": "New Files from Templates",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1086,
+      "line": 1096,
       "content": "CLOSED: [2026-01-21 Wed 11:36] | Command ID                               | Description                  | Default Keybinding | |------------------------------------------+------------------------------+--------------------| | [[cmd:scimax.templates.newFile]]         | New File from Template       | C-c C-t i          | | [[cmd:scimax.templates.newOrgFile]]      | New Org File from Template   | -                  | | [[cmd:scimax.templates.newMarkdownFile]] | New Markdown from Template   | -    ",
       "path": [
         "Templates"
@@ -75471,7 +75513,7 @@
       "heading": "Template Management",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1096,
+      "line": 1106,
       "content": "CLOSED: [2026-01-21 Wed 11:36] | Command ID                                  | Description                    | Default Keybinding | |---------------------------------------------+--------------------------------+--------------------| | [[cmd:scimax.templates.createFromSelection]]| Create Template from Selection | -                  | | [[cmd:scimax.templates.openDirectory]]      | Open Templates Directory       | -                  | | [[cmd:scimax.templates.editTemplates]]      | Edit User Tem",
       "path": [
         "Templates"
@@ -75509,7 +75551,7 @@
       "heading": "Manuscript",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1107,
+      "line": 1117,
       "content": "CLOSED: [2026-01-21 Wed 11:36] :PROPERTIES: :CUSTOM_ID: manuscript :END: Commands for preparing LaTeX manuscripts for journal submission by flattening includes. | Command ID                                | Description                       | Default Keybinding | |-------------------------------------------+-----------------------------------+--------------------| | [[cmd:scimax.manuscript.flatten]]         | Flatten Manuscript for Submission | -                  | | [[cmd:scimax.manuscript.prev",
       "path": [],
       "commands": [
@@ -75544,7 +75586,7 @@
       "heading": "Image Overlays",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1126,
+      "line": 1136,
       "content": "CLOSED: [2026-01-17 Sat 12:50] | Command ID                                     | Description                            | Default Keybinding | |------------------------------------------------+----------------------------------------+--------------------| | [[cmd:scimax.imageOverlays.toggle]]            | Toggle Image Overlays                  | -                  | | [[cmd:scimax.imageOverlays.toggleCurrentFile]] | Toggle Image Overlays for Current File | -                  | | [[cmd:scimax.im",
       "path": [],
       "commands": [
@@ -75574,7 +75616,7 @@
       "heading": "Spelling",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1140,
+      "line": 1150,
       "content": "CLOSED: [2026-01-24 Sat 17:41] Commands for navigating spelling errors. Requires VS Code spell-checking extension. | Command ID                            | Description                   | Default Keybinding | |---------------------------------------+-------------------------------+--------------------| | [[cmd:scimax.spelling.nextError]]     | Go to Next Spelling Error     | -                  | | [[cmd:scimax.spelling.previousError]] | Go to Previous Spelling Error | -                  |",
       "path": [],
       "commands": [
@@ -75609,7 +75651,7 @@
       "heading": "Jupyter",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1150,
+      "line": 1160,
       "content": "CLOSED: [2026-01-17 Sat 12:50]",
       "path": [],
       "commands": [],
@@ -75626,7 +75668,7 @@
       "heading": "Kernel Management",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1153,
+      "line": 1163,
       "content": "CLOSED: [2026-01-17 Sat 12:50] | Command ID                             | Description                    | Default Keybinding | |----------------------------------------+--------------------------------+--------------------| | [[cmd:scimax.jupyter.showKernels]]     | Show Available Jupyter Kernels | -                  | | [[cmd:scimax.jupyter.showRunning]]     | Show Running Kernels           | -                  | | [[cmd:scimax.jupyter.startKernel]]     | Start Jupyter Kernel           | -    ",
       "path": [
         "Jupyter"
@@ -75662,7 +75704,7 @@
       "heading": "Appendix: Keybinding Quick Reference",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1167,
+      "line": 1177,
       "content": "CLOSED: [2026-01-17 Sat 12:50]",
       "path": [],
       "commands": [],
@@ -75682,7 +75724,7 @@
       "heading": "Most Common Keybindings",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1170,
+      "line": 1180,
       "content": "CLOSED: [2026-01-17 Sat 12:50] | Keybinding   | Command                             | |--------------+-------------------------------------| | C-RET        | Execute code block / Insert heading | | C-c C-e      | Export dispatcher                   | | C-c C-j      | Jump to heading                     | | C-c C-t      | Cycle TODO state                    | | C-c C-l      | Insert link                         | | C-c C-o      | Open link                           | | C-c ]        | Insert citat",
       "path": [
         "Appendix: Keybinding Quick Reference"
@@ -75724,7 +75766,7 @@
       "heading": "Export Keybindings",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1192,
+      "line": 1202,
       "content": "CLOSED: [2026-01-17 Sat 12:50] | Keybinding  | Export Target      | |-------------+--------------------| | C-c C-e h h | HTML               | | C-c C-e h o | HTML and open      | | C-c C-e l l | LaTeX              | | C-c C-e l p | PDF                | | C-c C-e l o | PDF and open       | | C-c C-e l v | LaTeX live preview | | C-c C-e m m | Markdown           |",
       "path": [
         "Appendix: Keybinding Quick Reference"
@@ -75758,7 +75800,7 @@
       "heading": "Babel/Source Block Keybindings",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1205,
+      "line": 1215,
       "content": "CLOSED: [2026-01-17 Sat 12:51] | Keybinding | Action                 | |------------+------------------------| | C-RET      | Execute block          | | C-c C-c    | Execute block (in src) | | S-RET      | Execute and next       | | C-c C-v t  | Tangle                 | | C-c C-v p  | Execute to point       | | C-c C-v i  | Execute inline         | | C-c C-v q  | Queue block            | | C-DOWN     | Next source block      | | C-UP       | Previous source block  | | C-c C-n    | Insert block b",
       "path": [
         "Appendix: Keybinding Quick Reference"
@@ -75799,7 +75841,7 @@
       "heading": "Project and Navigation Keybindings",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1222,
+      "line": 1232,
       "content": "CLOSED: [2026-01-17 Sat 12:51] | Keybinding | Action                    | |------------+---------------------------| | C-c p p    | Switch project            | | C-c p f    | Find file in project      | | C-c p s    | Search in project         | | C-c p d    | Open project root         | | C-c p a    | Add project               | | C-c s      | Fuzzy search (current)    | | C-c S-s    | Fuzzy search (open files) | | C-c M-s    | Fuzzy search (outline)    | | C-c j c    | Jump to character       ",
       "path": [
         "Appendix: Keybinding Quick Reference"
@@ -75836,7 +75878,7 @@
       "heading": "Help System",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1239,
+      "line": 1249,
       "content": "CLOSED: [2026-01-18 Sun 09:59] :PROPERTIES: :CUSTOM_ID: help-system :END: Commands for discovering keybindings and command functionality. | Command ID                           | Description            | Default Keybinding | |--------------------------------------+------------------------+--------------------| | [[cmd:scimax.help.describeCommand]]  | Describe Command       | C-h f              | | [[cmd:scimax.help.describeKey]]      | Describe Key           | C-h k              | | [[cmd:scimax",
       "path": [],
       "commands": [
@@ -75873,7 +75915,7 @@
       "heading": "scimax.help.describeCommand",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1256,
+      "line": 1266,
       "content": "Shows the keybindings for a specific command. Useful for learning keyboard shortcuts.",
       "path": [
         "Help System"
@@ -75897,7 +75939,7 @@
       "heading": "scimax.help.describeKey",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1260,
+      "line": 1270,
       "content": "Describes what a specific key combination does. Enter the key sequence to see its bound command.",
       "path": [
         "Help System"
@@ -75921,7 +75963,7 @@
       "heading": "scimax.help.listKeybindings",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1264,
+      "line": 1274,
       "content": "Lists all keybindings defined by the extension. Opens a quick pick to browse available shortcuts.",
       "path": [
         "Help System"
@@ -75947,7 +75989,7 @@
       "heading": "scimax.help.describeVariable",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1268,
+      "line": 1278,
       "content": "Browse all scimax settings with completion. Shows the setting type, default value, current value, and description. Select a setting to open VS Code Settings.",
       "path": [
         "Help System"
@@ -75977,7 +76019,7 @@
       "heading": "scimax.help.apropos",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1272,
+      "line": 1282,
       "content": "Search the documentation for keywords. Enter search terms to find relevant documentation sections. Results are ranked by relevance (headings, commands, keybindings, content). Select a result to view details or open the documentation file.",
       "path": [
         "Help System"
@@ -76013,7 +76055,7 @@
       "heading": "scimax.update",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1276,
+      "line": 1286,
       "content": "CLOSED: [2026-01-24 Sat 17:41] Update Scimax VS Code from GitHub releases. This command: 1. Fetches the latest release from the [[https://github.com/jkitchin/scimax_vscode][GitHub repository]] 2. Shows the current version vs. the latest available version 3. Downloads the VSIX file with progress indication 4. Installs it using VS Code's extension manager 5. Offers to reload VS Code to activate the new version This provides an easy way to update without leaving VS Code. Requires the repository to ",
       "path": [
         "Help System"
@@ -76049,7 +76091,7 @@
       "heading": "Linting",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1289,
+      "line": 1299,
       "content": "CLOSED: [2026-01-18 Sun 09:59] :PROPERTIES: :CUSTOM_ID: linting :END: Commands for checking org-mode document quality. | Command ID                     | Description        | Default Keybinding | |--------------------------------+--------------------+--------------------| | [[cmd:scimax.org.lint]]        | Run Linter         | -                  | | [[cmd:scimax.org.lintCheckers]]| Show Lint Checkers | -                  |",
       "path": [],
       "commands": [
@@ -76084,7 +76126,7 @@
       "heading": "scimax.org.lint",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1302,
+      "line": 1312,
       "content": "Runs the org-mode linter on the current document. The linter checks for: - Duplicate IDs - Broken internal links - Missing TODO keywords in sequences - Unbalanced brackets and quotes - Invalid timestamps - Missing required properties - And more Results appear in the Problems panel.",
       "path": [
         "Linting"
@@ -76120,7 +76162,7 @@
       "heading": "scimax.org.lintCheckers",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1315,
+      "line": 1325,
       "content": "Shows available lint checkers and allows enabling/disabling specific checks.",
       "path": [
         "Linting"
@@ -76144,7 +76186,7 @@
       "heading": "Mark Ring",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1319,
+      "line": 1329,
       "content": ":PROPERTIES: :CUSTOM_ID: mark-ring :END: Emacs-style mark ring for navigation and selection. Save cursor positions (marks) and return to them later. Each document has its own mark ring, plus there's a global mark ring that tracks positions across all documents. | Command ID                       | Description               | Default Keybinding | |----------------------------------+---------------------------+--------------------| | [[cmd:scimax.mark.set]]          | Set Mark (for selection)  | C",
       "path": [],
       "commands": [
@@ -76178,7 +76220,7 @@
       "heading": "Mark Ring Concepts",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1339,
+      "line": 1349,
       "content": "- **Mark**: A saved cursor position that you can return to - **Point**: The current cursor position - **Mark Ring**: A stack of marks (per-document), most recent first (default size: 16) - **Global Mark Ring**: A cross-file stack of marks for navigating between documents - **Selection Mode**: When mark is set, cursor movement extends the selection from the mark",
       "path": [
         "Mark Ring"
@@ -76212,7 +76254,7 @@
       "heading": "Common Workflows",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1347,
+      "line": 1357,
       "content": "",
       "path": [
         "Mark Ring"
@@ -76228,7 +76270,7 @@
       "heading": "Setting a Mark for Selection",
       "level": 3,
       "file": "25-commands.org",
-      "line": 1349,
+      "line": 1359,
       "content": "1. Press =C-SPC= to set mark at current position (line flashes briefly as feedback) 2. Move cursor to end of desired selection - the region automatically expands 3. Press =C-SPC= again to deactivate selection mode (toggle behavior) 4. Press =C-g= to cancel selection and collapse to cursor position",
       "path": [
         "Mark Ring",
@@ -76266,7 +76308,7 @@
       "heading": "Returning to Previous Positions",
       "level": 3,
       "file": "25-commands.org",
-      "line": 1355,
+      "line": 1365,
       "content": "1. Press =C-SPC C-SPC= to push mark without activating selection mode 2. Navigate elsewhere in the file 3. Press =C-u C-SPC= to pop the most recent mark and jump to it 4. Current position is saved before jumping, so you can return with another pop",
       "path": [
         "Mark Ring",
@@ -76304,7 +76346,7 @@
       "heading": "Cross-file Navigation",
       "level": 3,
       "file": "25-commands.org",
-      "line": 1361,
+      "line": 1371,
       "content": "1. Marks are automatically pushed to the global ring when set 2. Press =C-x C-SPC= to pop from global mark ring and jump (can cross files) 3. Use =C-x C-x= to exchange point and mark (swap current position with last mark)",
       "path": [
         "Mark Ring",
@@ -76342,7 +76384,7 @@
       "heading": "Viewing the Mark Ring",
       "level": 3,
       "file": "25-commands.org",
-      "line": 1366,
+      "line": 1376,
       "content": "1. Run =scimax.mark.show= from command palette 2. Quick pick shows local marks and global marks with line previews 3. Select an entry to jump to that position 4. Timestamps show how long ago each mark was set",
       "path": [
         "Mark Ring",
@@ -76379,7 +76421,7 @@
       "heading": "Publishing",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1372,
+      "line": 1382,
       "content": "CLOSED: [2026-01-18 Sun 10:02] :PROPERTIES: :CUSTOM_ID: publishing :END: Commands for publishing org files to HTML, creating static sites similar to Emacs org-publish. | Command ID                        | Description                   | Default Keybinding | |-----------------------------------+-------------------------------+--------------------| | [[cmd:scimax.publish.init]]       | Initialize Publishing Project | -                  | | [[cmd:scimax.publish.project]]    | Publish Project      ",
       "path": [],
       "commands": [
@@ -76414,7 +76456,7 @@
       "heading": "Setting Up a Publishing Project",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1389,
+      "line": 1399,
       "content": "1. Run =scimax.publish.init= to create a publishing configuration 2. Configure the project in the generated =.org-publish.json= file 3. Use =scimax.publish.project= to publish the configured project",
       "path": [
         "Publishing"
@@ -76442,7 +76484,7 @@
       "heading": "Publishing Configuration",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1395,
+      "line": 1405,
       "content": "The =.org-publish.json= file configures: - Source directory for org files - Output directory for HTML - Include/exclude patterns - HTML template settings - Asset handling (CSS, images)",
       "path": [
         "Publishing"
@@ -76473,7 +76515,7 @@
       "heading": "Query Replace",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1404,
+      "line": 1414,
       "content": "CLOSED: [2026-01-18 Sun 10:02] :PROPERTIES: :CUSTOM_ID: query-replace :END: Interactive search and replace. | Command ID                  | Description   | Default Keybinding | |-----------------------------+---------------+--------------------| | [[cmd:scimax.queryReplace]] | Query Replace | M-%                | Provides Emacs-style interactive query-replace with confirmation for each replacement.",
       "path": [],
       "commands": [
@@ -76507,7 +76549,7 @@
       "heading": "Utilities",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1419,
+      "line": 1429,
       "content": "CLOSED: [2026-01-21 Wed 13:21] :PROPERTIES: :CUSTOM_ID: utilities :END: Miscellaneous utility commands. | Command ID                       | Description                       | Default Keybinding | |----------------------------------+-----------------------------------+--------------------| | [[cmd:scimax.openFolder]]        | Open Folder                       | -                  | | [[cmd:scimax.dired.open]]        | Open Dired (Directory Editor)     | C-x d              | | [[cmd:scimax.dired",
       "path": [],
       "commands": [
@@ -76545,7 +76587,7 @@
       "heading": "Dired Commands",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1436,
+      "line": 1446,
       "content": "Dired (Directory Editor) provides Emacs-style file management. Open with =C-x d= and use these keys in the dired panel: - Navigation: =n/p= (next/prev), =RET= (open), =^= (parent), =g= (refresh) - Marking: =m= (mark), =u= (unmark), =U= (unmark all), =t= (toggle marks) - Operations: =D= (delete), =C= (copy), =R= (rename/move), =+= (create directory) - WDired: =C-x C-q= (enter edit mode), =C-c C-c= (commit), =C-c C-k= (cancel) See [[file:37-dired.org][Dired documentation]] for full details.",
       "path": [
         "Utilities"
@@ -76584,7 +76626,7 @@
       "heading": "scimax.replaceNonAscii",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1447,
+      "line": 1457,
       "content": "Replaces common non-ASCII characters (smart quotes, em-dashes, etc.) with their ASCII equivalents. Useful for preparing documents for systems that don't handle Unicode well.",
       "path": [
         "Utilities"
@@ -76618,7 +76660,7 @@
       "heading": "scimax.showDebugInfo",
       "level": 2,
       "file": "25-commands.org",
-      "line": 1451,
+      "line": 1461,
       "content": "Displays diagnostic information about the scimax extension, including version, enabled features, and configuration state. Useful for troubleshooting.",
       "path": [
         "Utilities"
@@ -76648,7 +76690,7 @@
       "heading": "Index",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1455,
+      "line": 1465,
       "content": "CLOSED: [2026-01-17 Sat 12:51] This document contains [[*Introduction][310+ commands]] organized into [[*Document Structure][27 categories]] with their keybindings and descriptions. For configuration options, see the VS Code settings under scimax.*. For more information about the Scimax VS Code extension, visit the project repository.",
       "path": [],
       "commands": [],
@@ -76680,7 +76722,7 @@
       "heading": "Navigation",
       "level": 1,
       "file": "25-commands.org",
-      "line": 1464,
+      "line": 1474,
       "content": "- Previous: [[file:24-keybindings.org][Keybindings]] - Index: [[file:00-index.org][Documentation Index]] - Next: [[file:26-configuration.org][Configuration]]",
       "path": [],
       "commands": [],
@@ -95774,6 +95816,1006 @@
       ]
     },
     {
+      "heading": "Link Graph Visualization",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 10,
+      "content": "The link graph feature provides an interactive visualization of how your files are connected through links. Files are shown as nodes, and the links between them are shown as edges, enabling you to explore your knowledge base as a network.",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "link",
+        "graph",
+        "visualization",
+        "feature",
+        "provides",
+        "interactive",
+        "connected",
+        "through",
+        "links",
+        "shown",
+        "nodes",
+        "between",
+        "them",
+        "edges",
+        "enabling",
+        "explore",
+        "knowledge",
+        "base",
+        "network"
+      ]
+    },
+    {
+      "heading": "Overview",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 14,
+      "content": "The link graph visualization helps you: - *Discover connections* - See which files link to each other - *Navigate your knowledge base* - Click on nodes to open files - *Explore relationships* - Follow chains of links across multiple files - *Filter by context* - Filter links by tags, TODO states, and more",
+      "path": [
+        "Link Graph Visualization"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "overview",
+        "link",
+        "graph",
+        "visualization",
+        "helps",
+        "discover",
+        "connections",
+        "navigate",
+        "knowledge",
+        "base",
+        "click",
+        "nodes",
+        "open",
+        "explore",
+        "relationships",
+        "follow",
+        "chains",
+        "links",
+        "across",
+        "multiple"
+      ]
+    },
+    {
+      "heading": "Opening the Link Graph",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 23,
+      "content": "",
+      "path": [
+        "Link Graph Visualization"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "opening",
+        "link",
+        "graph"
+      ]
+    },
+    {
+      "heading": "Commands",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 25,
+      "content": "| Key         | Command                      | Description                      | |-------------+------------------------------+----------------------------------| | C-c S-g     | scimax.showLinkGraph         | Show link graph for current file | | (none)      | scimax.showLinkGraphForFile  | Show link graph for a file       | | (none)      | scimax.showLinkStats         | Show link statistics for file    |",
+      "path": [
+        "Link Graph Visualization",
+        "Opening the Link Graph"
+      ],
+      "commands": [
+        "scimax.showLinkGraph",
+        "scimax.showLinkGraphForFile",
+        "scimax.showLinkStats"
+      ],
+      "keybindings": [
+        "C-c"
+      ],
+      "keywords": [
+        "commands",
+        "key",
+        "command",
+        "description",
+        "-----------------------------------------------------------------------------",
+        "c-c",
+        "s-g",
+        "show",
+        "link",
+        "graph",
+        "current",
+        "none",
+        "statistics"
+      ]
+    },
+    {
+      "heading": "From Command Palette",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 33,
+      "content": "1. Open the Command Palette (=Ctrl+Shift+P=) 2. Type \"Link Graph\" or \"Scimax: Show Link Graph\" 3. Select the command",
+      "path": [
+        "Link Graph Visualization",
+        "Opening the Link Graph"
+      ],
+      "commands": [],
+      "keybindings": [
+        "Ctrl+Shift+P"
+      ],
+      "keywords": [
+        "command",
+        "palette",
+        "open",
+        "ctrlshiftp",
+        "type",
+        "link",
+        "graph",
+        "scimax",
+        "show",
+        "select"
+      ]
+    },
+    {
+      "heading": "Context Menu",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 39,
+      "content": "Right-click on a file in the explorer and select \"Show Link Graph\".",
+      "path": [
+        "Link Graph Visualization",
+        "Opening the Link Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "context",
+        "menu",
+        "right-click",
+        "explorer",
+        "select",
+        "show",
+        "link",
+        "graph"
+      ]
+    },
+    {
+      "heading": "Understanding the Graph",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 43,
+      "content": "",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "understanding",
+        "graph"
+      ]
+    },
+    {
+      "heading": "Nodes",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 45,
+      "content": "Each node in the graph represents a file: - *Center node* - The starting file, highlighted in a distinct color - *Connected nodes* - Files that link to or from the center file - *Node size* - Larger nodes have more connections",
+      "path": [
+        "Understanding the Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "nodes",
+        "node",
+        "graph",
+        "represents",
+        "center",
+        "starting",
+        "highlighted",
+        "distinct",
+        "color",
+        "connected",
+        "link",
+        "size",
+        "larger",
+        "connections"
+      ]
+    },
+    {
+      "heading": "Edges",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 53,
+      "content": "Edges (lines) represent links between files: - *Direction* - Arrows show link direction (source → target) - *Bidirectional* - Some file pairs may have links in both directions",
+      "path": [
+        "Understanding the Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "edges",
+        "lines",
+        "represent",
+        "links",
+        "between",
+        "direction",
+        "arrows",
+        "show",
+        "link",
+        "source",
+        "target",
+        "bidirectional",
+        "pairs",
+        "directions"
+      ]
+    },
+    {
+      "heading": "Node Tooltips",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 60,
+      "content": "Hover over a node to see information about the file: - File name and path - File type (org, markdown) - Number of headings - Number of TODO items - Tags present in the file - Modification time",
+      "path": [
+        "Understanding the Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "node",
+        "tooltips",
+        "hover",
+        "over",
+        "information",
+        "about",
+        "name",
+        "path",
+        "type",
+        "org",
+        "markdown",
+        "number",
+        "headings",
+        "todo",
+        "items",
+        "tags",
+        "present",
+        "modification",
+        "time"
+      ]
+    },
+    {
+      "heading": "Interacting with the Graph",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 71,
+      "content": "",
+      "path": [
+        "Understanding the Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "interacting",
+        "graph"
+      ]
+    },
+    {
+      "heading": "Click",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 73,
+      "content": "- *Single click* - Opens the file in the editor",
+      "path": [
+        "Understanding the Graph",
+        "Interacting with the Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "click",
+        "single",
+        "opens",
+        "editor"
+      ]
+    },
+    {
+      "heading": "Double-click",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 77,
+      "content": "- *Double-click* - Recenters the graph on that file",
+      "path": [
+        "Understanding the Graph",
+        "Interacting with the Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "double-click",
+        "recenters",
+        "graph"
+      ]
+    },
+    {
+      "heading": "Drag",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 81,
+      "content": "- *Drag nodes* - Move nodes around to arrange the layout - Nodes stay where you place them until you recenter",
+      "path": [
+        "Understanding the Graph",
+        "Interacting with the Graph"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "drag",
+        "nodes",
+        "move",
+        "around",
+        "arrange",
+        "layout",
+        "stay",
+        "place",
+        "them",
+        "until",
+        "recenter"
+      ]
+    },
+    {
+      "heading": "Graph Controls",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 86,
+      "content": "",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "graph",
+        "controls"
+      ]
+    },
+    {
+      "heading": "Depth",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 88,
+      "content": "Controls how many hops away from the center file to include: | Depth | Description                                    | |-------+------------------------------------------------| | 1     | Only direct connections                        | | 2     | Connections and their connections              | | 3     | Up to 3 hops away (larger graphs)              | Larger depths show more of the network but can become cluttered.",
+      "path": [
+        "Graph Controls"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "depth",
+        "controls",
+        "many",
+        "hops",
+        "away",
+        "center",
+        "include",
+        "description",
+        "-------------------------------------------------------",
+        "direct",
+        "connections",
+        "larger",
+        "graphs",
+        "depths",
+        "show",
+        "network",
+        "become",
+        "cluttered"
+      ]
+    },
+    {
+      "heading": "Direction",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 100,
+      "content": "Controls which types of links to follow: | Direction | Description                            | |-----------+----------------------------------------| | Both      | Show incoming and outgoing links       | | Outgoing  | Only show files this file links to     | | Incoming  | Only show files that link to this file |",
+      "path": [
+        "Graph Controls"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "direction",
+        "controls",
+        "types",
+        "links",
+        "follow",
+        "description",
+        "---------------------------------------------------",
+        "show",
+        "incoming",
+        "outgoing",
+        "link"
+      ]
+    },
+    {
+      "heading": "Filters",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 110,
+      "content": "The filter panel allows you to narrow down which links appear in the graph based on various criteria.",
+      "path": [
+        "Graph Controls"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "filters",
+        "filter",
+        "panel",
+        "allows",
+        "narrow",
+        "down",
+        "links",
+        "appear",
+        "graph",
+        "based",
+        "various",
+        "criteria"
+      ]
+    },
+    {
+      "heading": "File Type Filter",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 114,
+      "content": "Filter by file extension: - =org= - Org-mode files only - =md= - Markdown files only",
+      "path": [
+        "Graph Controls",
+        "Filters"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "type",
+        "filter",
+        "extension",
+        "org",
+        "org-mode",
+        "markdown"
+      ]
+    },
+    {
+      "heading": "Tag Filter",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 120,
+      "content": "Filter to show only links within headings that have specific tags: - Enter comma-separated tags (e.g., =project,important=) - A link appears if its containing heading has ANY of the specified tags",
+      "path": [
+        "Graph Controls",
+        "Filters"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "tag",
+        "filter",
+        "show",
+        "links",
+        "within",
+        "headings",
+        "specific",
+        "tags",
+        "enter",
+        "comma-separated",
+        "projectimportant",
+        "link",
+        "appears",
+        "containing",
+        "heading",
+        "any",
+        "specified"
+      ]
+    },
+    {
+      "heading": "TODO State Filter",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 126,
+      "content": "Filter links by the TODO state of their containing heading: - =TODO= - Links in headings with TODO state - =DONE= - Links in completed headings - =WAITING=, =NEXT=, etc. - Other states",
+      "path": [
+        "Graph Controls",
+        "Filters"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "todo",
+        "state",
+        "filter",
+        "links",
+        "containing",
+        "heading",
+        "headings",
+        "done",
+        "completed",
+        "waiting",
+        "next",
+        "etc",
+        "states"
+      ]
+    },
+    {
+      "heading": "Exclude Done Filter",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 133,
+      "content": "When checked, links in headings with DONE or CANCELLED states are hidden.",
+      "path": [
+        "Graph Controls",
+        "Filters"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "exclude",
+        "done",
+        "filter",
+        "checked",
+        "links",
+        "headings",
+        "cancelled",
+        "states",
+        "hidden"
+      ]
+    },
+    {
+      "heading": "Modified After Filter",
+      "level": 3,
+      "file": "39-link-graph.org",
+      "line": 137,
+      "content": "Show only links in files modified after a certain date: - Enter a date in YYYY-MM-DD format - Useful for finding recently updated connections",
+      "path": [
+        "Graph Controls",
+        "Filters"
+      ],
+      "commands": [],
+      "keybindings": [
+        "M-DD"
+      ],
+      "keywords": [
+        "modified",
+        "after",
+        "filter",
+        "show",
+        "links",
+        "certain",
+        "date",
+        "enter",
+        "yyyy-mm-dd",
+        "format",
+        "useful",
+        "finding",
+        "recently",
+        "updated",
+        "connections"
+      ]
+    },
+    {
+      "heading": "Link Statistics",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 143,
+      "content": "The =scimax.showLinkStats= command shows a summary of links for the current file: #+BEGIN_EXAMPLE Link Statistics for notes.org Outgoing links: 15 By type: file: 8 http: 5 cite: 2 Incoming links (backlinks): 3 #+END_EXAMPLE After viewing statistics, you can click \"Show Graph\" to open the full visualization.",
+      "path": [],
+      "commands": [
+        "scimax.showLinkStats"
+      ],
+      "keybindings": [],
+      "keywords": [
+        "link",
+        "statistics",
+        "command",
+        "shows",
+        "summary",
+        "links",
+        "current",
+        "beginexample",
+        "notesorg",
+        "outgoing",
+        "type",
+        "http",
+        "cite",
+        "incoming",
+        "backlinks",
+        "endexample",
+        "after",
+        "viewing",
+        "click",
+        "show"
+      ]
+    },
+    {
+      "heading": "How Links Are Indexed",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 160,
+      "content": "Links are extracted from your org and markdown files and stored in the database:",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "links",
+        "indexed",
+        "extracted",
+        "org",
+        "markdown",
+        "stored",
+        "database"
+      ]
+    },
+    {
+      "heading": "Link Types",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 164,
+      "content": "| Type  | Description                       | Example                  | |-------+-----------------------------------+--------------------------| | file  | Links to other files              | [[file:other.org]]       | | http  | Web links                         | [[https://example.com]]  | | https | Secure web links                  | [[https://example.com]]  | | cite  | Citation links                    | cite:author-2024         | | id    | Links to headings by ID           | [[id:abc-123]]  ",
+      "path": [
+        "How Links Are Indexed"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "link",
+        "types",
+        "type",
+        "description",
+        "example",
+        "--------------------------------------------------------------------",
+        "links",
+        "fileotherorg",
+        "http",
+        "web",
+        "httpsexamplecom",
+        "https",
+        "secure",
+        "cite",
+        "citation",
+        "citeauthor-2024",
+        "headings",
+        "idabc-123"
+      ]
+    },
+    {
+      "heading": "Heading Association",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 175,
+      "content": "Each link is associated with its containing heading. This enables filtering: - Links under a heading inherit that heading's tags - Filter by TODO state to see links in active vs completed tasks - Filter by priority to focus on important connections",
+      "path": [
+        "How Links Are Indexed"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "heading",
+        "association",
+        "link",
+        "associated",
+        "containing",
+        "enables",
+        "filtering",
+        "links",
+        "under",
+        "inherit",
+        "tags",
+        "filter",
+        "todo",
+        "state",
+        "active",
+        "completed",
+        "tasks",
+        "priority",
+        "focus",
+        "important"
+      ]
+    },
+    {
+      "heading": "Use Cases",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 183,
+      "content": "",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "cases"
+      ]
+    },
+    {
+      "heading": "Exploring Backlinks",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 185,
+      "content": "Want to see what references a particular file? 1. Open the file 2. Run =scimax.showLinkGraph= 3. Set direction to \"Incoming\" 4. Explore which files cite this one",
+      "path": [
+        "Use Cases"
+      ],
+      "commands": [
+        "scimax.showLinkGraph"
+      ],
+      "keybindings": [],
+      "keywords": [
+        "exploring",
+        "backlinks",
+        "want",
+        "references",
+        "particular",
+        "open",
+        "run",
+        "set",
+        "direction",
+        "incoming",
+        "explore",
+        "cite",
+        "one"
+      ]
+    },
+    {
+      "heading": "Tracing Topic Chains",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 194,
+      "content": "Want to follow a chain of related topics? 1. Open a starting file 2. Set depth to 2 or 3 3. Double-click interesting nodes to recenter 4. Follow the chain of connections",
+      "path": [
+        "Use Cases"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "tracing",
+        "topic",
+        "chains",
+        "want",
+        "follow",
+        "chain",
+        "related",
+        "topics",
+        "open",
+        "starting",
+        "set",
+        "depth",
+        "double-click",
+        "interesting",
+        "nodes",
+        "recenter",
+        "connections"
+      ]
+    },
+    {
+      "heading": "Finding Active Project Connections",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 203,
+      "content": "Want to see links only in active tasks? 1. Open a project file 2. Apply filter: TODO state = \"TODO\" or \"NEXT\" 3. Or check \"Exclude done\" to hide completed items 4. See which files are referenced by active work",
+      "path": [
+        "Use Cases"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "finding",
+        "active",
+        "project",
+        "connections",
+        "want",
+        "links",
+        "tasks",
+        "open",
+        "apply",
+        "filter",
+        "todo",
+        "state",
+        "next",
+        "check",
+        "exclude",
+        "done",
+        "hide",
+        "completed",
+        "items",
+        "referenced"
+      ]
+    },
+    {
+      "heading": "Recent Modifications Review",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 212,
+      "content": "Want to see recently updated connections? 1. Apply \"Modified after\" filter with a recent date 2. See which connected files have been recently changed 3. Useful for reviewing changes in a connected set of notes",
+      "path": [
+        "Use Cases"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "recent",
+        "modifications",
+        "review",
+        "want",
+        "recently",
+        "updated",
+        "connections",
+        "apply",
+        "modified",
+        "after",
+        "filter",
+        "date",
+        "connected",
+        "changed",
+        "useful",
+        "reviewing",
+        "changes",
+        "set",
+        "notes"
+      ]
+    },
+    {
+      "heading": "Technical Details",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 220,
+      "content": "",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "technical",
+        "details"
+      ]
+    },
+    {
+      "heading": "Database Tables",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 222,
+      "content": "The link graph uses the =links= table in the Scimax database: | Column      | Description                            | |-------------+----------------------------------------| | file_path   | Source file containing the link        | | target      | Link target (path, URL, etc.)          | | link_type   | Type of link (file, http, cite, etc.)  | | line_number | Line where link appears                | | heading_id  | ID of containing heading (for filters) |",
+      "path": [
+        "Technical Details"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "database",
+        "tables",
+        "link",
+        "graph",
+        "uses",
+        "links",
+        "table",
+        "scimax",
+        "column",
+        "description",
+        "-----------------------------------------------------",
+        "filepath",
+        "source",
+        "containing",
+        "target",
+        "path",
+        "url",
+        "etc",
+        "linktype",
+        "type"
+      ]
+    },
+    {
+      "heading": "Visualization Technology",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 234,
+      "content": "The graph is rendered using vis.js Network in a VS Code webview: - Force-directed layout automatically arranges nodes - Physics simulation enables smooth dragging - SVG rendering for crisp display at any zoom level",
+      "path": [
+        "Technical Details"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "visualization",
+        "technology",
+        "graph",
+        "rendered",
+        "visjs",
+        "network",
+        "code",
+        "webview",
+        "force-directed",
+        "layout",
+        "automatically",
+        "arranges",
+        "nodes",
+        "physics",
+        "simulation",
+        "enables",
+        "smooth",
+        "dragging",
+        "svg",
+        "rendering"
+      ]
+    },
+    {
+      "heading": "Performance",
+      "level": 2,
+      "file": "39-link-graph.org",
+      "line": 242,
+      "content": "- Default maximum of 100 nodes to prevent overwhelming graphs - Truncation indicator shows when limit is reached - Use filters to narrow down large graphs",
+      "path": [
+        "Technical Details"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "performance",
+        "default",
+        "maximum",
+        "100",
+        "nodes",
+        "prevent",
+        "overwhelming",
+        "graphs",
+        "truncation",
+        "indicator",
+        "shows",
+        "limit",
+        "reached",
+        "filters",
+        "narrow",
+        "down",
+        "large"
+      ]
+    },
+    {
+      "heading": "Related Topics",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 248,
+      "content": "- [[file:05-links.org][Hyperlinks]] - Creating and following links - [[file:18-database-search.org][Database and Search]] - Database structure and search - [[file:16-notebook.org][Notebooks]] - Project organization with nb: links",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "related",
+        "topics",
+        "file05-linksorg",
+        "hyperlinks",
+        "creating",
+        "following",
+        "links",
+        "file18-database-searchorg",
+        "database",
+        "search",
+        "structure",
+        "file16-notebookorg",
+        "notebooks",
+        "project",
+        "organization"
+      ]
+    },
+    {
+      "heading": "Navigation",
+      "level": 1,
+      "file": "39-link-graph.org",
+      "line": 254,
+      "content": "- Previous: [[file:38-find-file.org][Find File]] - Index: [[file:00-index.org][Documentation Index]]",
+      "path": [],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "navigation",
+        "previous",
+        "file38-find-fileorg",
+        "find",
+        "index",
+        "file00-indexorg",
+        "documentation"
+      ]
+    },
+    {
       "heading": "Overview",
       "level": 1,
       "file": "DOCUMENTATION_PLAN.org",
@@ -97987,10 +99029,459 @@
       ]
     },
     {
-      "heading": "Potential Future Extension Points",
+      "heading": "Database Extension Points",
       "level": 2,
       "file": "extension-points.org",
       "line": 579,
+      "content": "Extension points for extracting custom data during indexing, running custom queries, and enriching graph visualizations. These enable building knowledge graphs, custom search algorithms, and entity extraction systems.",
+      "path": [
+        "Extension Points"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "database",
+        "extension",
+        "points",
+        "extracting",
+        "custom",
+        "data",
+        "during",
+        "indexing",
+        "running",
+        "queries",
+        "enriching",
+        "graph",
+        "visualizations",
+        "enable",
+        "building",
+        "knowledge",
+        "graphs",
+        "search",
+        "algorithms",
+        "entity"
+      ]
+    },
+    {
+      "heading": "IndexerAdapter - Custom Content Extraction",
+      "level": 3,
+      "file": "extension-points.org",
+      "line": 585,
+      "content": "Hook into the file indexing pipeline to extract entities, relationships, or custom metadata from files as they are indexed. Location: =src/adapters/indexerAdapter.ts=",
+      "path": [
+        "Extension Points",
+        "Database Extension Points"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "indexeradapter",
+        "custom",
+        "content",
+        "extraction",
+        "hook",
+        "into",
+        "indexing",
+        "pipeline",
+        "extract",
+        "entities",
+        "relationships",
+        "metadata",
+        "indexed",
+        "location",
+        "srcadaptersindexeradapterts"
+      ]
+    },
+    {
+      "heading": "IndexerAdapter Interface",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 592,
+      "content": "#+BEGIN_SRC typescript interface IndexerAdapter { /** Unique identifier */ id: string; /** Human-readable description */ description?: string; /** Priority for ordering (higher first) */ priority?: number; /** File types to process (['org', 'md']). Empty = all. */ fileTypes?: string[]; /** Extract custom data during indexing */ extract( content: string, ast: OrgDocumentNode | undefined, context: IndexContext ): Promise<ExtractedData[]>; /** Called when file is removed (cleanup) */",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "IndexerAdapter - Custom Content Extraction"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "indexeradapter",
+        "interface",
+        "beginsrc",
+        "typescript",
+        "unique",
+        "identifier",
+        "string",
+        "human-readable",
+        "description",
+        "priority",
+        "ordering",
+        "higher",
+        "first",
+        "number",
+        "types",
+        "process",
+        "org",
+        "empty",
+        "filetypes",
+        "extract"
+      ]
+    },
+    {
+      "heading": "Extracted Data Types",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 628,
+      "content": "#+BEGIN_SRC typescript // Entity - a named concept, person, project, etc. interface ExtractedEntity { type: 'entity'; category: string;  // 'person', 'concept', 'project' name: string; properties?: Record<string, unknown>; lineNumber?: number; } // Relationship between entities or files interface ExtractedRelationship { type: 'relationship'; source: string; target: string; relation: string;  // 'references', 'is_part_of', 'related_to' weight?: number; properties?: Record<string, unknown>; }",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "IndexerAdapter - Custom Content Extraction"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "extracted",
+        "data",
+        "types",
+        "beginsrc",
+        "typescript",
+        "entity",
+        "named",
+        "concept",
+        "person",
+        "project",
+        "etc",
+        "interface",
+        "extractedentity",
+        "type",
+        "category",
+        "string",
+        "name",
+        "properties",
+        "recordstring",
+        "unknown"
+      ]
+    },
+    {
+      "heading": "Example: Entity Extractor",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 658,
+      "content": "#+BEGIN_SRC typescript import { registerIndexer, IndexerAdapter } from './adapters/indexerAdapter'; const entityExtractor: IndexerAdapter = { id: 'knowledge-graph-entities', description: 'Extract named entities for knowledge graph', fileTypes: ['org', 'md'], async extract(content, ast, context) { const entities: ExtractedEntity[] = []; // Example: Extract #+CONCEPT: definitions const conceptMatches = content.matchAll(/^#\\+CONCEPT:\\s*(.+)$/gm); for (const match of conceptMatches) { entities.push(",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "IndexerAdapter - Custom Content Extraction"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "example",
+        "entity",
+        "extractor",
+        "beginsrc",
+        "typescript",
+        "import",
+        "registerindexer",
+        "indexeradapter",
+        "adaptersindexeradapter",
+        "const",
+        "entityextractor",
+        "knowledge-graph-entities",
+        "description",
+        "extract",
+        "named",
+        "entities",
+        "knowledge",
+        "graph",
+        "filetypes",
+        "org"
+      ]
+    },
+    {
+      "heading": "QueryProviderAdapter - Custom Search Types",
+      "level": 3,
+      "file": "extension-points.org",
+      "line": 688,
+      "content": "Register custom query providers for specialized searches like graph traversal, path finding, or semantic similarity queries. Location: =src/adapters/queryProviderAdapter.ts=",
+      "path": [
+        "Extension Points",
+        "Database Extension Points"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "queryprovideradapter",
+        "custom",
+        "search",
+        "types",
+        "register",
+        "query",
+        "providers",
+        "specialized",
+        "searches",
+        "like",
+        "graph",
+        "traversal",
+        "path",
+        "finding",
+        "semantic",
+        "similarity",
+        "queries",
+        "location",
+        "srcadaptersqueryprovideradapterts"
+      ]
+    },
+    {
+      "heading": "QueryProvider Interface",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 695,
+      "content": "#+BEGIN_SRC typescript interface QueryProvider { /** Query type identifier */ queryType: string; /** Human-readable name */ name: string; /** Description */ description?: string; /** Capabilities (pagination, filtering, ranking) */ capabilities?: QueryCapabilities; /** Validate parameters (return true or error message) */ validate?(params: QueryParams): true | string; /** Execute the query */ execute(params: QueryParams, db: unknown): Promise<QueryResponse>; } interface QueryResponse { results: ",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "QueryProviderAdapter - Custom Search Types"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "queryprovider",
+        "interface",
+        "beginsrc",
+        "typescript",
+        "query",
+        "type",
+        "identifier",
+        "querytype",
+        "string",
+        "human-readable",
+        "name",
+        "description",
+        "capabilities",
+        "pagination",
+        "filtering",
+        "ranking",
+        "querycapabilities",
+        "validate",
+        "parameters",
+        "return"
+      ]
+    },
+    {
+      "heading": "Built-in Query Providers",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 726,
+      "content": "| Query Type    | Description                          | Parameters          | |---------------+--------------------------------------+---------------------| | graph-path    | Find shortest path between files     | from, to, maxHops   | | related-files | Find files related by links and tags | filePath, limit     |",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "QueryProviderAdapter - Custom Search Types"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "built-in",
+        "query",
+        "providers",
+        "type",
+        "description",
+        "parameters",
+        "--------------------------------------------------------------------------",
+        "graph-path",
+        "find",
+        "shortest",
+        "path",
+        "between",
+        "maxhops",
+        "related-files",
+        "related",
+        "links",
+        "tags",
+        "filepath",
+        "limit"
+      ]
+    },
+    {
+      "heading": "Example: Custom Similarity Query",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 733,
+      "content": "#+BEGIN_SRC typescript import { registerQueryProvider, QueryProvider } from './adapters/queryProviderAdapter'; const similarityProvider: QueryProvider = { queryType: 'semantic-similarity', name: 'Semantic Similarity Search', description: 'Find semantically similar files using embeddings', validate(params) { if (!params.filePath) return 'Missing filePath'; return true; }, async execute(params, db) { const filePath = params.filePath as string; const limit = (params.limit as number) || 10;",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "QueryProviderAdapter - Custom Search Types"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "example",
+        "custom",
+        "similarity",
+        "query",
+        "beginsrc",
+        "typescript",
+        "import",
+        "registerqueryprovider",
+        "queryprovider",
+        "adaptersqueryprovideradapter",
+        "const",
+        "similarityprovider",
+        "querytype",
+        "semantic-similarity",
+        "name",
+        "semantic",
+        "search",
+        "description",
+        "find",
+        "semantically"
+      ]
+    },
+    {
+      "heading": "GraphDataProviderAdapter - Graph Enrichment",
+      "level": 3,
+      "file": "extension-points.org",
+      "line": 769,
+      "content": "Add custom data to link graph nodes and edges, or inject additional edges beyond the standard file links (e.g., semantic relationships). Location: =src/adapters/graphDataAdapter.ts=",
+      "path": [
+        "Extension Points",
+        "Database Extension Points"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "graphdataprovideradapter",
+        "graph",
+        "enrichment",
+        "add",
+        "custom",
+        "data",
+        "link",
+        "nodes",
+        "edges",
+        "inject",
+        "additional",
+        "beyond",
+        "standard",
+        "links",
+        "semantic",
+        "relationships",
+        "location",
+        "srcadaptersgraphdataadapterts"
+      ]
+    },
+    {
+      "heading": "GraphDataProvider Interface",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 776,
+      "content": "#+BEGIN_SRC typescript interface GraphDataProvider { id: string; name: string; description?: string; priority?: number; /** Enrich node with custom properties */ enrichNode?(node: GraphNode, context: GraphDataContext): Promise<NodeEnrichment | undefined>; /** Enrich edge with custom properties */ enrichEdge?(edge: GraphEdge, context: GraphDataContext): Promise<EdgeEnrichment | undefined>; /** Add custom edges (e.g., semantic relationships) */ getCustomEdges?(filePath: string, context: GraphDataC",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "GraphDataProviderAdapter - Graph Enrichment"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "graphdataprovider",
+        "interface",
+        "beginsrc",
+        "typescript",
+        "string",
+        "name",
+        "description",
+        "priority",
+        "number",
+        "enrich",
+        "node",
+        "custom",
+        "properties",
+        "enrichnode",
+        "graphnode",
+        "context",
+        "graphdatacontext",
+        "promisenodeenrichment",
+        "undefined",
+        "edge"
+      ]
+    },
+    {
+      "heading": "Built-in Providers",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 813,
+      "content": "| Provider ID          | Description                              | |----------------------+------------------------------------------| | link-count-importance | Sizes nodes based on link count         | | recency-coloring     | Colors nodes by modification recency     |",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "GraphDataProviderAdapter - Graph Enrichment"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "built-in",
+        "providers",
+        "provider",
+        "description",
+        "----------------------------------------------------------------",
+        "link-count-importance",
+        "sizes",
+        "nodes",
+        "based",
+        "link",
+        "count",
+        "recency-coloring",
+        "colors",
+        "modification",
+        "recency"
+      ]
+    },
+    {
+      "heading": "Example: Cluster Provider",
+      "level": 4,
+      "file": "extension-points.org",
+      "line": 820,
+      "content": "#+BEGIN_SRC typescript import { registerGraphDataProvider, GraphDataProvider } from './adapters/graphDataAdapter'; const clusterProvider: GraphDataProvider = { id: 'topic-clusters', name: 'Topic Clustering', description: 'Group files by topic similarity', async enrichNode(node, context) { // Compute cluster membership const cluster = await getFileCluster(node.id, context.db); return { group: cluster.name, color: cluster.color, properties: { clusterId: cluster.id } };",
+      "path": [
+        "Extension Points",
+        "Database Extension Points",
+        "GraphDataProviderAdapter - Graph Enrichment"
+      ],
+      "commands": [],
+      "keybindings": [],
+      "keywords": [
+        "example",
+        "cluster",
+        "provider",
+        "beginsrc",
+        "typescript",
+        "import",
+        "registergraphdataprovider",
+        "graphdataprovider",
+        "adaptersgraphdataadapter",
+        "const",
+        "clusterprovider",
+        "topic-clusters",
+        "name",
+        "topic",
+        "clustering",
+        "description",
+        "group",
+        "similarity",
+        "async",
+        "enrichnode"
+      ]
+    },
+    {
+      "heading": "Potential Future Extension Points",
+      "level": 2,
+      "file": "extension-points.org",
+      "line": 859,
       "content": "These patterns could be extended for additional plugin types:",
       "path": [
         "Extension Points"
@@ -98013,7 +99504,7 @@
       "heading": "Speed Commands",
       "level": 3,
       "file": "extension-points.org",
-      "line": 583,
+      "line": 863,
       "content": "Custom single-key commands at headline beginnings. #+BEGIN_SRC typescript interface SpeedCommand { key: string; description: string; execute(editor: TextEditor, heading: HeadingNode): Promise<void>; } #+END_SRC",
       "path": [
         "Extension Points",
@@ -98048,7 +99539,7 @@
       "heading": "Capture Templates",
       "level": 3,
       "file": "extension-points.org",
-      "line": 595,
+      "line": 875,
       "content": "Custom org-capture templates. #+BEGIN_SRC typescript interface CaptureTemplate { key: string; description: string; template: string; target: CaptureTarget; } #+END_SRC",
       "path": [
         "Extension Points",
@@ -98078,7 +99569,7 @@
       "heading": "Entity Definitions",
       "level": 3,
       "file": "extension-points.org",
-      "line": 608,
+      "line": 888,
       "content": "Custom special character entities (like org-entities). #+BEGIN_SRC typescript interface OrgEntity { name: string; latex: string; html: string; unicode: string; } #+END_SRC",
       "path": [
         "Extension Points",
@@ -98111,7 +99602,7 @@
       "heading": "Document Linters",
       "level": 3,
       "file": "extension-points.org",
-      "line": 621,
+      "line": 901,
       "content": "Custom lint rules for org documents. #+BEGIN_SRC typescript interface LintRule { id: string; severity: 'error' | 'warning' | 'info'; check(document: OrgDocument): Diagnostic[]; } #+END_SRC",
       "path": [
         "Extension Points",
@@ -98146,7 +99637,7 @@
       "heading": "VS Code Extension API",
       "level": 1,
       "file": "extension-points.org",
-      "line": 633,
+      "line": 913,
       "content": "External VS Code extensions can contribute to scimax via the extension API.",
       "path": [],
       "commands": [],
@@ -98166,7 +99657,7 @@
       "heading": "Accessing the API",
       "level": 2,
       "file": "extension-points.org",
-      "line": 637,
+      "line": 917,
       "content": "#+BEGIN_SRC typescript // In your extension's activate() function export async function activate(context: vscode.ExtensionContext) { const scimaxExt = vscode.extensions.getExtension('scimax.scimax-vscode'); if (!scimaxExt) { console.log('Scimax extension not installed'); return; } // Ensure scimax is activated const scimaxApi = scimaxExt.isActive ? scimaxExt.exports : await scimaxExt.activate(); // Now use the API... } #+END_SRC",
       "path": [
         "VS Code Extension API"
@@ -98202,7 +99693,7 @@
       "heading": "Available API Methods",
       "level": 2,
       "file": "extension-points.org",
-      "line": 658,
+      "line": 938,
       "content": "",
       "path": [
         "VS Code Extension API"
@@ -98219,7 +99710,7 @@
       "heading": "registerBabelExecutor(executor)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 660,
+      "line": 940,
       "content": "Register a custom language executor for source blocks. #+BEGIN_SRC typescript const disposable = scimaxApi.registerBabelExecutor({ languages: ['ruby', 'rb'], async execute(code, context) { return { success: true, stdout: 'result', stderr: '', executionTime: 100 }; }, async isAvailable() { return true; } }); context.subscriptions.push(disposable); #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98254,7 +99745,7 @@
       "heading": "createSimpleExecutor(options)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 678,
+      "line": 958,
       "content": "Helper to create a command-based executor. #+BEGIN_SRC typescript const rubyExec = scimaxApi.createSimpleExecutor({ languages: ['ruby'], command: 'ruby', extension: '.rb', }); context.subscriptions.push(scimaxApi.registerBabelExecutor(rubyExec)); #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98287,7 +99778,7 @@
       "heading": "registerLinkType(handler)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 692,
+      "line": 972,
       "content": "Register a custom link type handler. #+BEGIN_SRC typescript const disposable = scimaxApi.registerLinkType({ type: 'jira', description: 'Jira issue links', resolve: (path) => ({ displayText: path, url: `https://jira.example.com/browse/${path}`, tooltip: `Open Jira issue ${path}` }), export: (path, desc, backend) => { const url = `https://jira.example.com/browse/${path}`; const text = desc || path; if (backend === 'html') return `<a href=\"${url}\">${text}</a>`; if (backend === 'latex') return `\\\\hr",
       "path": [
         "VS Code Extension API",
@@ -98322,7 +99813,7 @@
       "heading": "registerLinkFollowHandler(handler)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 717,
+      "line": 997,
       "content": "Register a VS Code action for when a link type is clicked. #+BEGIN_SRC typescript const disposable = scimaxApi.registerLinkFollowHandler({ type: 'jira', async follow(path, context) { await vscode.env.openExternal( vscode.Uri.parse(`https://jira.example.com/browse/${path}`) ); } }); context.subscriptions.push(disposable); #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98357,7 +99848,7 @@
       "heading": "registerBlockExport(handler)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 734,
+      "line": 1014,
       "content": "Register a custom export handler for special blocks. #+BEGIN_SRC typescript const disposable = scimaxApi.registerBlockExport({ blockType: 'callout', export: (content, backend, ctx) => { if (backend === 'html') return `<div class=\"callout\">${content}</div>`; if (backend === 'latex') return `\\\\begin{tcolorbox}${content}\\\\end{tcolorbox}`; return content; }, }); context.subscriptions.push(disposable); #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98392,7 +99883,7 @@
       "heading": "registerBlockHighlight(config)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 751,
+      "line": 1031,
       "content": "Register visual highlighting for custom block types in the editor. #+BEGIN_SRC typescript const disposable = scimaxApi.registerBlockHighlight({ blockType: 'callout', backgroundColor: 'rgba(100, 149, 237, 0.1)', borderColor: 'rgba(100, 149, 237, 0.5)', headerColor: 'cornflowerblue', }); context.subscriptions.push(disposable); #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98427,7 +99918,7 @@
       "heading": "registerExportHook(hook)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 766,
+      "line": 1046,
       "content": "Register a hook to customize the export process. #+BEGIN_SRC typescript const disposable = scimaxApi.registerExportHook({ id: 'my-custom-hook', // Modify options before export preExport: (ctx) => ({ ...ctx.options, toc: true }), // Transform output after export postExport: (output, ctx) => { if (ctx.backend === 'html') { return `<!-- Custom Header -->\\n${output}`; } return undefined; }, // Filter specific elements elementFilter: (rendered, ctx) => { if (ctx.element.type === 'paragraph') {",
       "path": [
         "VS Code Extension API",
@@ -98462,7 +99953,7 @@
       "heading": "createWrapperHook(id, options)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 794,
+      "line": 1074,
       "content": "Helper to create a simple wrapper hook. #+BEGIN_SRC typescript const hook = scimaxApi.createWrapperHook('my-wrapper', { backend: 'html',           // Optional: filter by backend before: '<!-- Start -->', after: '<!-- End -->', priority: 10,              // Optional: higher runs first }); context.subscriptions.push(scimaxApi.registerExportHook(hook)); #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98497,7 +99988,7 @@
       "heading": "createElementReplacerHook(id, options)",
       "level": 3,
       "file": "extension-points.org",
-      "line": 809,
+      "line": 1089,
       "content": "Helper to create a hook that modifies specific element types. #+BEGIN_SRC typescript const hook = scimaxApi.createElementReplacerHook('para-wrapper', { elementType: ['paragraph', 'headline'],  // Can be string or array backend: 'html',                         // Optional: filter by backend replace: (rendered, element) => { return `<div class=\"custom\">${rendered}</div>`; }, }); context.subscriptions.push(scimaxApi.registerExportHook(hook)); #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98532,7 +100023,7 @@
       "heading": "Direct Registry Access",
       "level": 3,
       "file": "extension-points.org",
-      "line": 825,
+      "line": 1105,
       "content": "For advanced use cases, you can access the registries directly: #+BEGIN_SRC typescript // Access all registries const { registries } = scimaxApi; // Check registered block types registries.blockExport.getBlockTypes();  // ['warning', 'note', ...] // Check if a block has a custom handler registries.blockExport.hasHandler('callout');  // true/false // Get highlight config for a block type registries.blockHighlight.getConfig('warning'); // Get all export hooks registries.exportHook.getHooks();  // ",
       "path": [
         "VS Code Extension API",
@@ -98567,7 +100058,7 @@
       "heading": "Utility Functions",
       "level": 3,
       "file": "extension-points.org",
-      "line": 849,
+      "line": 1129,
       "content": "#+BEGIN_SRC typescript // Check if a language is supported scimaxApi.isLanguageSupported('python');  // true // Get all registered languages scimaxApi.getRegisteredLanguages();  // ['python', 'py', 'bash', ...] #+END_SRC",
       "path": [
         "VS Code Extension API",
@@ -98598,7 +100089,7 @@
       "heading": "Core Library Extraction",
       "level": 1,
       "file": "extension-points.org",
-      "line": 859,
+      "line": 1139,
       "content": "The =src/parser/= directory is designed to be extractable as a standalone npm library (=@scimax/org-core=) with no VS Code dependencies.",
       "path": [],
       "commands": [],
@@ -98622,7 +100113,7 @@
       "heading": "What's in Core",
       "level": 2,
       "file": "extension-points.org",
-      "line": 864,
+      "line": 1144,
       "content": "- AST types (=orgElementTypes.ts=) - Parser (=orgParser.ts=, =orgExportParser.ts=, =orgParserUnified.ts=) - Export backends (=orgExport*.ts=) - Link resolution (=orgLinkTypes.ts= - resolve/export only) - Entities (=orgEntities.ts=) - Babel execution (=orgBabel.ts=)",
       "path": [
         "Core Library Extraction"
@@ -98656,7 +100147,7 @@
       "heading": "What's in VS Code Layer",
       "level": 2,
       "file": "extension-points.org",
-      "line": 873,
+      "line": 1153,
       "content": "- Providers (=src/org/*.ts=) - Link follow actions (=src/adapters/linkFollowAdapter.ts=) - Commands and UI - Database and indexing",
       "path": [
         "Core Library Extraction"
@@ -98681,7 +100172,7 @@
       "heading": "Related Documentation",
       "level": 1,
       "file": "extension-points.org",
-      "line": 880,
+      "line": 1160,
       "content": "- [[file:source-blocks.org][Source Blocks]] - Babel execution - [[file:keybindings.org][Keybindings]] - Command reference - [[file:configuration.org][Configuration]] - Settings",
       "path": [],
       "commands": [],

--- a/src/linkGraph/__tests__/linkGraphQueries.test.ts
+++ b/src/linkGraph/__tests__/linkGraphQueries.test.ts
@@ -5,6 +5,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { LinkGraphQueryService, LinkGraphFilters } from '../linkGraphQueries';
 
+// Mock vscode (needed by graphDataAdapter import chain)
+vi.mock('vscode', () => ({
+    Disposable: class {
+        constructor(private callback: () => void) {}
+        dispose() { this.callback(); }
+    }
+}));
+
 // Mock the logger
 vi.mock('../../utils/logger', () => ({
     databaseLogger: {

--- a/src/linkGraph/__tests__/linkGraphQueries.test.ts
+++ b/src/linkGraph/__tests__/linkGraphQueries.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for LinkGraphQueryService
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { LinkGraphQueryService, LinkGraphFilters } from '../linkGraphQueries';
+
+// Mock the logger
+vi.mock('../../utils/logger', () => ({
+    databaseLogger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+    }
+}));
+
+// Mock database client
+function createMockDb(responses: Record<string, any[]> = {}) {
+    return {
+        execute: vi.fn().mockImplementation(({ sql }: { sql: string }) => {
+            // Return appropriate mock data based on the query
+            for (const [pattern, rows] of Object.entries(responses)) {
+                if (sql.includes(pattern)) {
+                    return Promise.resolve({ rows });
+                }
+            }
+            return Promise.resolve({ rows: [] });
+        })
+    };
+}
+
+describe('LinkGraphQueryService', () => {
+    describe('buildGraph', () => {
+        it('should build a graph with center node', async () => {
+            const mockDb = createMockDb({
+                'FROM links': [],  // No links
+                'FROM files': [{ file_type: 'org', mtime: Date.now() }],
+                'FROM headings': [{ total: 5, todos: 2, upcoming: 0 }],
+                'COUNT(*)': [{ count: 0 }],
+                'SELECT tags': []
+            });
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const result = await service.buildGraph(
+                '/test/file.org',
+                1,
+                'both',
+                {},
+                100
+            );
+
+            expect(result.nodes).toHaveLength(1);
+            expect(result.nodes[0].id).toBe('/test/file.org');
+            expect(result.nodes[0].isCenter).toBe(true);
+            expect(result.edges).toHaveLength(0);
+            expect(result.truncated).toBe(false);
+        });
+
+        it('should include connected files at depth 1', async () => {
+            const mockDb = createMockDb({
+                // Outgoing links query
+                'l.file_path = ?': [
+                    { target: '/test/linked.org' }
+                ],
+                // File metadata
+                'FROM files WHERE path': [{ file_type: 'org', mtime: Date.now() }],
+                'FROM headings WHERE file_path': [{ total: 3, todos: 1, upcoming: 0 }],
+                'COUNT(*) as count FROM links': [{ count: 2 }],
+                'SELECT tags': []
+            });
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const result = await service.buildGraph(
+                '/test/file.org',
+                1,
+                'outgoing',
+                {},
+                100
+            );
+
+            expect(result.nodes.length).toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    describe('getLinkStats', () => {
+        it('should return link statistics for a file', async () => {
+            const mockDb = createMockDb({
+                'link_type, COUNT(*)': [
+                    { link_type: 'file', count: 5 },
+                    { link_type: 'http', count: 3 }
+                ],
+                'COUNT(DISTINCT file_path)': [{ count: 2 }]
+            });
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const stats = await service.getLinkStats('/test/file.org');
+
+            expect(stats.outgoing).toBe(8);
+            expect(stats.outgoingByType).toEqual({
+                file: 5,
+                http: 3
+            });
+            expect(stats.incoming).toBe(2);
+        });
+
+        it('should handle files with no links', async () => {
+            const mockDb = createMockDb({});
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const stats = await service.getLinkStats('/test/empty.org');
+
+            expect(stats.outgoing).toBe(0);
+            expect(stats.incoming).toBe(0);
+            expect(stats.outgoingByType).toEqual({});
+        });
+    });
+
+    describe('filters', () => {
+        it('should apply file type filter', async () => {
+            const mockDb = createMockDb({});
+            const executeSpy = vi.spyOn(mockDb, 'execute');
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const filters: LinkGraphFilters = {
+                fileTypes: ['org']
+            };
+
+            await service.buildGraph('/test/file.org', 1, 'both', filters, 100);
+
+            // Check that file_type filter was included in query
+            const calls = executeSpy.mock.calls;
+            const hasFileTypeFilter = calls.some(call => {
+                const sql = (call[0] as any).sql || '';
+                return sql.includes('file_type');
+            });
+            expect(hasFileTypeFilter).toBe(true);
+        });
+
+        it('should apply tag filter', async () => {
+            const mockDb = createMockDb({});
+            const executeSpy = vi.spyOn(mockDb, 'execute');
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const filters: LinkGraphFilters = {
+                tags: ['project', 'important']
+            };
+
+            await service.buildGraph('/test/file.org', 1, 'both', filters, 100);
+
+            // Check that tag filter was included in query
+            const calls = executeSpy.mock.calls;
+            const hasTagFilter = calls.some(call => {
+                const sql = (call[0] as any).sql || '';
+                return sql.includes('h.tags LIKE');
+            });
+            expect(hasTagFilter).toBe(true);
+        });
+
+        it('should apply excludeDone filter', async () => {
+            const mockDb = createMockDb({});
+            const executeSpy = vi.spyOn(mockDb, 'execute');
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const filters: LinkGraphFilters = {
+                excludeDone: true
+            };
+
+            await service.buildGraph('/test/file.org', 1, 'both', filters, 100);
+
+            // Check that DONE exclusion was included in query
+            const calls = executeSpy.mock.calls;
+            const hasDoneFilter = calls.some(call => {
+                const sql = (call[0] as any).sql || '';
+                return sql.includes('DONE') || sql.includes('CANCELLED');
+            });
+            expect(hasDoneFilter).toBe(true);
+        });
+
+        it('should apply modification time filter', async () => {
+            const mockDb = createMockDb({});
+            const executeSpy = vi.spyOn(mockDb, 'execute');
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const oneWeekAgo = Date.now() - (7 * 24 * 60 * 60 * 1000);
+            const filters: LinkGraphFilters = {
+                modifiedAfter: oneWeekAgo
+            };
+
+            await service.buildGraph('/test/file.org', 1, 'both', filters, 100);
+
+            // Check that mtime filter was included in query
+            const calls = executeSpy.mock.calls;
+            const hasMtimeFilter = calls.some(call => {
+                const sql = (call[0] as any).sql || '';
+                return sql.includes('mtime');
+            });
+            expect(hasMtimeFilter).toBe(true);
+        });
+    });
+
+    describe('direction handling', () => {
+        it('should only get outgoing links when direction is outgoing', async () => {
+            const mockDb = createMockDb({});
+            const executeSpy = vi.spyOn(mockDb, 'execute');
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            await service.buildGraph('/test/file.org', 1, 'outgoing', {}, 100);
+
+            // Should call for outgoing links (file_path = ?)
+            // Should NOT call for incoming links (target = ?)
+            const calls = executeSpy.mock.calls;
+            const hasOutgoingQuery = calls.some(call => {
+                const sql = (call[0] as any).sql || '';
+                return sql.includes('l.file_path = ?') && sql.includes('FROM links');
+            });
+            expect(hasOutgoingQuery).toBe(true);
+        });
+
+        it('should only get incoming links when direction is incoming', async () => {
+            const mockDb = createMockDb({});
+            const executeSpy = vi.spyOn(mockDb, 'execute');
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            await service.buildGraph('/test/file.org', 1, 'incoming', {}, 100);
+
+            // Should call for incoming links (target LIKE)
+            const calls = executeSpy.mock.calls;
+            const hasIncomingQuery = calls.some(call => {
+                const sql = (call[0] as any).sql || '';
+                return sql.includes('l.target') && sql.includes('FROM links');
+            });
+            expect(hasIncomingQuery).toBe(true);
+        });
+    });
+
+    describe('truncation', () => {
+        it('should truncate when nodes exceed maxNodes', async () => {
+            // Create mock that returns many connected files
+            const manyFiles = Array.from({ length: 150 }, (_, i) => ({
+                target: `/test/file${i}.org`
+            }));
+
+            const mockDb = createMockDb({
+                'l.file_path = ?': manyFiles,
+                'FROM files': [{ file_type: 'org', mtime: Date.now() }],
+                'FROM headings': [{ total: 1, todos: 0, upcoming: 0 }],
+                'COUNT(*)': [{ count: 1 }],
+                'SELECT tags': []
+            });
+
+            const service = new LinkGraphQueryService(mockDb as any);
+            const result = await service.buildGraph(
+                '/test/file.org',
+                1,
+                'outgoing',
+                {},
+                50  // Low max to trigger truncation
+            );
+
+            expect(result.truncated).toBe(true);
+            expect(result.nodes.length).toBeLessThanOrEqual(50);
+        });
+    });
+});

--- a/src/linkGraph/commands.ts
+++ b/src/linkGraph/commands.ts
@@ -1,0 +1,161 @@
+/**
+ * Link Graph Commands
+ *
+ * VS Code commands for the link graph visualization feature.
+ * Uses lazy database loading to avoid blocking extension activation.
+ */
+
+import * as vscode from 'vscode';
+import { LinkGraphProvider } from './linkGraphProvider';
+import { LinkGraphQueryService } from './linkGraphQueries';
+import { getDatabase } from '../database/lazyDb';
+import { databaseLogger as log } from '../utils/logger';
+
+let graphProvider: LinkGraphProvider | undefined;
+
+/**
+ * Get database client, showing error if not available
+ */
+async function getDatabaseClient() {
+    const db = await getDatabase();
+    if (!db) {
+        vscode.window.showErrorMessage('Database not available. Try running "Scimax: Reindex Files" first.');
+        return null;
+    }
+    const client = db.getClient();
+    if (!client) {
+        vscode.window.showErrorMessage('Database client not initialized.');
+        return null;
+    }
+    return client;
+}
+
+/**
+ * Register link graph commands
+ */
+export function registerLinkGraphCommands(
+    context: vscode.ExtensionContext
+): vscode.Disposable[] {
+    const disposables: vscode.Disposable[] = [];
+
+    // Show link graph for current file
+    disposables.push(
+        vscode.commands.registerCommand('scimax.showLinkGraph', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                vscode.window.showWarningMessage('No file is currently open');
+                return;
+            }
+
+            const filePath = editor.document.uri.fsPath;
+            const ext = filePath.split('.').pop()?.toLowerCase();
+
+            if (ext !== 'org' && ext !== 'md') {
+                vscode.window.showWarningMessage('Link graph is only available for org and markdown files');
+                return;
+            }
+
+            const client = await getDatabaseClient();
+            if (!client) return;
+
+            // Create or reuse provider
+            if (!graphProvider) {
+                graphProvider = new LinkGraphProvider(context, client);
+            }
+
+            await graphProvider.show(filePath);
+        })
+    );
+
+    // Show link graph for a specific file (from context menu, etc.)
+    disposables.push(
+        vscode.commands.registerCommand('scimax.showLinkGraphForFile', async (uri?: vscode.Uri) => {
+            let filePath: string | undefined;
+
+            if (uri) {
+                filePath = uri.fsPath;
+            } else {
+                filePath = vscode.window.activeTextEditor?.document.uri.fsPath;
+            }
+
+            if (!filePath) {
+                vscode.window.showWarningMessage('No file specified');
+                return;
+            }
+
+            const client = await getDatabaseClient();
+            if (!client) return;
+
+            // Create or reuse provider
+            if (!graphProvider) {
+                graphProvider = new LinkGraphProvider(context, client);
+            }
+
+            await graphProvider.show(filePath);
+        })
+    );
+
+    // Show link statistics for current file
+    disposables.push(
+        vscode.commands.registerCommand('scimax.showLinkStats', async () => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                vscode.window.showWarningMessage('No file is currently open');
+                return;
+            }
+
+            const filePath = editor.document.uri.fsPath;
+
+            const client = await getDatabaseClient();
+            if (!client) return;
+
+            const queryService = new LinkGraphQueryService(client);
+
+            try {
+                const stats = await queryService.getLinkStats(filePath);
+
+                const typeBreakdown = Object.entries(stats.outgoingByType)
+                    .map(([type, count]) => `  ${type}: ${count}`)
+                    .join('\n');
+
+                const message = [
+                    `Link Statistics for ${filePath.split('/').pop()}`,
+                    '',
+                    `Outgoing links: ${stats.outgoing}`,
+                    typeBreakdown ? `By type:\n${typeBreakdown}` : '',
+                    `Incoming links (backlinks): ${stats.incoming}`
+                ].filter(Boolean).join('\n');
+
+                // Show in information message with option to open graph
+                const action = await vscode.window.showInformationMessage(
+                    message,
+                    { modal: false },
+                    'Show Graph'
+                );
+
+                if (action === 'Show Graph') {
+                    // Create or reuse provider
+                    if (!graphProvider) {
+                        graphProvider = new LinkGraphProvider(context, client);
+                    }
+                    await graphProvider.show(filePath);
+                }
+            } catch (error) {
+                log.error('Failed to get link statistics', error as Error);
+                vscode.window.showErrorMessage(`Failed to get link statistics: ${error}`);
+            }
+        })
+    );
+
+    // Cleanup on deactivation
+    disposables.push({
+        dispose: () => {
+            if (graphProvider) {
+                graphProvider.dispose();
+                graphProvider = undefined;
+            }
+        }
+    });
+
+    return disposables;
+}

--- a/src/linkGraph/index.ts
+++ b/src/linkGraph/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Link Graph Module
+ *
+ * Provides visualization and querying of file link relationships.
+ * Files are connected by org-mode links, enabling graph-based exploration
+ * of your knowledge base.
+ *
+ * Features:
+ * - Interactive graph visualization with vis.js
+ * - Draggable nodes for custom layouts
+ * - Click to open files, double-click to recenter
+ * - Filter by tags, TODO states, modification time, etc.
+ * - Adjustable depth for exploring connections
+ * - Bidirectional link tracking (forward and backlinks)
+ */
+
+export { LinkGraphQueryService, LinkGraphFilters, GraphNode, GraphEdge, GraphData } from './linkGraphQueries';
+export { LinkGraphProvider } from './linkGraphProvider';
+export { registerLinkGraphCommands } from './commands';

--- a/src/linkGraph/linkGraphProvider.ts
+++ b/src/linkGraph/linkGraphProvider.ts
@@ -1,0 +1,693 @@
+/**
+ * Link Graph Webview Provider
+ *
+ * Provides a VS Code webview panel for visualizing file link graphs.
+ * Uses vis.js Network for interactive graph rendering with draggable nodes.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import type { Client } from '@libsql/client';
+import { LinkGraphQueryService, LinkGraphFilters, GraphData } from './linkGraphQueries';
+import { databaseLogger as log } from '../utils/logger';
+
+/**
+ * Link Graph Provider
+ * Manages the webview panel for graph visualization
+ */
+export class LinkGraphProvider {
+    private panel: vscode.WebviewPanel | undefined;
+    private queryService: LinkGraphQueryService;
+    private currentFile: string = '';
+    private currentDepth: number = 1;
+    private currentDirection: 'both' | 'outgoing' | 'incoming' = 'both';
+    private currentFilters: LinkGraphFilters = {};
+
+    constructor(
+        private context: vscode.ExtensionContext,
+        private db: Client
+    ) {
+        this.queryService = new LinkGraphQueryService(db);
+    }
+
+    /**
+     * Show the link graph for a file
+     */
+    async show(filePath: string): Promise<void> {
+        this.currentFile = filePath;
+
+        if (this.panel) {
+            this.panel.reveal();
+            this.panel.title = `Link Graph: ${path.basename(filePath)}`;
+        } else {
+            this.panel = vscode.window.createWebviewPanel(
+                'scimaxLinkGraph',
+                `Link Graph: ${path.basename(filePath)}`,
+                vscode.ViewColumn.Beside,
+                {
+                    enableScripts: true,
+                    retainContextWhenHidden: true,
+                    localResourceRoots: [
+                        vscode.Uri.joinPath(this.context.extensionUri, 'media')
+                    ]
+                }
+            );
+
+            this.panel.webview.html = this.getWebviewContent();
+
+            this.panel.webview.onDidReceiveMessage(
+                (message: any) => this.handleMessage(message),
+                undefined,
+                this.context.subscriptions
+            );
+
+            this.panel.onDidDispose(() => {
+                this.panel = undefined;
+            });
+        }
+
+        await this.updateGraph();
+    }
+
+    /**
+     * Handle messages from the webview
+     */
+    private async handleMessage(message: any): Promise<void> {
+        switch (message.type) {
+            case 'openFile':
+                try {
+                    const doc = await vscode.workspace.openTextDocument(message.path);
+                    await vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+                } catch (e) {
+                    vscode.window.showErrorMessage(`Could not open file: ${message.path}`);
+                }
+                break;
+
+            case 'recenterGraph':
+                this.currentFile = message.path;
+                if (this.panel) {
+                    this.panel.title = `Link Graph: ${path.basename(message.path)}`;
+                }
+                await this.updateGraph();
+                break;
+
+            case 'updateDepth':
+                this.currentDepth = message.depth;
+                await this.updateGraph();
+                break;
+
+            case 'updateDirection':
+                this.currentDirection = message.direction;
+                await this.updateGraph();
+                break;
+
+            case 'updateFilters':
+                this.currentFilters = this.parseFilters(message.filters);
+                await this.updateGraph();
+                break;
+
+            case 'refresh':
+                await this.updateGraph();
+                break;
+
+            case 'ready':
+                // Webview is ready, send initial data
+                await this.updateGraph();
+                break;
+        }
+    }
+
+    /**
+     * Parse filters from webview message
+     */
+    private parseFilters(rawFilters: any): LinkGraphFilters {
+        const filters: LinkGraphFilters = {};
+
+        if (rawFilters.tags?.length) {
+            filters.tags = rawFilters.tags;
+        }
+        if (rawFilters.excludeDone) {
+            filters.excludeDone = true;
+        }
+        if (rawFilters.hasDeadline) {
+            filters.hasDeadline = true;
+        }
+        if (rawFilters.fileTypes?.length) {
+            filters.fileTypes = rawFilters.fileTypes;
+        }
+        if (rawFilters.modifiedAfter) {
+            filters.modifiedAfter = rawFilters.modifiedAfter;
+        }
+
+        return filters;
+    }
+
+    /**
+     * Update the graph with current settings
+     */
+    private async updateGraph(): Promise<void> {
+        if (!this.panel) return;
+
+        try {
+            const graphData = await this.queryService.buildGraph(
+                this.currentFile,
+                this.currentDepth,
+                this.currentDirection,
+                this.currentFilters,
+                100  // max nodes
+            );
+
+            this.panel.webview.postMessage({
+                type: 'setGraphData',
+                data: graphData,
+                centerFile: this.currentFile
+            });
+        } catch (error) {
+            log.error('Failed to build graph', error as Error);
+            vscode.window.showErrorMessage(`Failed to build link graph: ${error}`);
+        }
+    }
+
+    /**
+     * Get the webview HTML content
+     */
+    private getWebviewContent(): string {
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://unpkg.com; style-src 'unsafe-inline'; img-src data:;">
+    <title>Link Graph</title>
+    <script src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js"></script>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, sans-serif);
+            background: var(--vscode-editor-background, #1e1e1e);
+            color: var(--vscode-editor-foreground, #cccccc);
+            overflow: hidden;
+        }
+
+        .controls {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            z-index: 100;
+            background: var(--vscode-sideBar-background, #252526);
+            padding: 12px;
+            border-radius: 6px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            max-width: 280px;
+            font-size: 12px;
+        }
+
+        .control-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .control-row label {
+            min-width: 70px;
+            font-size: 11px;
+            color: var(--vscode-descriptionForeground, #858585);
+        }
+
+        select, input[type="range"] {
+            flex: 1;
+            background: var(--vscode-input-background, #3c3c3c);
+            color: var(--vscode-input-foreground, #cccccc);
+            border: 1px solid var(--vscode-input-border, #3c3c3c);
+            padding: 4px 6px;
+            border-radius: 3px;
+            font-size: 11px;
+        }
+
+        select:focus, input:focus {
+            outline: 1px solid var(--vscode-focusBorder, #007fd4);
+        }
+
+        .filter-section {
+            border-top: 1px solid var(--vscode-widget-border, #454545);
+            padding-top: 8px;
+            margin-top: 4px;
+        }
+
+        .filter-section summary {
+            cursor: pointer;
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--vscode-foreground, #cccccc);
+            user-select: none;
+        }
+
+        .filter-section summary:hover {
+            color: var(--vscode-textLink-foreground, #3794ff);
+        }
+
+        .filter-group {
+            margin-top: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .checkbox-row {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            font-size: 11px;
+        }
+
+        .checkbox-row input[type="checkbox"] {
+            width: 14px;
+            height: 14px;
+        }
+
+        .tag-input {
+            display: flex;
+            gap: 4px;
+        }
+
+        .tag-input input {
+            flex: 1;
+            font-size: 11px;
+            padding: 4px 6px;
+            background: var(--vscode-input-background, #3c3c3c);
+            color: var(--vscode-input-foreground, #cccccc);
+            border: 1px solid var(--vscode-input-border, #3c3c3c);
+            border-radius: 3px;
+        }
+
+        .tag-input button {
+            padding: 4px 8px;
+            background: var(--vscode-button-background, #0e639c);
+            color: var(--vscode-button-foreground, #ffffff);
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 11px;
+        }
+
+        .tag-input button:hover {
+            background: var(--vscode-button-hoverBackground, #1177bb);
+        }
+
+        .tag-chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-top: 4px;
+        }
+
+        .tag-chip {
+            background: var(--vscode-badge-background, #4d4d4d);
+            color: var(--vscode-badge-foreground, #ffffff);
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 10px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .tag-chip:hover {
+            background: var(--vscode-badge-background, #5a5a5a);
+        }
+
+        .tag-chip .remove {
+            font-weight: bold;
+            opacity: 0.7;
+        }
+
+        .tag-chip:hover .remove {
+            opacity: 1;
+        }
+
+        .stats {
+            font-size: 10px;
+            color: var(--vscode-descriptionForeground, #858585);
+            padding-top: 8px;
+            border-top: 1px solid var(--vscode-widget-border, #454545);
+        }
+
+        #graph {
+            width: 100vw;
+            height: 100vh;
+        }
+
+        .legend {
+            position: absolute;
+            bottom: 10px;
+            right: 10px;
+            background: var(--vscode-sideBar-background, #252526);
+            padding: 10px 14px;
+            border-radius: 6px;
+            font-size: 11px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+        }
+
+        .legend-title {
+            font-weight: 600;
+            margin-bottom: 6px;
+            color: var(--vscode-foreground, #cccccc);
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin: 4px 0;
+            color: var(--vscode-descriptionForeground, #858585);
+        }
+
+        .legend-dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            flex-shrink: 0;
+        }
+
+        .help-text {
+            font-size: 10px;
+            color: var(--vscode-descriptionForeground, #858585);
+            margin-top: 8px;
+            line-height: 1.4;
+        }
+
+        .loading {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-size: 14px;
+            color: var(--vscode-descriptionForeground, #858585);
+        }
+
+        .empty-state {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            text-align: center;
+            color: var(--vscode-descriptionForeground, #858585);
+        }
+
+        .empty-state h3 {
+            margin-bottom: 8px;
+            color: var(--vscode-foreground, #cccccc);
+        }
+    </style>
+</head>
+<body>
+    <div class="controls">
+        <div class="control-row">
+            <label>Depth:</label>
+            <input type="range" id="depth" min="1" max="3" value="1">
+            <span id="depthValue" style="min-width: 16px; text-align: center;">1</span>
+        </div>
+
+        <div class="control-row">
+            <label>Direction:</label>
+            <select id="direction">
+                <option value="both">Both directions</option>
+                <option value="outgoing">Outgoing only →</option>
+                <option value="incoming">← Incoming only</option>
+            </select>
+        </div>
+
+        <details class="filter-section">
+            <summary>Filters</summary>
+            <div class="filter-group">
+                <div class="control-row">
+                    <label>Modified:</label>
+                    <select id="modifiedFilter">
+                        <option value="">Any time</option>
+                        <option value="1">Last 24 hours</option>
+                        <option value="7">Last 7 days</option>
+                        <option value="30">Last 30 days</option>
+                        <option value="90">Last 90 days</option>
+                    </select>
+                </div>
+
+                <div class="control-row">
+                    <label>File type:</label>
+                    <select id="fileTypeFilter">
+                        <option value="">All types</option>
+                        <option value="org">Org only</option>
+                        <option value="md">Markdown only</option>
+                    </select>
+                </div>
+
+                <div class="checkbox-row">
+                    <input type="checkbox" id="excludeDone">
+                    <label for="excludeDone">Exclude DONE items</label>
+                </div>
+
+                <div class="checkbox-row">
+                    <input type="checkbox" id="hasDeadline">
+                    <label for="hasDeadline">Has deadline</label>
+                </div>
+
+                <div class="control-row">
+                    <label>Tags:</label>
+                </div>
+                <div class="tag-input">
+                    <input type="text" id="tagInput" placeholder="Add tag filter...">
+                    <button id="addTag">+</button>
+                </div>
+                <div class="tag-chips" id="tagChips"></div>
+            </div>
+        </details>
+
+        <div class="stats" id="stats">Loading...</div>
+
+        <div class="help-text">
+            Click node to open file<br>
+            Double-click to recenter graph<br>
+            Drag nodes to rearrange
+        </div>
+    </div>
+
+    <div id="graph"></div>
+    <div class="loading" id="loading">Loading graph...</div>
+
+    <div class="legend">
+        <div class="legend-title">Legend</div>
+        <div class="legend-item">
+            <div class="legend-dot" style="background: #e74c3c;"></div>
+            <span>Center file</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-dot" style="background: #3498db;"></div>
+            <span>Depth 1</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-dot" style="background: #2ecc71;"></div>
+            <span>Depth 2</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-dot" style="background: #9b59b6;"></div>
+            <span>Depth 3</span>
+        </div>
+    </div>
+
+    <script>
+        const vscode = acquireVsCodeApi();
+        let network = null;
+        let currentFilters = { tags: [] };
+
+        const depthColors = ['#e74c3c', '#3498db', '#2ecc71', '#9b59b6'];
+
+        // Receive messages from extension
+        window.addEventListener('message', event => {
+            const { type, data, centerFile } = event.data;
+            if (type === 'setGraphData') {
+                document.getElementById('loading').style.display = 'none';
+                renderGraph(data, centerFile);
+                updateStats(data);
+            }
+        });
+
+        function renderGraph(data, centerFile) {
+            const container = document.getElementById('graph');
+
+            if (data.nodes.length === 0) {
+                container.innerHTML = '<div class="empty-state"><h3>No links found</h3><p>This file has no links to other indexed files.</p></div>';
+                if (network) {
+                    network.destroy();
+                    network = null;
+                }
+                return;
+            }
+
+            // Transform nodes for vis.js
+            const nodes = data.nodes.map(node => ({
+                id: node.id,
+                label: node.label,
+                title: node.title,
+                color: {
+                    background: node.isCenter ? '#e74c3c' : depthColors[node.level] || '#95a5a6',
+                    border: node.isCenter ? '#c0392b' : '#7f8c8d',
+                    highlight: { background: '#f39c12', border: '#e67e22' },
+                    hover: { background: '#f1c40f', border: '#f39c12' }
+                },
+                size: node.isCenter ? 25 : 15 + Math.min(node.linkCount, 10),
+                font: {
+                    size: node.isCenter ? 14 : 11,
+                    color: '#ecf0f1'
+                },
+                borderWidth: node.hasUpcomingDeadline ? 3 : 2,
+                borderWidthSelected: 4
+            }));
+
+            // Transform edges for vis.js
+            const edges = data.edges.map(edge => ({
+                id: edge.id,
+                from: edge.from,
+                to: edge.to,
+                title: edge.title,
+                arrows: 'to',
+                width: Math.min(1 + edge.count, 5),
+                color: {
+                    color: '#7f8c8d',
+                    highlight: '#f39c12',
+                    hover: '#bdc3c7'
+                },
+                smooth: { type: 'curvedCW', roundness: 0.2 }
+            }));
+
+            const options = {
+                physics: {
+                    forceAtlas2Based: {
+                        gravitationalConstant: -50,
+                        centralGravity: 0.01,
+                        springLength: 150,
+                        springConstant: 0.08
+                    },
+                    maxVelocity: 50,
+                    solver: 'forceAtlas2Based',
+                    stabilization: { iterations: 100 }
+                },
+                interaction: {
+                    hover: true,
+                    tooltipDelay: 100,
+                    dragNodes: true,
+                    dragView: true,
+                    zoomView: true
+                }
+            };
+
+            if (network) {
+                network.setData({ nodes, edges });
+            } else {
+                network = new vis.Network(container, { nodes, edges }, options);
+
+                // Click to open file
+                network.on('click', params => {
+                    if (params.nodes.length > 0) {
+                        vscode.postMessage({ type: 'openFile', path: params.nodes[0] });
+                    }
+                });
+
+                // Double-click to recenter
+                network.on('doubleClick', params => {
+                    if (params.nodes.length > 0) {
+                        vscode.postMessage({ type: 'recenterGraph', path: params.nodes[0] });
+                    }
+                });
+            }
+        }
+
+        function updateStats(data) {
+            const stats = document.getElementById('stats');
+            const truncatedMsg = data.truncated ? ' (truncated)' : '';
+            stats.textContent = data.nodes.length + ' nodes, ' + data.edges.length + ' edges' + truncatedMsg;
+        }
+
+        function sendFilters() {
+            const filters = {
+                tags: currentFilters.tags,
+                excludeDone: document.getElementById('excludeDone').checked,
+                hasDeadline: document.getElementById('hasDeadline').checked,
+                fileTypes: document.getElementById('fileTypeFilter').value
+                    ? [document.getElementById('fileTypeFilter').value]
+                    : undefined,
+                modifiedAfter: document.getElementById('modifiedFilter').value
+                    ? Date.now() - (parseInt(document.getElementById('modifiedFilter').value) * 24 * 60 * 60 * 1000)
+                    : undefined
+            };
+            vscode.postMessage({ type: 'updateFilters', filters });
+        }
+
+        // Event listeners
+        document.getElementById('depth').addEventListener('input', e => {
+            document.getElementById('depthValue').textContent = e.target.value;
+            vscode.postMessage({ type: 'updateDepth', depth: parseInt(e.target.value) });
+        });
+
+        document.getElementById('direction').addEventListener('change', e => {
+            vscode.postMessage({ type: 'updateDirection', direction: e.target.value });
+        });
+
+        document.getElementById('modifiedFilter').addEventListener('change', sendFilters);
+        document.getElementById('fileTypeFilter').addEventListener('change', sendFilters);
+        document.getElementById('excludeDone').addEventListener('change', sendFilters);
+        document.getElementById('hasDeadline').addEventListener('change', sendFilters);
+
+        // Tag management
+        document.getElementById('addTag').addEventListener('click', () => {
+            const input = document.getElementById('tagInput');
+            const tag = input.value.trim().replace(/^:/, '').replace(/:$/, '');
+            if (tag && !currentFilters.tags.includes(tag)) {
+                currentFilters.tags.push(tag);
+                renderTagChips();
+                sendFilters();
+            }
+            input.value = '';
+        });
+
+        document.getElementById('tagInput').addEventListener('keypress', e => {
+            if (e.key === 'Enter') {
+                document.getElementById('addTag').click();
+            }
+        });
+
+        function renderTagChips() {
+            const container = document.getElementById('tagChips');
+            container.innerHTML = currentFilters.tags.map(tag =>
+                '<span class="tag-chip" data-tag="' + tag + '">' + tag + ' <span class="remove">×</span></span>'
+            ).join('');
+
+            container.querySelectorAll('.tag-chip').forEach(chip => {
+                chip.addEventListener('click', () => {
+                    const tag = chip.dataset.tag;
+                    currentFilters.tags = currentFilters.tags.filter(t => t !== tag);
+                    renderTagChips();
+                    sendFilters();
+                });
+            });
+        }
+
+        // Signal ready
+        vscode.postMessage({ type: 'ready' });
+    </script>
+</body>
+</html>`;
+    }
+
+    /**
+     * Dispose of the provider
+     */
+    dispose(): void {
+        if (this.panel) {
+            this.panel.dispose();
+            this.panel = undefined;
+        }
+    }
+}

--- a/src/linkGraph/linkGraphQueries.ts
+++ b/src/linkGraph/linkGraphQueries.ts
@@ -1,0 +1,629 @@
+/**
+ * Link Graph Query Service
+ *
+ * Provides SQL queries and data structures for building file link graphs.
+ * Supports filtering by file metadata, heading properties, tags, TODO states, etc.
+ */
+
+import type { Client } from '@libsql/client';
+import { databaseLogger as log } from '../utils/logger';
+
+/**
+ * Filters for graph queries
+ */
+export interface LinkGraphFilters {
+    // File-level filters
+    fileTypes?: ('org' | 'md')[];
+    modifiedAfter?: number;      // timestamp ms
+    modifiedBefore?: number;
+    projectIds?: number[];
+
+    // Heading-level filters
+    tags?: string[];             // ANY of these tags
+    excludeTags?: string[];      // NONE of these tags
+    todoStates?: string[];       // 'TODO', 'NEXT', etc.
+    excludeDone?: boolean;       // Exclude DONE/CANCELLED
+    priorities?: string[];       // 'A', 'B', 'C'
+    hasDeadline?: boolean;
+    hasScheduled?: boolean;
+    deadlineWithinDays?: number; // Upcoming deadlines
+
+    // Property filters
+    properties?: Record<string, string>;
+
+    // Link-level filters
+    linkTypes?: string[];        // 'file', 'id', 'cite', etc.
+}
+
+/**
+ * Graph node representing a file
+ */
+export interface GraphNode {
+    id: string;                  // file path
+    label: string;               // filename
+    title: string;               // hover tooltip HTML
+    level: number;               // distance from center (0 = center)
+    isCenter: boolean;
+    fileType: 'org' | 'md';
+    mtime: number;
+
+    // Aggregated metadata for display
+    headingCount: number;
+    todoCount: number;
+    linkCount: number;
+    hasUpcomingDeadline: boolean;
+    topTags: string[];
+}
+
+/**
+ * Graph edge representing a link between files
+ */
+export interface GraphEdge {
+    id: string;                  // unique edge id
+    from: string;                // source file path
+    to: string;                  // target file path
+    linkType: string;
+    count: number;               // number of links (for edge thickness)
+    title: string;               // hover tooltip
+    arrows: 'to';
+}
+
+/**
+ * Complete graph data for visualization
+ */
+export interface GraphData {
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    truncated: boolean;          // true if max nodes reached
+    totalEdges: number;
+}
+
+/**
+ * File metadata for node building
+ */
+interface FileMetadata {
+    fileType: 'org' | 'md';
+    mtime: number;
+    headingCount: number;
+    todoCount: number;
+    linkCount: number;
+    hasUpcomingDeadline: boolean;
+    topTags: string[];
+}
+
+/**
+ * Link Graph Query Service
+ * Builds graph data from the database for visualization
+ */
+export class LinkGraphQueryService {
+    constructor(private db: Client) {}
+
+    /**
+     * Build graph data starting from a center file
+     */
+    async buildGraph(
+        centerFile: string,
+        depth: number,
+        direction: 'both' | 'outgoing' | 'incoming',
+        filters: LinkGraphFilters,
+        maxNodes: number = 100
+    ): Promise<GraphData> {
+        log.debug('Building link graph', { centerFile, depth, direction, maxNodes });
+
+        // Step 1: Get all connected files up to depth
+        const connectedFiles = await this.getConnectedFiles(
+            centerFile, depth, direction, filters
+        );
+
+        log.debug('Found connected files', { count: connectedFiles.size });
+
+        // Step 2: Build nodes with metadata
+        const nodes = await this.buildNodes(centerFile, connectedFiles, filters);
+
+        // Step 3: Build edges between nodes
+        const edges = await this.buildEdges(
+            nodes.map(n => n.id),
+            direction,
+            filters
+        );
+
+        // Step 4: Truncate if needed
+        const truncated = nodes.length > maxNodes;
+        const finalNodes = truncated ? nodes.slice(0, maxNodes) : nodes;
+        const nodeIds = new Set(finalNodes.map(n => n.id));
+        const finalEdges = edges.filter(e => nodeIds.has(e.from) && nodeIds.has(e.to));
+
+        log.debug('Graph built', {
+            nodes: finalNodes.length,
+            edges: finalEdges.length,
+            truncated
+        });
+
+        return {
+            nodes: finalNodes,
+            edges: finalEdges,
+            truncated,
+            totalEdges: edges.length
+        };
+    }
+
+    /**
+     * Get all files connected within depth, applying filters
+     */
+    private async getConnectedFiles(
+        centerFile: string,
+        depth: number,
+        direction: 'both' | 'outgoing' | 'incoming',
+        filters: LinkGraphFilters
+    ): Promise<Map<string, number>> {  // file path -> depth level
+        const visited = new Map<string, number>();
+        visited.set(centerFile, 0);
+
+        let frontier = [centerFile];
+
+        for (let currentDepth = 0; currentDepth < depth; currentDepth++) {
+            const nextFrontier: string[] = [];
+
+            for (const file of frontier) {
+                // Get outgoing links
+                if (direction !== 'incoming') {
+                    const outgoing = await this.getFilteredLinksFrom(file, filters);
+                    for (const target of outgoing) {
+                        if (!visited.has(target)) {
+                            visited.set(target, currentDepth + 1);
+                            nextFrontier.push(target);
+                        }
+                    }
+                }
+
+                // Get incoming links (backlinks)
+                if (direction !== 'outgoing') {
+                    const incoming = await this.getFilteredLinksTo(file, filters);
+                    for (const source of incoming) {
+                        if (!visited.has(source)) {
+                            visited.set(source, currentDepth + 1);
+                            nextFrontier.push(source);
+                        }
+                    }
+                }
+            }
+
+            frontier = nextFrontier;
+            if (frontier.length === 0) break;
+        }
+
+        return visited;
+    }
+
+    /**
+     * Get outgoing file links with filters applied
+     */
+    private async getFilteredLinksFrom(
+        filePath: string,
+        filters: LinkGraphFilters
+    ): Promise<string[]> {
+        const conditions: string[] = ['l.file_path = ?'];
+        const args: any[] = [filePath];
+
+        // Add filter conditions
+        this.addFilterConditions(conditions, args, filters);
+
+        const sql = `
+            SELECT DISTINCT l.target
+            FROM links l
+            LEFT JOIN files f ON l.target = f.path
+            LEFT JOIN headings h ON l.heading_id = h.id
+            WHERE ${conditions.join(' AND ')}
+              AND f.id IS NOT NULL
+        `;
+
+        try {
+            const result = await this.db.execute({ sql, args });
+            return result.rows.map((r: any) => r.target as string);
+        } catch (e) {
+            log.error('Error getting outgoing links', e as Error, { filePath });
+            return [];
+        }
+    }
+
+    /**
+     * Get incoming file links (backlinks) with filters applied
+     */
+    private async getFilteredLinksTo(
+        filePath: string,
+        filters: LinkGraphFilters
+    ): Promise<string[]> {
+        // Match exact path or path with search string suffix
+        const conditions: string[] = [
+            "(l.target = ? OR l.target LIKE ? OR l.target LIKE ?)"
+        ];
+        const fileName = filePath.split('/').pop() || filePath;
+        const args: any[] = [filePath, `%${filePath}`, `%${fileName}::%`];
+
+        this.addFilterConditions(conditions, args, filters);
+
+        const sql = `
+            SELECT DISTINCT l.file_path
+            FROM links l
+            LEFT JOIN files f ON l.file_path = f.path
+            LEFT JOIN headings h ON l.heading_id = h.id
+            WHERE ${conditions.join(' AND ')}
+              AND f.id IS NOT NULL
+        `;
+
+        try {
+            const result = await this.db.execute({ sql, args });
+            return result.rows.map((r: any) => r.file_path as string);
+        } catch (e) {
+            log.error('Error getting incoming links', e as Error, { filePath });
+            return [];
+        }
+    }
+
+    /**
+     * Add filter conditions to query
+     */
+    private addFilterConditions(
+        conditions: string[],
+        args: any[],
+        filters: LinkGraphFilters
+    ): void {
+        // Default to file links only
+        const linkTypes = filters.linkTypes?.length ? filters.linkTypes : ['file'];
+        conditions.push(`l.link_type IN (${linkTypes.map(() => '?').join(',')})`);
+        args.push(...linkTypes);
+
+        // File type filter
+        if (filters.fileTypes?.length) {
+            conditions.push(`(f.file_type IS NULL OR f.file_type IN (${filters.fileTypes.map(() => '?').join(',')}))`);
+            args.push(...filters.fileTypes);
+        }
+
+        // Modification time filters
+        if (filters.modifiedAfter) {
+            conditions.push('(f.mtime IS NULL OR f.mtime > ?)');
+            args.push(filters.modifiedAfter);
+        }
+        if (filters.modifiedBefore) {
+            conditions.push('(f.mtime IS NULL OR f.mtime < ?)');
+            args.push(filters.modifiedBefore);
+        }
+
+        // Project filter
+        if (filters.projectIds?.length) {
+            conditions.push(`(f.project_id IS NULL OR f.project_id IN (${filters.projectIds.map(() => '?').join(',')}))`);
+            args.push(...filters.projectIds);
+        }
+
+        // Tag filters (requires heading association)
+        if (filters.tags?.length) {
+            const tagConditions = filters.tags.map(() => "h.tags LIKE ?");
+            conditions.push(`(h.id IS NULL OR (${tagConditions.join(' OR ')}))`);
+            args.push(...filters.tags.map(t => `%"${t}"%`));
+        }
+
+        if (filters.excludeTags?.length) {
+            for (const tag of filters.excludeTags) {
+                conditions.push("(h.id IS NULL OR h.tags NOT LIKE ?)");
+                args.push(`%"${tag}"%`);
+            }
+        }
+
+        // TODO state filters
+        if (filters.todoStates?.length) {
+            conditions.push(`(h.id IS NULL OR h.todo_state IN (${filters.todoStates.map(() => '?').join(',')}))`);
+            args.push(...filters.todoStates);
+        }
+
+        if (filters.excludeDone) {
+            conditions.push("(h.id IS NULL OR h.todo_state IS NULL OR h.todo_state NOT IN ('DONE', 'CANCELLED'))");
+        }
+
+        // Priority filter
+        if (filters.priorities?.length) {
+            conditions.push(`(h.id IS NULL OR h.priority IN (${filters.priorities.map(() => '?').join(',')}))`);
+            args.push(...filters.priorities);
+        }
+
+        // Deadline filters
+        if (filters.hasDeadline) {
+            conditions.push("h.deadline IS NOT NULL");
+        }
+
+        if (filters.deadlineWithinDays !== undefined) {
+            const futureDate = Date.now() + (filters.deadlineWithinDays * 24 * 60 * 60 * 1000);
+            conditions.push("(h.deadline IS NOT NULL AND h.deadline <= ?)");
+            args.push(new Date(futureDate).toISOString().split('T')[0]);
+        }
+
+        // Scheduled filter
+        if (filters.hasScheduled) {
+            conditions.push("h.scheduled IS NOT NULL");
+        }
+
+        // Property filters
+        if (filters.properties) {
+            for (const [key, value] of Object.entries(filters.properties)) {
+                conditions.push("(h.id IS NULL OR json_extract(h.properties, ?) = ?)");
+                args.push(`$.${key}`, value);
+            }
+        }
+    }
+
+    /**
+     * Build node objects with metadata
+     */
+    private async buildNodes(
+        centerFile: string,
+        connectedFiles: Map<string, number>,
+        _filters: LinkGraphFilters
+    ): Promise<GraphNode[]> {
+        const nodes: GraphNode[] = [];
+
+        for (const [filePath, level] of connectedFiles) {
+            const metadata = await this.getFileMetadata(filePath);
+
+            nodes.push({
+                id: filePath,
+                label: this.getFileName(filePath),
+                title: this.buildTooltip(filePath, metadata),
+                level,
+                isCenter: filePath === centerFile,
+                fileType: metadata.fileType,
+                mtime: metadata.mtime,
+                headingCount: metadata.headingCount,
+                todoCount: metadata.todoCount,
+                linkCount: metadata.linkCount,
+                hasUpcomingDeadline: metadata.hasUpcomingDeadline,
+                topTags: metadata.topTags
+            });
+        }
+
+        // Sort by level, then by link count (most connected first)
+        nodes.sort((a, b) => {
+            if (a.level !== b.level) return a.level - b.level;
+            return b.linkCount - a.linkCount;
+        });
+
+        return nodes;
+    }
+
+    /**
+     * Get metadata for a file
+     */
+    private async getFileMetadata(filePath: string): Promise<FileMetadata> {
+        try {
+            // File info
+            const fileResult = await this.db.execute({
+                sql: 'SELECT file_type, mtime FROM files WHERE path = ?',
+                args: [filePath]
+            });
+            const file = fileResult.rows[0];
+
+            // Heading stats
+            const headingResult = await this.db.execute({
+                sql: `SELECT
+                        COUNT(*) as total,
+                        SUM(CASE WHEN todo_state IS NOT NULL AND todo_state NOT IN ('DONE', 'CANCELLED') THEN 1 ELSE 0 END) as todos,
+                        SUM(CASE WHEN deadline IS NOT NULL AND deadline > date('now') AND deadline < date('now', '+7 days') THEN 1 ELSE 0 END) as upcoming
+                      FROM headings WHERE file_path = ?`,
+                args: [filePath]
+            });
+            const headings = headingResult.rows[0];
+
+            // Link count (outgoing)
+            const linkResult = await this.db.execute({
+                sql: 'SELECT COUNT(*) as count FROM links WHERE file_path = ?',
+                args: [filePath]
+            });
+
+            // Top tags
+            const tagResult = await this.db.execute({
+                sql: `SELECT tags FROM headings WHERE file_path = ? AND tags != '[]'`,
+                args: [filePath]
+            });
+            const allTags = tagResult.rows
+                .flatMap((r: any) => {
+                    try {
+                        return JSON.parse(r.tags as string) as string[];
+                    } catch {
+                        return [];
+                    }
+                });
+            const tagCounts = new Map<string, number>();
+            for (const tag of allTags) {
+                tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+            }
+            const topTags = [...tagCounts.entries()]
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 5)
+                .map(([tag]) => tag);
+
+            return {
+                fileType: (file?.file_type || 'org') as 'org' | 'md',
+                mtime: (file?.mtime || 0) as number,
+                headingCount: (headings?.total || 0) as number,
+                todoCount: (headings?.todos || 0) as number,
+                linkCount: (linkResult.rows[0]?.count || 0) as number,
+                hasUpcomingDeadline: ((headings?.upcoming || 0) as number) > 0,
+                topTags
+            };
+        } catch (e) {
+            log.error('Error getting file metadata', e as Error, { filePath });
+            return {
+                fileType: 'org',
+                mtime: 0,
+                headingCount: 0,
+                todoCount: 0,
+                linkCount: 0,
+                hasUpcomingDeadline: false,
+                topTags: []
+            };
+        }
+    }
+
+    /**
+     * Build edges between nodes
+     */
+    private async buildEdges(
+        nodePaths: string[],
+        direction: 'both' | 'outgoing' | 'incoming',
+        filters: LinkGraphFilters
+    ): Promise<GraphEdge[]> {
+        if (nodePaths.length === 0) return [];
+
+        const nodeSet = new Set(nodePaths);
+        const edgeMap = new Map<string, GraphEdge>();
+
+        // Default to file links
+        const linkTypes = filters.linkTypes?.length ? filters.linkTypes : ['file'];
+
+        // Build placeholders for IN clause
+        const placeholders = nodePaths.map(() => '?').join(',');
+        const linkTypePlaceholders = linkTypes.map(() => '?').join(',');
+
+        const sql = `
+            SELECT l.file_path, l.target, l.link_type, COUNT(*) as count
+            FROM links l
+            WHERE l.file_path IN (${placeholders})
+              AND l.link_type IN (${linkTypePlaceholders})
+            GROUP BY l.file_path, l.target, l.link_type
+        `;
+
+        const args = [...nodePaths, ...linkTypes];
+
+        try {
+            const result = await this.db.execute({ sql, args });
+
+            for (const row of result.rows) {
+                const from = row.file_path as string;
+                const to = row.target as string;
+
+                // Only include edges where both endpoints are in our node set
+                // For target, we need to check if it matches any node (could be partial path)
+                const toNode = this.findMatchingNode(to, nodeSet);
+                if (!toNode) continue;
+                if (!nodeSet.has(from)) continue;
+
+                if (direction === 'outgoing' && !nodePaths.includes(from)) continue;
+                if (direction === 'incoming' && !nodePaths.includes(toNode)) continue;
+
+                const edgeKey = `${from}|${toNode}|${row.link_type}`;
+
+                if (!edgeMap.has(edgeKey)) {
+                    edgeMap.set(edgeKey, {
+                        id: edgeKey,
+                        from,
+                        to: toNode,
+                        linkType: row.link_type as string,
+                        count: row.count as number,
+                        title: `${row.count} link(s)`,
+                        arrows: 'to'
+                    });
+                } else {
+                    // Aggregate counts for same edge
+                    const existing = edgeMap.get(edgeKey)!;
+                    existing.count += row.count as number;
+                    existing.title = `${existing.count} link(s)`;
+                }
+            }
+        } catch (e) {
+            log.error('Error building edges', e as Error);
+        }
+
+        return [...edgeMap.values()];
+    }
+
+    /**
+     * Find a matching node for a link target
+     * Link targets may be partial paths or include search strings
+     */
+    private findMatchingNode(target: string, nodeSet: Set<string>): string | null {
+        // Exact match
+        if (nodeSet.has(target)) return target;
+
+        // Check if target ends with any node's filename
+        for (const node of nodeSet) {
+            const nodeName = node.split('/').pop() || node;
+            if (target.endsWith(nodeName) || target.startsWith(nodeName)) {
+                return node;
+            }
+            // Handle targets like "file.org::*Heading"
+            if (target.includes('::')) {
+                const [filePart] = target.split('::');
+                if (node.endsWith(filePart) || filePart.endsWith(nodeName)) {
+                    return node;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get just the filename from a path
+     */
+    private getFileName(filePath: string): string {
+        return filePath.split('/').pop() || filePath;
+    }
+
+    /**
+     * Build HTML tooltip for a node
+     */
+    private buildTooltip(filePath: string, metadata: FileMetadata): string {
+        const deadlineIcon = metadata.hasUpcomingDeadline ? '⚠️ ' : '';
+        const tags = metadata.topTags.length > 0
+            ? `\n🏷️ ${metadata.topTags.map((t: string) => ':' + t + ':').join(' ')}`
+            : '';
+        const modDate = metadata.mtime
+            ? new Date(metadata.mtime).toLocaleDateString()
+            : 'Unknown';
+
+        return `<b>${this.getFileName(filePath)}</b>${deadlineIcon ? ' ' + deadlineIcon : ''}
+<hr>
+📁 ${filePath}
+📑 ${metadata.headingCount} headings
+☐ ${metadata.todoCount} active TODOs
+🔗 ${metadata.linkCount} links
+📅 ${modDate}${tags}`.trim();
+    }
+
+    /**
+     * Get simple link statistics for a file
+     */
+    async getLinkStats(filePath: string): Promise<{
+        outgoing: number;
+        incoming: number;
+        outgoingByType: Record<string, number>;
+    }> {
+        try {
+            // Outgoing links
+            const outResult = await this.db.execute({
+                sql: 'SELECT link_type, COUNT(*) as count FROM links WHERE file_path = ? GROUP BY link_type',
+                args: [filePath]
+            });
+
+            const outgoingByType: Record<string, number> = {};
+            let outgoing = 0;
+            for (const row of outResult.rows) {
+                outgoingByType[row.link_type as string] = row.count as number;
+                outgoing += row.count as number;
+            }
+
+            // Incoming links (backlinks)
+            const fileName = filePath.split('/').pop() || filePath;
+            const inResult = await this.db.execute({
+                sql: `SELECT COUNT(DISTINCT file_path) as count FROM links
+                      WHERE target = ? OR target LIKE ? OR target LIKE ?`,
+                args: [filePath, `%${filePath}`, `%${fileName}::%`]
+            });
+
+            const incoming = (inResult.rows[0]?.count || 0) as number;
+
+            return { outgoing, incoming, outgoingByType };
+        } catch (e) {
+            log.error('Error getting link stats', e as Error, { filePath });
+            return { outgoing: 0, incoming: 0, outgoingByType: {} };
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive link graph visualization feature that allows users to explore file connections as an interactive network, along with extensible database adapter patterns for custom data extraction and graph enrichment.

## Key Changes

### Link Graph Visualization Feature
- **New command `scimax.showLinkGraph`** (keybinding: `C-c S-g`) - Visualize file connections for the current file
- **Interactive graph controls** - Adjust depth, direction (incoming/outgoing/both), and apply filters by file type, tags, TODO state, and modification date
- **Node interactions** - Click to open files, double-click to recenter graph, drag to rearrange
- **Link statistics** - New `scimax.showLinkStats` command shows summary of link counts by type
- **Comprehensive documentation** - New `docs/39-link-graph.org` with use cases, technical details, and examples

### Database Extension Points
Three new adapter patterns for extending the indexing and graph visualization pipeline:

1. **IndexerAdapter** - Hook into file indexing to extract custom entities, relationships, and metadata
   - Supports file type filtering and priority ordering
   - Enables knowledge graph construction and entity extraction
   - Includes cleanup callbacks when files are removed

2. **QueryProviderAdapter** - Register custom query types for specialized searches
   - Built-in providers for graph path finding and related file discovery
   - Extensible for semantic similarity, graph traversal, and custom algorithms

3. **GraphDataProviderAdapter** - Enrich graph nodes/edges and inject custom relationships
   - Node and edge enrichment with custom properties, colors, sizes
   - Custom edge injection for semantic relationships beyond file links
   - Node and edge filtering capabilities
   - Built-in providers for link-count-based sizing and recency-based coloring

### Documentation Updates
- Updated `docs/00-index.org` with Link Graph section and index entry
- Added keybinding reference in `docs/24-keybindings.org`
- Added command reference in `docs/25-commands.org`
- Updated `docs/05-links.org` with link to Link Graph documentation
- Added comprehensive extension points documentation in `docs/extension-points.org`

### Testing
- Added `src/adapters/__tests__/indexerAdapter.test.ts` - 218 lines of tests covering registration, filtering, priority ordering, and error handling
- Added `src/adapters/__tests__/graphDataAdapter.test.ts` - 370 lines of tests for node/edge enrichment, custom edges, filtering, and provider composition

### Package Configuration
- Registered three new VS Code commands with appropriate icons and keybindings
- Fixed peer dependency declarations in `package-lock.json`

## Implementation Details

- Graph visualization uses vis.js Network library with force-directed layout
- Links are stored in database with heading association for context-aware filtering
- Adapters use priority-based ordering (higher priority runs first) for predictable composition
- Error handling in adapters is non-fatal - failures are collected and logged without stopping the pipeline
- Maximum 100 nodes per graph to prevent overwhelming visualizations; filters can narrow results

https://claude.ai/code/session_01DX2BMMj27YDebw8FfURg7X